### PR TITLE
OCPBUGS-11309: Provide a way to add replaces and skips in the CSV

### DIFF
--- a/bundle/manifests/lvms-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvms-operator.clusterserviceversion.yaml
@@ -31,6 +31,7 @@ metadata:
     containerImage: quay.io/ocs-dev/lvm-operator:latest
     description: Logical volume manager storage provides dynamically provisioned local
       storage for container workloads
+    olm.skipRange: ""
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/initialization-resource: |-
       {

--- a/config/manifests/bases/kustomization.yaml
+++ b/config/manifests/bases/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- lvms-operator.clusterserviceversion.yaml
+commonAnnotations:
+  olm.skipRange: ""
+patches:
+- patch: '[{"op": "replace", "path": "/spec/replaces", "value": ""}]'
+  target:
+    kind: ClusterServiceVersion
+    name: lvms-operator.v0.0.0

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,7 +1,7 @@
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:
-#- bases/odf-lvm-operator.clusterserviceversion.yaml
+- bases
 - ../default
 - ../samples
 - ../scorecard


### PR DESCRIPTION
This PR provides a way to add REPLACES and SKIP_RANGE in the CSV, which is required by OLM while upgrading a CSV to the newer version.