### PR TITLE
OCPVE-253: Support multiple storage/device classes

### DIFF
--- a/api/v1alpha1/lvmcluster_types.go
+++ b/api/v1alpha1/lvmcluster_types.go
@@ -84,6 +84,10 @@ type DeviceClass struct {
 	// +kubebuilder:validation:Required
 	// +required
 	ThinPoolConfig *ThinPoolConfig `json:"thinPoolConfig"`
+
+	// Default is a flag to indicate whether the device-class is the default
+	// +optional
+	Default bool `json:"default,omitempty"`
 }
 
 // DeviceSelector specifies the list of criteria that have to match before a device is assigned

--- a/api/v1alpha1/lvmvolumegroup_types.go
+++ b/api/v1alpha1/lvmvolumegroup_types.go
@@ -42,6 +42,10 @@ type LVMVolumeGroupSpec struct {
 	// +kubebuilder:validation:Required
 	// +required
 	ThinPoolConfig *ThinPoolConfig `json:"thinPoolConfig"`
+
+	// Default is a flag to indicate whether the device-class is the default
+	// +optional
+	Default bool `json:"default,omitempty"`
 }
 
 // LVMVolumeGroupStatus defines the observed state of LVMVolumeGroup

--- a/bundle/manifests/lvm.topolvm.io_lvmclusters.yaml
+++ b/bundle/manifests/lvm.topolvm.io_lvmclusters.yaml
@@ -44,6 +44,10 @@ spec:
                       PVs
                     items:
                       properties:
+                        default:
+                          description: Default is a flag to indicate whether the device-class
+                            is the default
+                          type: boolean
                         deviceSelector:
                           description: DeviceSelector is a set of rules that should
                             match for a device to be included in the LVMCluster

--- a/bundle/manifests/lvm.topolvm.io_lvmvolumegroups.yaml
+++ b/bundle/manifests/lvm.topolvm.io_lvmvolumegroups.yaml
@@ -34,6 +34,10 @@ spec:
           spec:
             description: LVMVolumeGroupSpec defines the desired state of LVMVolumeGroup
             properties:
+              default:
+                description: Default is a flag to indicate whether the device-class
+                  is the default
+                type: boolean
               deviceSelector:
                 description: DeviceSelector is a set of rules that should match for
                   a device to be included in this TopoLVMCluster

