### PR TITLE
OCPVE-259: Update naming in the code after the repo move

### DIFF
--- a/.github/workflows/weekly-build.yaml
+++ b/.github/workflows/weekly-build.yaml
@@ -14,5 +14,5 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: manual-operator-build-push
-          repo: red-hat-storage/lvm-operator
+          repo: openshift/lvm-operator
           inputs: '{ "branch": "main" }'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,13 +8,13 @@ contribute to the project.
 
 Developers must follow these steps to make a change:
 
-1. Fork the `red-hat-storage/lvm-operator` repository on GitHub.
+1. Fork the `openshift/lvm-operator` repository on GitHub.
 2. Create a branch from the `main` branch, or from a versioned branch (such
    as `release-4.9`) if you are proposing a backport.
 3. Make changes.
 4. Create tests as needed and ensure that all tests pass.
 5. Push your changes to a branch in your fork of the repository.
-6. Submit a pull request to the `red-hat-storage/lvm-operator` repository.
+6. Submit a pull request to the `openshift/lvm-operator` repository.
 7. Work with the community to make any necessary changes through the code
    review process (effectively repeating steps 3-7 as needed).
 

--- a/PROJECT
+++ b/PROJECT
@@ -5,7 +5,7 @@ plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
 projectName: lvm-operator
-repo: github.com/red-hat-storage/lvm-operator
+repo: github.com/openshift/lvm-operator
 resources:
 - api:
     crdVersion: v1
@@ -14,7 +14,7 @@ resources:
   domain: topolvm.io
   group: lvm
   kind: LVMCluster
-  path: github.com/red-hat-storage/lvm-operator/api/v1alpha1
+  path: github.com/openshift/lvm-operator/api/v1alpha1
   version: v1alpha1
   webhooks:
     validation: true
@@ -25,7 +25,7 @@ resources:
   domain: topolvm.io
   group: lvm
   kind: LVMVolumeGroup
-  path: github.com/red-hat-storage/lvm-operator/api/v1alpha1
+  path: github.com/openshift/lvm-operator/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -33,6 +33,6 @@ resources:
   domain: topolvm.io
   group: lvm
   kind: LVMVolumeGroupNodeStatus
-  path: github.com/red-hat-storage/lvm-operator/api/v1alpha1
+  path: github.com/openshift/lvm-operator/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/bundle/manifests/lvms-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvms-operator.clusterserviceversion.yaml
@@ -60,7 +60,7 @@ metadata:
     operators.operatorframework.io/internal-objects: '["logicalvolumes.topolvm.io",
       "lvmvolumegroups.lvm.topolvm.io", "lvmvolumegroupnodestatuses.lvm.topolvm.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-    repository: https://github.com/red-hat-storage/lvm-operator
+    repository: https://github.com/openshift/lvm-operator
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
@@ -803,7 +803,7 @@ spec:
   - LVM
   links:
   - name: Source Repository
-    url: https://github.com/red-hat-storage/lvm-operator
+    url: https://github.com/openshift/lvm-operator
   maintainers:
   - email: ocs-support@redhat.com
     name: Red Hat Support

--- a/cmd/vgmanager/main.go
+++ b/cmd/vgmanager/main.go
@@ -26,8 +26,8 @@ import (
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
-	"github.com/red-hat-storage/lvm-operator/pkg/vgmanager"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
+	"github.com/openshift/lvm-operator/pkg/vgmanager"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -3,7 +3,7 @@
 # It should be run by config/default
 resources:
 - bases/lvm.topolvm.io_lvmclusters.yaml
-# Topolvm CRD from https://github.com/red-hat-storage/topolvm/blob/main/config/crd/bases/topolvm.io_logicalvolumes.yaml
+# Topolvm CRD from https://github.com/openshift/topolvm/blob/main/config/crd/bases/topolvm.io_logicalvolumes.yaml
 - bases/topolvm.io_logicalvolumes.yaml
 - bases/lvm.topolvm.io_lvmvolumegroups.yaml
 - bases/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml

--- a/config/manifests/bases/clusterserviceversion.yaml.in
+++ b/config/manifests/bases/clusterserviceversion.yaml.in
@@ -30,7 +30,7 @@ metadata:
             }
           }
         }
-    repository: https://github.com/red-hat-storage/lvm-operator
+    repository: https://github.com/openshift/lvm-operator
     operatorframework.io/suggested-namespace: openshift-storage
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/internal-objects: '["logicalvolumes.topolvm.io", "lvmvolumegroups.lvm.topolvm.io", "lvmvolumegroupnodestatuses.lvm.topolvm.io"]'
@@ -73,7 +73,7 @@ spec:
   - LVM
   links:
   - name: Source Repository
-    url: https://github.com/red-hat-storage/lvm-operator
+    url: https://github.com/openshift/lvm-operator
   maintainers:
   - email: ocs-support@redhat.com
     name: Red Hat Support

--- a/controllers/lvm_volumegroup.go
+++ b/controllers/lvm_volumegroup.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/controllers/lvmcluster_controller.go
+++ b/controllers/lvmcluster_controller.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/go-logr/logr"
 	secv1client "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	topolvmv1 "github.com/topolvm/topolvm/api/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	corev1helper "k8s.io/component-helpers/scheduling/corev1"

--- a/controllers/lvmcluster_controller_test.go
+++ b/controllers/lvmcluster_controller_test.go
@@ -23,7 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"

