### PR TITLE
OCPBUGS-8102: Include all the device class names in the error message

### DIFF
--- a/api/v1alpha1/lvmcluster_webhook.go
+++ b/api/v1alpha1/lvmcluster_webhook.go
@@ -190,16 +190,18 @@ func (l *LVMCluster) verifySingleDefaultDeviceClass() error {
 
 func (l *LVMCluster) verifyPathsAreNotEmpty() error {
 
+	var deviceClassesWithoutPaths []string
 	for _, deviceClass := range l.Spec.Storage.DeviceClasses {
 		if deviceClass.DeviceSelector != nil {
 			if len(deviceClass.DeviceSelector.Paths) == 0 {
 				return fmt.Errorf("path list should not be empty when DeviceSelector is specified")
 			}
 		} else {
-			if len(l.Spec.Storage.DeviceClasses) > 1 {
-				return fmt.Errorf("path list should not be empty when there are multiple deviceClasses. Please specify device path(s) under deviceSelector.paths for %s deviceClass", deviceClass.Name)
-			}
+			deviceClassesWithoutPaths = append(deviceClassesWithoutPaths, deviceClass.Name)
 		}
+	}
+	if len(l.Spec.Storage.DeviceClasses) > 1 && len(deviceClassesWithoutPaths) > 0 {
+		return fmt.Errorf("path list should not be empty when there are multiple deviceClasses. Please specify device path(s) under deviceSelector.paths for %s deviceClass(es)", strings.Join(deviceClassesWithoutPaths, `,`))
 	}
 
 	return nil


### PR DESCRIPTION
This PR enhances the error message when multiple device classes are used, but no paths specified for at least one of them. The new error message includes all the device class names that do not have paths.