### PR TITLE
OCPVE-234: Add further resource requests

### DIFF
--- a/bundle/manifests/lvms-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvms-operator.clusterserviceversion.yaml
@@ -604,7 +604,10 @@ spec:
                 - containerPort: 8443
                   name: https
                   protocol: TCP
-                resources: {}
+                resources:
+                  requests:
+                    cpu: 1m
+                    memory: 20Mi
               - command:
                 - /metricsexporter
                 image: quay.io/ocs-dev/lvms-operator:latest

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -22,6 +22,10 @@ spec:
         - containerPort: 8443
           protocol: TCP
           name: https
+        resources:
+          requests:
+            cpu: 1m
+            memory: 20Mi
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -52,6 +52,9 @@ const (
 	VgManagerMemRequest = "45Mi"
 	VgManagerCPURequest = "2m"
 
+	CertGeneratorMemRequest = "15Mi"
+	CertGeneratorCPURequest = "1m"
+
 	// topoLVM Node resource requests
 	TopolvmNodeMemRequest = "25Mi"
 	TopolvmNodeCPURequest = "1m"
@@ -64,6 +67,9 @@ const (
 
 	LivenessProbeMemRequest = "15Mi"
 	LivenessProbeCPURequest = "1m"
+
+	FileCheckerMemRequest = "10Mi"
+	FileCheckerCPURequest = "1m"
 
 	// CSI Provisioner requires below environment values to make use of CSIStorageCapacity
 	PodNameEnv   = "POD_NAME"

--- a/controllers/topolvm_controller.go
+++ b/controllers/topolvm_controller.go
@@ -202,6 +202,12 @@ func getInitContainer(initImage string) *corev1.Container {
 		Image:        initImage,
 		Command:      command,
 		VolumeMounts: volumeMounts,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(CertGeneratorCPURequest),
+				corev1.ResourceMemory: resource.MustParse(CertGeneratorMemRequest),
+			},
+		},
 	}
 
 	return ssCertGenerator

--- a/controllers/topolvm_node.go
+++ b/controllers/topolvm_node.go
@@ -235,6 +235,12 @@ func getNodeInitContainer(initImage string) *corev1.Container {
 		Image:        initImage,
 		Command:      command,
 		VolumeMounts: volumeMounts,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(FileCheckerCPURequest),
+				corev1.ResourceMemory: resource.MustParse(FileCheckerMemRequest),
+			},
+		},
 	}
 
 	return fileChecker


### PR DESCRIPTION
This PR adds resource requests for the `file-checker`, `self-signed-cert-generator` initcontainers, and `kube-rbac-proxy` container. 

Not specifying resource requests for initcontainers might cause problems with ResourceQuotas like in https://github.com/kubedb/project/issues/311.

Follow-up for #303 