### PR TITLE
makefile: Add a way to add replaces,skips in the CSV

### DIFF
--- a/bundle/manifests/lvm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvm-operator.clusterserviceversion.yaml
@@ -30,6 +30,7 @@ metadata:
     categories: Storage
     containerImage: quay.io/ocs-dev/lvm-operator:latest
     description: The ODF LVM Operator manages local storage using LVM
+    olm.skipRange: ""
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/initialization-resource: |-
       {

--- a/config/manifests/bases/kustomization.yaml
+++ b/config/manifests/bases/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- lvm-operator.clusterserviceversion.yaml
+commonAnnotations:
+  olm.skipRange: ""
+patches:
+- patch: '[{"op": "replace", "path": "/spec/replaces", "value": ""}]'
+  target:
+    kind: ClusterServiceVersion
+    name: lvm-operator.v0.0.0

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,7 +1,7 @@
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:
-#- bases/odf-lvm-operator.clusterserviceversion.yaml
+- bases
 - ../default
 - ../samples
 - ../scorecard


### PR DESCRIPTION
REPLACES, SKIP_RANGE is required by OLM while upgrading a CSV to the newer version.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

https://bugzilla.redhat.com/show_bug.cgi?id=2126708