--- a/bundle/manifests/lvms-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvms-operator.clusterserviceversion.yaml
@@ -14,6 +14,7 @@ metadata:
             "storage": {
               "deviceClasses": [
                 {
+                  "default": true,
                   "name": "vg1",
                   "thinPoolConfig": {
                     "name": "thin-pool-1",

--- a/config/crd/bases/lvm.topolvm.io_lvmclusters.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmclusters.yaml
@@ -46,6 +46,10 @@ spec:
                       PVs
                     items:
                       properties:
+                        default:
+                          description: Default is a flag to indicate whether the device-class
+                            is the default
+                          type: boolean
                         deviceSelector:
                           description: DeviceSelector is a set of rules that should
                             match for a device to be included in the LVMCluster

--- a/config/crd/bases/lvm.topolvm.io_lvmvolumegroups.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmvolumegroups.yaml
@@ -36,6 +36,10 @@ spec:
           spec:
             description: LVMVolumeGroupSpec defines the desired state of LVMVolumeGroup
             properties:
+              default:
+                description: Default is a flag to indicate whether the device-class
+                  is the default
+                type: boolean
               deviceSelector:
                 description: DeviceSelector is a set of rules that should match for
                   a device to be included in this TopoLVMCluster

--- a/config/samples/lvm_v1alpha1_lvmcluster.yaml
+++ b/config/samples/lvm_v1alpha1_lvmcluster.yaml
@@ -6,6 +6,7 @@ spec:
   storage:
     deviceClasses:
     - name: vg1
+      default: true
       thinPoolConfig:
         name: thin-pool-1
         sizePercent: 90

--- a/controllers/lvm_volumegroup.go
+++ b/controllers/lvm_volumegroup.go
@@ -138,6 +138,7 @@ func (c lvmVG) getLvmVolumeGroups(r *LVMClusterReconciler, instance *lvmv1alpha1
 				NodeSelector:   deviceClass.NodeSelector,
 				DeviceSelector: deviceClass.DeviceSelector,
 				ThinPoolConfig: deviceClass.ThinPoolConfig,
+				Default:        len(deviceClasses) == 1 || deviceClass.Default, //True if there is only one device class or default is explicitly set.
 			},
 		}
 		lvmVolumeGroups = append(lvmVolumeGroups, lvmVolumeGroup)

--- a/controllers/lvmcluster_controller_test.go
+++ b/controllers/lvmcluster_controller_test.go
@@ -52,7 +52,8 @@ var _ = Describe("LVMCluster controller", func() {
 		Spec: lvmv1alpha1.LVMClusterSpec{
 			Storage: lvmv1alpha1.Storage{
 				DeviceClasses: []lvmv1alpha1.DeviceClass{{
-					Name: testDeviceClassName,
+					Name:    testDeviceClassName,
+					Default: true,
 					ThinPoolConfig: &lvmv1alpha1.ThinPoolConfig{
 						Name:               testThinPoolName,
 						SizePercent:        50,

--- a/doc/user-guide/usage.md
+++ b/doc/user-guide/usage.md
@@ -47,6 +47,7 @@ spec:
   storage:
     deviceClasses:
     - name: vg1
+      default: true
       thinPoolConfig:
         name: thin-pool-1
         sizePercent: 90

--- a/e2e/lvmcluster.go
+++ b/e2e/lvmcluster.go
@@ -37,7 +37,8 @@ func generateLVMCluster() *v1alpha1.LVMCluster {
 			Storage: v1alpha1.Storage{
 				DeviceClasses: []v1alpha1.DeviceClass{
 					{
-						Name: "vg1",
+						Name:    "vg1",
+						Default: true,
 						ThinPoolConfig: &v1alpha1.ThinPoolConfig{
 							Name:               "mytp1",
 							SizePercent:        90,

--- a/pkg/vgmanager/vgmanager_controller.go
+++ b/pkg/vgmanager/vgmanager_controller.go
@@ -194,7 +194,7 @@ func (r *VGReconciler) reconcile(ctx context.Context, req ctrl.Request, volumeGr
 		dc := &lvmd.DeviceClass{
 			Name:           volumeGroup.Name,
 			VolumeGroup:    volumeGroup.Name,
-			Default:        true,
+			Default:        volumeGroup.Spec.Default,
 			ThinPoolConfig: &lvmd.ThinPoolConfig{},
 		}
 


### PR DESCRIPTION
This PR enables the support of multiple storage/device classes. 

- `api/v1alpha1/lvmcluster_types.go`: Introduces a new field `Default` in `DeviceClass`, which indicates whether the device-class is the default.
- `api/v1alpha1/lvmcluster_webhook.go`: Removes the validation for a single device class. Adds another validation to make sure there is only one default device class. If there is only one device class, it is considered the default one internally even if `Default` field is not set, to make the upgrades easier. Specifying more than one default device class errors TopoLVM.
- `api/v1alpha1/lvmvolumegroup_types.go`: Introduces a new field `Default` in `LVMVolumeGroupSpec` which matches the field in `DeviceClass` and is used internally. `controllers/lvm_volumegroup.go` change handles the matching.
- `pkg/vgmanager/vgmanager_controller.go`: Uses the new field `Default` in `LVMVolumeGroupSpec` to set `Default` for TopoLVM device class.

The rest of the code adjusts the tests and documentation for the new `Default` field.    

Signed-off-by: Suleyman Akbas <sakbas@redhat.com>