### PR TITLE
refactor: change sidecar images repo to registry.k8s.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,11 +106,11 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 OPERATOR_NAMESPACE ?= openshift-storage
 TOPOLVM_CSI_IMAGE ?= quay.io/ocs-dev/topolvm:latest
-CSI_REGISTRAR_IMAGE ?= k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
-CSI_PROVISIONER_IMAGE ?= k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
-CSI_LIVENESSPROBE_IMAGE ?= k8s.gcr.io/sig-storage/livenessprobe:v2.5.0
-CSI_RESIZER_IMAGE ?= k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
-CSI_SNAPSHOTTER_IMAGE ?= k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
+CSI_REGISTRAR_IMAGE ?= registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.3.0
+CSI_PROVISIONER_IMAGE ?= registry.k8s.io/sig-storage/csi-provisioner:v3.0.0
+CSI_LIVENESSPROBE_IMAGE ?= registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+CSI_RESIZER_IMAGE ?= registry.k8s.io/sig-storage/csi-resizer:v1.3.0
+CSI_SNAPSHOTTER_IMAGE ?= registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
 VGMANAGER_IMAGE ?= quay.io/ocs-dev/vgmanager:latest
 
 

--- a/bundle/manifests/lvm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvm-operator.clusterserviceversion.yaml
@@ -258,9 +258,7 @@ spec:
           - create
         serviceAccountName: controller-manager
       deployments:
-      - label:
-          app.kubernetes.io/name: lvm-operator
-        name: lvm-operator-controller-manager
+      - name: lvm-operator-controller-manager
         spec:
           replicas: 1
           selector:
@@ -277,6 +275,18 @@ spec:
             spec:
               containers:
               - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=10
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources: {}
+              - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
@@ -286,15 +296,15 @@ spec:
                 - name: TOPOLVM_CSI_IMAGE
                   value: quay.io/ocs-dev/topolvm:latest
                 - name: CSI_LIVENESSPROBE_IMAGE
-                  value: k8s.gcr.io/sig-storage/livenessprobe:v2.5.0
+                  value: registry.k8s.io/sig-storage/livenessprobe:v2.5.0
                 - name: CSI_PROVISIONER_IMAGE
-                  value: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
+                  value: registry.k8s.io/sig-storage/csi-provisioner:v3.0.0
                 - name: CSI_REGISTRAR_IMAGE
-                  value: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
+                  value: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.3.0
                 - name: CSI_RESIZER_IMAGE
-                  value: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
+                  value: registry.k8s.io/sig-storage/csi-resizer:v1.3.0
                 - name: CSI_SNAPSHOTTER_IMAGE
-                  value: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
+                  value: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
                 - name: POD_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -326,18 +336,6 @@ spec:
                     memory: 50Mi
                 securityContext:
                   allowPrivilegeEscalation: false
-              - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                  protocol: TCP
-                resources: {}
               - command:
                 - /metricsexporter
                 image: quay.io/ocs-dev/lvm-operator:latest

--- a/config/manager/manager.env
+++ b/config/manager/manager.env
@@ -1,7 +1,7 @@
 OPERATOR_NAMESPACE=openshift-storage
 TOPOLVM_CSI_IMAGE=quay.io/ocs-dev/topolvm:latest
-CSI_REGISTRAR_IMAGE=k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
-CSI_PROVISIONER_IMAGE=k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
-CSI_LIVENESSPROBE_IMAGE=k8s.gcr.io/sig-storage/livenessprobe:v2.5.0
-CSI_RESIZER_IMAGE=k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
-CSI_SNAPSHOTTER_IMAGE=k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
+CSI_REGISTRAR_IMAGE=registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.3.0
+CSI_PROVISIONER_IMAGE=registry.k8s.io/sig-storage/csi-provisioner:v3.0.0
+CSI_LIVENESSPROBE_IMAGE=registry.k8s.io/sig-storage/livenessprobe:v2.5.0
+CSI_RESIZER_IMAGE=registry.k8s.io/sig-storage/csi-resizer:v1.3.0
+CSI_SNAPSHOTTER_IMAGE=registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1

--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -25,11 +25,11 @@ var (
 		"OPERATOR_NAMESPACE": "openshift-storage",
 		// TODO: Switch to upstream topolvm image once PR https://github.com/topolvm/topolvm/pull/463 is merged
 		"TOPOLVM_CSI_IMAGE":       "quay.io/ocs-dev/topolvm:latest",
-		"CSI_REGISTRAR_IMAGE":     "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0",
-		"CSI_PROVISIONER_IMAGE":   "k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0",
-		"CSI_LIVENESSPROBE_IMAGE": "k8s.gcr.io/sig-storage/livenessprobe:v2.5.0",
-		"CSI_RESIZER_IMAGE":       "k8s.gcr.io/sig-storage/csi-resizer:v1.3.0",
-		"CSI_SNAPSHOTTER_IMAGE":   "k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1",
+		"CSI_REGISTRAR_IMAGE":     "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.3.0",
+		"CSI_PROVISIONER_IMAGE":   "registry.k8s.io/sig-storage/csi-provisioner:v3.0.0",
+		"CSI_LIVENESSPROBE_IMAGE": "registry.k8s.io/sig-storage/livenessprobe:v2.5.0",
+		"CSI_RESIZER_IMAGE":       "registry.k8s.io/sig-storage/csi-resizer:v1.3.0",
+		"CSI_SNAPSHOTTER_IMAGE":   "registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1",
 
 		// not being used, only for reference
 		"VGMANAGER_IMAGE": "quay.io/ocs-dev/vgmanager:latest",


### PR DESCRIPTION
Change sidecar images repo to registry.k8s.io which is a redirect to k8s.gcr.io.

Ref: https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>