### PR TITLE
OCPVE-234: Reduce CPU and Memory requests and remove limits

### DIFF
--- a/bundle/manifests/lvms-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvms-operator.clusterserviceversion.yaml
@@ -584,12 +584,9 @@ spec:
                   initialDelaySeconds: 5
                   periodSeconds: 10
                 resources:
-                  limits:
-                    cpu: 100m
-                    memory: 100Mi
                   requests:
-                    cpu: 50m
-                    memory: 50Mi
+                    cpu: 3m
+                    memory: 30Mi
                 securityContext:
                   allowPrivilegeEscalation: false
                 volumeMounts:
@@ -613,12 +610,9 @@ spec:
                 image: quay.io/ocs-dev/lvms-operator:latest
                 name: metricsexporter
                 resources:
-                  limits:
-                    cpu: 100m
-                    memory: 100Mi
                   requests:
-                    cpu: 30m
-                    memory: 30Mi
+                    cpu: 1m
+                    memory: 20Mi
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: lvms-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,12 +56,9 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          limits:
-            cpu: 100m
-            memory: 100Mi
           requests:
-            cpu: 50m
-            memory: 50Mi
+            cpu: 3m
+            memory: 30Mi
         env:
         - name: POD_NAMESPACE
           valueFrom:
@@ -76,11 +73,8 @@ spec:
         image: controller:latest
         name: metricsexporter
         resources:
-          limits:
-            cpu: 100m
-            memory: 100Mi
           requests:
-            cpu: 30m
-            memory: 30Mi
+            cpu: 1m
+            memory: 20Mi
       serviceAccountName: lvms-operator
       terminationGracePeriodSeconds: 10

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -37,53 +37,34 @@ const (
 	TopolvmControllerContainerLivenessPort  = int32(9808)
 	TopolvmControllerContainerReadinessPort = int32(8080)
 
-	// CSI Controller resource requests/limits
-	// TODO: Reduce these values and reach optimistic values without effecting performance
-	TopolvmControllerMemRequest = "100Mi"
-	TopolvmControllerMemLimit   = "150Mi"
-	TopolvmControllerCPURequest = "100m"
-	TopolvmControllerCPULimit   = "100m"
+	// CSI Controller resource requests
+	TopolvmControllerMemRequest = "45Mi"
+	TopolvmControllerCPURequest = "2m"
 
 	TopolvmCsiProvisionerMemRequest = "50Mi"
-	TopolvmCsiProvisionerMemLimit   = "100Mi"
-	TopolvmCsiProvisionerCPURequest = "50m"
-	TopolvmCsiProvisionerCPULimit   = "100m"
+	TopolvmCsiProvisionerCPURequest = "2m"
 
-	TopolvmCsiResizerMemRequest = "50Mi"
-	TopolvmCsiResizerMemLimit   = "100Mi"
-	TopolvmCsiResizerCPURequest = "20m"
-	TopolvmCsiResizerCPULimit   = "50m"
+	TopolvmCsiResizerMemRequest = "35Mi"
+	TopolvmCsiResizerCPURequest = "1m"
 
-	TopolvmCsiSnapshotterMemRequest = "50Mi"
-	TopolvmCsiSnapshotterMemLimit   = "100Mi"
-	TopolvmCsiSnapshotterCPURequest = "20m"
-	TopolvmCsiSnapshotterCPULimit   = "50m"
+	TopolvmCsiSnapshotterMemRequest = "35Mi"
+	TopolvmCsiSnapshotterCPURequest = "1m"
 
-	VgManagerMemRequest = "50Mi"
-	VgManagerMemLimit   = "100Mi"
-	VgManagerCPURequest = "30m"
-	VgManagerCPULimit   = "50m"
+	VgManagerMemRequest = "45Mi"
+	VgManagerCPURequest = "2m"
 
-	// topoLVM Node resource requests/limits
-	TopolvmNodeMemRequest = "150Mi"
-	TopolvmNodeMemLimit   = "200Mi"
-	TopolvmNodeCPURequest = "50m"
-	TopolvmNodeCPULimit   = "100m"
+	// topoLVM Node resource requests
+	TopolvmNodeMemRequest = "25Mi"
+	TopolvmNodeCPURequest = "1m"
 
-	TopolvmdMemRequest = "100Mi"
-	TopolvmdMemLimit   = "150Mi"
-	TopolvmdCPURequest = "150m"
-	TopolvmdCPULimit   = "200m"
+	TopolvmdMemRequest = "30Mi"
+	TopolvmdCPURequest = "2m"
 
-	CSIRegistrarMemRequest = "30Mi"
-	CSIRegistrarMemLimit   = "50Mi"
-	CSIRegistrarCPURequest = "20m"
-	CSIRegistrarCPULimit   = "30m"
+	CSIRegistrarMemRequest = "15Mi"
+	CSIRegistrarCPURequest = "1m"
 
-	LivenessProbeMemRequest = "30Mi"
-	LivenessProbeMemLimit   = "50Mi"
-	LivenessProbeCPURequest = "30m"
-	LivenessProbeCPULimit   = "50m"
+	LivenessProbeMemRequest = "15Mi"
+	LivenessProbeCPURequest = "1m"
 
 	// CSI Provisioner requires below environment values to make use of CSIStorageCapacity
 	PodNameEnv   = "POD_NAME"

--- a/controllers/topolvm_controller.go
+++ b/controllers/topolvm_controller.go
@@ -211,10 +211,6 @@ func getControllerContainer() *corev1.Container {
 	}
 
 	resourceRequirements := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(TopolvmControllerCPULimit),
-			corev1.ResourceMemory: resource.MustParse(TopolvmControllerMemLimit),
-		},
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse(TopolvmControllerCPURequest),
 			corev1.ResourceMemory: resource.MustParse(TopolvmControllerMemRequest),
