### PR TITLE
OCPVE-236: Reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build --ldflags "-s -w" -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -17,15 +17,18 @@ COPY cmd/ cmd/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o vgmanager cmd/vgmanager/main.go
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o metricsexporter cmd/metricsexporter/exporter.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build --ldflags "-s -w" -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build --ldflags "-s -w" -a -o vgmanager cmd/vgmanager/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build --ldflags "-s -w" -a -o metricsexporter cmd/metricsexporter/exporter.go
 
 # vgmanager needs 'nsenter' and other basic linux utils to correctly function
-FROM quay.io/centos/centos:stream8
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 
-# Install required utilities
-RUN dnf install -y openssl && dnf clean all
+# Update the image to get the latest CVE updates
+RUN microdnf update -y && \
+    microdnf install -y openssl && \
+    microdnf install -y util-linux && \
+    microdnf clean all
 
 WORKDIR /
 COPY --from=builder /workspace/manager .

--- a/Dockerfile.vgmanager
+++ b/Dockerfile.vgmanager
@@ -16,11 +16,17 @@ COPY pkg/ pkg/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o vgmanager cmd/vgmanager/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build --ldflags "-s -w" -a -o vgmanager cmd/vgmanager/main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM centos:stream8
+# vgmanager needs 'nsenter' and other basic linux utils to correctly function
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+
+# Update the image to get the latest CVE updates
+RUN microdnf update -y && \
+    microdnf install -y openssl && \
+    microdnf install -y util-linux && \
+    microdnf clean all
+
 WORKDIR /
 COPY --from=builder /workspace/vgmanager .
 USER 65532:65532


### PR DESCRIPTION
This PR reduces the size of the images by
- specifying `--ldflags "-s -w"` in go build commands, which will strip debug information and remove DWARF symbols, reducing the size of the binary.
- changing the base image from `quay.io/centos/centos:stream8` to `registry.access.redhat.com/ubi8/ubi-minimal:8.7` on vgmanager and combined Dockerfiles.

The result is as follows:

Before: 
<img width="604" alt="Screenshot 2023-01-26 at 17 04 40" src="https://user-images.githubusercontent.com/5543238/218828639-45a90cf2-361a-4bf0-a4f3-44c03fea2451.png">

After:
<img width="700" alt="Screenshot 2023-02-14 at 19 52 16" src="https://user-images.githubusercontent.com/5543238/218830534-0a0b7416-7b00-4475-8c60-afd751a6e381.png">

The difference is big for vgmanager and combined images because of the base image change.

Signed-off-by: Suleyman Akbas <sakbas@redhat.com>