### PR TITLE
OCPVE-287: Update CSI sidecar image versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,11 +111,11 @@ test: manifests generate fmt vet envtest godeps-update ## Run tests.
 
 OPERATOR_NAMESPACE ?= openshift-storage
 TOPOLVM_CSI_IMAGE ?= quay.io/ocs-dev/topolvm:latest
-CSI_REGISTRAR_IMAGE ?= k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
-CSI_PROVISIONER_IMAGE ?= k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
-CSI_LIVENESSPROBE_IMAGE ?= k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
-CSI_RESIZER_IMAGE ?= k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
-CSI_SNAPSHOTTER_IMAGE ?= k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
+CSI_REGISTRAR_IMAGE ?= k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.2
+CSI_PROVISIONER_IMAGE ?= k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
+CSI_LIVENESSPROBE_IMAGE ?= k8s.gcr.io/sig-storage/livenessprobe:v2.8.0
+CSI_RESIZER_IMAGE ?= k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
+CSI_SNAPSHOTTER_IMAGE ?= k8s.gcr.io/sig-storage/csi-snapshotter:v6.1.0
 VGMANAGER_IMAGE ?= quay.io/ocs-dev/vgmanager:latest
 
 

--- a/bundle/manifests/lvms-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvms-operator.clusterserviceversion.yaml
@@ -549,15 +549,15 @@ spec:
                 - name: TOPOLVM_CSI_IMAGE
                   value: quay.io/ocs-dev/topolvm:latest
                 - name: CSI_LIVENESSPROBE_IMAGE
-                  value: k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
+                  value: k8s.gcr.io/sig-storage/livenessprobe:v2.8.0
                 - name: CSI_PROVISIONER_IMAGE
-                  value: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
+                  value: k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
                 - name: CSI_REGISTRAR_IMAGE
-                  value: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
+                  value: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.2
                 - name: CSI_RESIZER_IMAGE
-                  value: k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
+                  value: k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
                 - name: CSI_SNAPSHOTTER_IMAGE
-                  value: k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
+                  value: k8s.gcr.io/sig-storage/csi-snapshotter:v6.1.0
                 - name: POD_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/config/manager/manager.env
+++ b/config/manager/manager.env
@@ -1,7 +1,7 @@
 OPERATOR_NAMESPACE=openshift-storage
 TOPOLVM_CSI_IMAGE=quay.io/ocs-dev/topolvm:latest
-CSI_REGISTRAR_IMAGE=k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
-CSI_PROVISIONER_IMAGE=k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
-CSI_LIVENESSPROBE_IMAGE=k8s.gcr.io/sig-storage/livenessprobe:v2.7.0
-CSI_RESIZER_IMAGE=k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
-CSI_SNAPSHOTTER_IMAGE=k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
+CSI_REGISTRAR_IMAGE=k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.2
+CSI_PROVISIONER_IMAGE=k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
+CSI_LIVENESSPROBE_IMAGE=k8s.gcr.io/sig-storage/livenessprobe:v2.8.0
+CSI_RESIZER_IMAGE=k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
+CSI_SNAPSHOTTER_IMAGE=k8s.gcr.io/sig-storage/csi-snapshotter:v6.1.0

--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -24,11 +24,11 @@ var (
 	defaultValMap = map[string]string{
 		"OPERATOR_NAMESPACE":      "openshift-storage",
 		"TOPOLVM_CSI_IMAGE":       "quay.io/ocs-dev/topolvm:latest",
-		"CSI_REGISTRAR_IMAGE":     "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1",
-		"CSI_PROVISIONER_IMAGE":   "k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1",
-		"CSI_LIVENESSPROBE_IMAGE": "k8s.gcr.io/sig-storage/livenessprobe:v2.7.0",
-		"CSI_RESIZER_IMAGE":       "k8s.gcr.io/sig-storage/csi-resizer:v1.5.0",
-		"CSI_SNAPSHOTTER_IMAGE":   "k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1",
+		"CSI_REGISTRAR_IMAGE":     "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.2",
+		"CSI_PROVISIONER_IMAGE":   "k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0",
+		"CSI_LIVENESSPROBE_IMAGE": "k8s.gcr.io/sig-storage/livenessprobe:v2.8.0",
+		"CSI_RESIZER_IMAGE":       "k8s.gcr.io/sig-storage/csi-resizer:v1.6.0",
+		"CSI_SNAPSHOTTER_IMAGE":   "k8s.gcr.io/sig-storage/csi-snapshotter:v6.1.0",
 
 		// not being used, only for reference
 		"VGMANAGER_IMAGE": "quay.io/ocs-dev/vgmanager:latest",


### PR DESCRIPTION
This PR updates CSI sidecar image versions to match [the ones](https://github.com/openshift/topolvm/blob/main/csi-sidecars.mk) on the rebased TopoLVM repo. 

Signed-off-by: Suleyman Akbas <sakbas@redhat.com>