### PR TITLE
OCPVE-235: Add management workload annotations

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   name: operator
   namespace: system
+  annotations:
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   template:
     spec:

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
+  annotations:
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   template:
     spec:

--- a/config/default/manager_custom_env.yaml.in
+++ b/config/default/manager_custom_env.yaml.in
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: operator
   namespace: system
+  annotations:
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   template:
     spec:

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: operator
   namespace: system
+  annotations:
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   template:
     spec:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    workload.openshift.io/allowed: "management"
   labels:
     app.kubernetes.io/name: lvms-operator
     security.openshift.io/scc.podSecurityLabelSync: "false"
@@ -15,6 +17,8 @@ kind: Deployment
 metadata:
   name: operator
   namespace: system
+  annotations:
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     app.kubernetes.io/name: lvms-operator
 spec:

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -26,7 +26,6 @@ const (
 	// CSI Controller container and deployment names
 	TopolvmControllerDeploymentName = "topolvm-controller"
 	TopolvmControllerContainerName  = "topolvm-controller"
-	CsiRegistrarContainerName       = "csi-registrar"
 	CsiResizerContainerName         = "csi-resizer"
 	CsiProvisionerContainerName     = "csi-provisioner"
 	CsiSnapshotterContainerName     = "csi-snapshotter"
@@ -106,6 +105,13 @@ const (
 
 	// name of the lvm-operator container
 	LVMOperatorContainerName = "manager"
+
+	// annotations
+
+	// WorkloadPartitioningManagement contains the management workload annotation
+	workloadPartitioningManagementAnnotation = "target.workload.openshift.io/management"
+
+	managementAnnotationVal = `{"effect": "PreferredDuringScheduling"}`
 
 	// labels and values
 

--- a/controllers/topolvm_controller.go
+++ b/controllers/topolvm_controller.go
@@ -143,6 +143,10 @@ func getControllerDeployment(lvmCluster *lvmv1alpha1.LVMCluster, namespace strin
 		*getCsiSnapshotterContainer(),
 	}
 
+	annotations := map[string]string{
+		workloadPartitioningManagementAnnotation: managementAnnotationVal,
+	}
+
 	labels := map[string]string{
 		AppKubernetesNameLabel:      CsiDriverNameVal,
 		AppKubernetesManagedByLabel: ManagedByLabelVal,
@@ -152,9 +156,10 @@ func getControllerDeployment(lvmCluster *lvmv1alpha1.LVMCluster, namespace strin
 
 	controllerDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      TopolvmControllerDeploymentName,
-			Namespace: namespace,
-			Labels:    labels,
+			Name:        TopolvmControllerDeploymentName,
+			Namespace:   namespace,
+			Annotations: annotations,
+			Labels:      labels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,

--- a/controllers/topolvm_node.go
+++ b/controllers/topolvm_node.go
@@ -175,6 +175,9 @@ func getNodeDaemonSet(lvmCluster *lvmv1alpha1.LVMCluster, namespace string, init
 	if tolerations != nil {
 		topolvmNodeTolerations = tolerations
 	}
+	annotations := map[string]string{
+		workloadPartitioningManagementAnnotation: managementAnnotationVal,
+	}
 	labels := map[string]string{
 		AppKubernetesNameLabel:      CsiDriverNameVal,
 		AppKubernetesManagedByLabel: ManagedByLabelVal,
@@ -183,9 +186,10 @@ func getNodeDaemonSet(lvmCluster *lvmv1alpha1.LVMCluster, namespace string, init
 	}
 	nodeDaemonSet := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      TopolvmNodeDaemonsetName,
-			Namespace: namespace,
-			Labels:    labels,
+			Name:        TopolvmNodeDaemonsetName,
+			Namespace:   namespace,
+			Annotations: annotations,
+			Labels:      labels,
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: labels},

--- a/controllers/vgmanager_daemonset.go
+++ b/controllers/vgmanager_daemonset.go
@@ -183,6 +183,9 @@ func newVGManagerDaemonset(lvmCluster *lvmv1alpha1.LVMCluster, namespace string,
 			},
 		},
 	}
+	annotations := map[string]string{
+		workloadPartitioningManagementAnnotation: managementAnnotationVal,
+	}
 	labels := map[string]string{
 		AppKubernetesNameLabel:      VGManagerLabelVal,
 		AppKubernetesManagedByLabel: ManagedByLabelVal,
@@ -191,9 +194,10 @@ func newVGManagerDaemonset(lvmCluster *lvmv1alpha1.LVMCluster, namespace string,
 	}
 	ds := appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      VGManagerUnit,
-			Namespace: namespace,
-			Labels:    labels,
+			Name:        VGManagerUnit,
+			Namespace:   namespace,
+			Annotations: annotations,
+			Labels:      labels,
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: labels},

--- a/e2e/helper.go
+++ b/e2e/helper.go
@@ -37,10 +37,15 @@ func createNamespace(ctx context.Context, namespace string) error {
 	label["pod-security.kubernetes.io/enforce"] = "privileged"
 	label["security.openshift.io/scc.podSecurityLabelSync"] = "false"
 
+	annotations := make(map[string]string)
+	// annotation required for workload partitioning
+	annotations["workload.openshift.io/allowed"] = "management"
+
 	ns := &k8sv1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   namespace,
-			Labels: label,
+			Name:        namespace,
+			Annotations: annotations,
+			Labels:      label,
 		},
 	}
 	err := crClient.Create(ctx, ns)
@@ -58,10 +63,15 @@ func deleteNamespaceAndWait(ctx context.Context, namespace string) error {
 	label["pod-security.kubernetes.io/enforce"] = "baseline"
 	label["security.openshift.io/scc.podSecurityLabelSync"] = "false"
 
+	annotations := make(map[string]string)
+	// annotation required for workload partitioning
+	annotations["workload.openshift.io/allowed"] = "management"
+
 	ns := &k8sv1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   namespace,
-			Labels: label,
+			Name:        namespace,
+			Annotations: annotations,
+			Labels:      label,
 		},
 	}
 	err := crClient.Delete(ctx, ns)

--- a/e2e/subscription.go
+++ b/e2e/subscription.go
@@ -48,6 +48,10 @@ func generateClusterObjects(lvmCatalogImage string, subscriptionChannel string) 
 	// label required for monitoring this namespace
 	label["openshift.io/cluster-monitoring"] = "true"
 
+	annotations := make(map[string]string)
+	// annotation required for workload partitioning
+	annotations["workload.openshift.io/allowed"] = "management"
+
 	// Namespaces
 	co.namespaces = append(co.namespaces, k8sv1.Namespace{
 		TypeMeta: metav1.TypeMeta{
@@ -55,8 +59,9 @@ func generateClusterObjects(lvmCatalogImage string, subscriptionChannel string) 
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   installNamespace,
-			Labels: label,
+			Name:        installNamespace,
+			Annotations: annotations,
+			Labels:      label,
 		},
 	})
 

--- a/olm-deploy/openshift-storage-namespace.yaml
+++ b/olm-deploy/openshift-storage-namespace.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-storage
+  annotations:
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/enforce: "privileged"


### PR DESCRIPTION
This PR enables management workload partitioning, which was introduced in [this proposal.](https://github.com/openshift/enhancements/blob/master/enhancements/workload-partitioning/management-workload-partitioning.md)

Signed-off-by: Suleyman Akbas <sakbas@redhat.com>