--- a/controllers/lvmcluster_controller_watches.go
+++ b/controllers/lvmcluster_controller_watches.go
@@ -19,7 +19,7 @@ package controllers
 import (
 	"context"
 
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/controllers/scc.go
+++ b/controllers/scc.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	secv1 "github.com/openshift/api/security/v1"
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -35,7 +35,7 @@ import (
 
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	secv1client "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	topolvmv1 "github.com/topolvm/topolvm/api/v1"
 	//+kubebuilder:scaffold:imports
 )

--- a/controllers/topolvm_controller.go
+++ b/controllers/topolvm_controller.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/topolvm_csi_driver.go
+++ b/controllers/topolvm_csi_driver.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/topolvm_node.go
+++ b/controllers/topolvm_node.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/topolvm_snapshotclass.go
+++ b/controllers/topolvm_snapshotclass.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/controllers/topolvm_storageclass.go
+++ b/controllers/topolvm_storageclass.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controllers
 
 import (
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )

--- a/controllers/vgmanager.go
+++ b/controllers/vgmanager.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/controllers/vgmanager_daemonset.go
+++ b/controllers/vgmanager_daemonset.go
@@ -19,7 +19,7 @@ package controllers
 import (
 	"os"
 
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/controllers/vgmanager_test.go
+++ b/controllers/vgmanager_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/doc/dev-guide/reconciler.md
+++ b/doc/dev-guide/reconciler.md
@@ -56,4 +56,4 @@ Note:
 [topolvm-design]: https://github.com/topolvm/topolvm/blob/main/docs/design.md
 [controller]: ../../controllers/lvmcluster_controller.go
 [lvmcluster]: ../../api/v1alpha1/lvmcluster_types.go
-[issue]: https://github.com/red-hat-storage/lvm-operator/issues
+[issue]: https://github.com/openshift/lvm-operator/issues

--- a/doc/usage/install.md
+++ b/doc/usage/install.md
@@ -60,7 +60,7 @@ oc get pods -w
 After the controller is running, create the sample lvmCluster CR:
 
 ```
-oc create -n lvm-operator-system -f https://github.com/red-hat-storage/lvm-operator/raw/main/config/samples/lvm_v1alpha1_lvmcluster.yaml
+oc create -n lvm-operator-system -f https://github.com/openshift/lvm-operator/raw/main/config/samples/lvm_v1alpha1_lvmcluster.yaml
 ```
 
 This will try to leverage all nodes and all available disks on these nodes.

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -22,9 +22,9 @@ import (
 	"os"
 
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	lvmv1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	lvmv1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"

--- a/e2e/lvmcluster.go
+++ b/e2e/lvmcluster.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"time"
 
-	v1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	v1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/e2e/validation.go
+++ b/e2e/validation.go
@@ -24,7 +24,7 @@ import (
 
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	. "github.com/onsi/gomega"
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/red-hat-storage/lvm-operator
+module github.com/openshift/lvm-operator
 
 go 1.18
 

--- a/main.go
+++ b/main.go
@@ -35,8 +35,8 @@ import (
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	secv1client "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
 
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
-	"github.com/red-hat-storage/lvm-operator/controllers"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
+	"github.com/openshift/lvm-operator/controllers"
 	topolvmv1 "github.com/topolvm/topolvm/api/v1"
 	//+kubebuilder:scaffold:imports
 )

--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -21,13 +21,13 @@ You will get a dump of:
 
 #### Contribution Flow
 Developers must follow these steps to make a change:
-1. Fork the `red-hat-storage/lvm-operator` repository on GitHub.
+1. Fork the `openshift/lvm-operator` repository on GitHub.
 2. Create a branch from the master branch, or from a versioned branch (such
    as `release-4.2`) if you are proposing a backport.
 3. Make changes.
 4. Ensure your commit messages include sign-off.
 5. Push your changes to a branch in your fork of the repository.
-6. Submit a pull request to the `red-hat-storage/lvm-operator` repository.
+6. Submit a pull request to the `openshift/lvm-operator` repository.
 7. Work with the community to make any necessary changes through the code
    review process (effectively repeating steps 3-7 as needed).
 

--- a/pkg/vgmanager/filter.go
+++ b/pkg/vgmanager/filter.go
@@ -19,7 +19,7 @@ package vgmanager
 import (
 	"strings"
 
-	"github.com/red-hat-storage/lvm-operator/pkg/internal"
+	"github.com/openshift/lvm-operator/pkg/internal"
 )
 
 const (

--- a/pkg/vgmanager/filter_test.go
+++ b/pkg/vgmanager/filter_test.go
@@ -3,7 +3,7 @@ package vgmanager
 import (
 	"testing"
 
-	"github.com/red-hat-storage/lvm-operator/pkg/internal"
+	"github.com/openshift/lvm-operator/pkg/internal"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/vgmanager/lvm.go
+++ b/pkg/vgmanager/lvm.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/red-hat-storage/lvm-operator/pkg/internal"
+	"github.com/openshift/lvm-operator/pkg/internal"
 )
 
 type lvmError string

--- a/pkg/vgmanager/lvm_test.go
+++ b/pkg/vgmanager/lvm_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	mockExec "github.com/red-hat-storage/lvm-operator/pkg/internal/test"
+	mockExec "github.com/openshift/lvm-operator/pkg/internal/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/vgmanager/vgmanager_controller.go
+++ b/pkg/vgmanager/vgmanager_controller.go
@@ -27,9 +27,9 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
-	lvmv1alpha1 "github.com/red-hat-storage/lvm-operator/api/v1alpha1"
-	"github.com/red-hat-storage/lvm-operator/controllers"
-	"github.com/red-hat-storage/lvm-operator/pkg/internal"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
+	"github.com/openshift/lvm-operator/controllers"
+	"github.com/openshift/lvm-operator/pkg/internal"
 	"github.com/topolvm/topolvm/lvmd"
 	lvmdCMD "github.com/topolvm/topolvm/pkg/lvmd/cmd"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
This PR changes the occurrences of `red-hat-storage` organization to `openshift` in the code. 

Signed-off-by: Suleyman Akbas <sakbas@redhat.com>