### PR TITLE
OCPBUGS-11047: Add a watcher for storage class objects to the operator

### DIFF
--- a/controllers/lvmcluster_controller_watches.go
+++ b/controllers/lvmcluster_controller_watches.go
@@ -21,6 +21,7 @@ import (
 
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,7 +40,10 @@ func (r *LVMClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&source.Kind{Type: &lvmv1alpha1.LVMVolumeGroupNodeStatus{}},
 			handler.EnqueueRequestsFromMapFunc(r.getLVMClusterObjsForReconcile),
-			//			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+		).
+		Watches(
+			&source.Kind{Type: &storagev1.StorageClass{}},
+			handler.EnqueueRequestsFromMapFunc(r.getLVMClusterObjsForReconcile),
 		).
 		Complete(r)
 }

--- a/controllers/topolvm_storageclass.go
+++ b/controllers/topolvm_storageclass.go
@@ -109,7 +109,7 @@ func getTopolvmStorageClasses(r *LVMClusterReconciler, ctx context.Context, lvmC
 	defaultStorageClassName := ""
 	setDefaultStorageClass := true
 
-	// Mark the first lvmo storage class default if no other storageclasses exist on the cluster
+	// Mark the lvms storage class, associated with the default device class, as default if no other default storage class exists on the cluster
 	scList := &storagev1.StorageClassList{}
 	err := r.Client.List(ctx, scList)
 
@@ -145,8 +145,10 @@ func getTopolvmStorageClasses(r *LVMClusterReconciler, ctx context.Context, lvmC
 		}
 		// reconcile will pick up any existing LVMO storage classes as well
 		if setDefaultStorageClass && (defaultStorageClassName == "" || defaultStorageClassName == scName) {
-			storageClass.Annotations[defaultSCAnnotation] = "true"
-			defaultStorageClassName = scName
+			if len(lvmCluster.Spec.Storage.DeviceClasses) == 1 || deviceClass.Default {
+				storageClass.Annotations[defaultSCAnnotation] = "true"
+				defaultStorageClassName = scName
+			}
 		}
 		sc = append(sc, storageClass)
 	}


### PR DESCRIPTION
This PR adds a watcher for storage class objects to the LVM operator. So, when lvms storage classes are modified, they will immediately be reconciled. Also, when setting an lvms storage class as default, we now check if the associated device class is the default one instead of randomly assigning a storage class as default. 