### PR TITLE
OCPBUGS-8102: Make path list mandatory for multiple device classes

### DIFF
--- a/api/v1alpha1/lvmcluster_webhook.go
+++ b/api/v1alpha1/lvmcluster_webhook.go
@@ -193,7 +193,11 @@ func (l *LVMCluster) verifyPathsAreNotEmpty() error {
 	for _, deviceClass := range l.Spec.Storage.DeviceClasses {
 		if deviceClass.DeviceSelector != nil {
 			if len(deviceClass.DeviceSelector.Paths) == 0 {
-				return fmt.Errorf("Path list should not be empty when DeviceSelector is specified.")
+				return fmt.Errorf("path list should not be empty when DeviceSelector is specified")
+			}
+		} else {
+			if len(l.Spec.Storage.DeviceClasses) > 1 {
+				return fmt.Errorf("path list should not be empty when there are multiple deviceClasses. Please specify device path(s) under deviceSelector.paths for %s deviceClass", deviceClass.Name)
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds a validation to enforce users to specify path lists for devices when they use multiple device classes. This makes the device distribution over device classes transparent and does not give the responsibility to the operator to do this automagically.   