@@ -278,10 +274,6 @@ func getCsiProvisionerContainer() *corev1.Container {
 	}
 
 	resourceRequirements := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(TopolvmCsiProvisionerCPULimit),
-			corev1.ResourceMemory: resource.MustParse(TopolvmCsiProvisionerMemLimit),
-		},
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse(TopolvmCsiProvisionerCPURequest),
 			corev1.ResourceMemory: resource.MustParse(TopolvmCsiProvisionerMemRequest),
@@ -334,10 +326,6 @@ func getCsiResizerContainer() *corev1.Container {
 	}
 
 	resourceRequirements := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(TopolvmCsiResizerCPULimit),
-			corev1.ResourceMemory: resource.MustParse(TopolvmCsiResizerMemLimit),
-		},
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse(TopolvmCsiResizerCPURequest),
 			corev1.ResourceMemory: resource.MustParse(TopolvmCsiResizerMemRequest),
@@ -365,10 +353,6 @@ func getCsiSnapshotterContainer() *corev1.Container {
 	}
 
 	resourceRequirements := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(TopolvmCsiSnapshotterCPULimit),
-			corev1.ResourceMemory: resource.MustParse(TopolvmCsiSnapshotterMemLimit),
-		},
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse(TopolvmCsiSnapshotterCPURequest),
 			corev1.ResourceMemory: resource.MustParse(TopolvmCsiSnapshotterMemRequest),
@@ -388,10 +372,6 @@ func getCsiSnapshotterContainer() *corev1.Container {
 
 func getLivenessProbeContainer() *corev1.Container {
 	resourceRequirements := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(LivenessProbeCPULimit),
-			corev1.ResourceMemory: resource.MustParse(LivenessProbeMemLimit),
-		},
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse(LivenessProbeCPURequest),
 			corev1.ResourceMemory: resource.MustParse(LivenessProbeMemRequest),

--- a/controllers/topolvm_node.go
+++ b/controllers/topolvm_node.go
@@ -244,10 +244,6 @@ func getLvmdContainer() *corev1.Container {
 	}
 
 	resourceRequirements := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(TopolvmdCPULimit),
-			corev1.ResourceMemory: resource.MustParse(TopolvmdMemLimit),
-		},
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse(TopolvmdCPURequest),
 			corev1.ResourceMemory: resource.MustParse(TopolvmdMemRequest),
@@ -285,10 +281,6 @@ func getNodeContainer() *corev1.Container {
 	}
 
 	requirements := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(TopolvmNodeCPULimit),
-			corev1.ResourceMemory: resource.MustParse(TopolvmNodeMemLimit),
-		},
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse(TopolvmNodeCPURequest),
 			corev1.ResourceMemory: resource.MustParse(TopolvmNodeMemRequest),
@@ -358,10 +350,6 @@ func getCsiRegistrarContainer() *corev1.Container {
 	}
 
 	requirements := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(CSIRegistrarCPULimit),
-			corev1.ResourceMemory: resource.MustParse(CSIRegistrarMemLimit),
-		},
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse(CSIRegistrarCPURequest),
 			corev1.ResourceMemory: resource.MustParse(CSIRegistrarMemRequest),
@@ -381,10 +369,6 @@ func getCsiRegistrarContainer() *corev1.Container {
 
 func getNodeLivenessProbeContainer() *corev1.Container {
 	resourceRequirements := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(LivenessProbeCPULimit),
-			corev1.ResourceMemory: resource.MustParse(LivenessProbeMemLimit),
-		},
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse(LivenessProbeCPURequest),
 			corev1.ResourceMemory: resource.MustParse(LivenessProbeMemRequest),

--- a/controllers/vgmanager_daemonset.go
+++ b/controllers/vgmanager_daemonset.go
@@ -135,10 +135,6 @@ func newVGManagerDaemonset(lvmCluster *lvmv1alpha1.LVMCluster, namespace string,
 	}
 
 	resourceRequirements := corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(VgManagerCPULimit),
-			corev1.ResourceMemory: resource.MustParse(VgManagerMemLimit),
-		},
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse(VgManagerCPURequest),
 			corev1.ResourceMemory: resource.MustParse(VgManagerMemRequest),


### PR DESCRIPTION
This PR reduces CPU and Memory requests or all the pods to the "at rest" values shown in [the analysis document](https://docs.google.com/spreadsheets/d/1eLBkG4HhlKlxRlB9H8kjuXs5F3zzVOPfkOOhFIOrfzU/edit#gid=0). It also removes all the CPU and Memory limits from the containers.

Signed-off-by: Suleyman Akbas <sakbas@redhat.com>