### PR TITLE
OCPBUGS-11893: Enable updating initcontainer images during an upgrade

### DIFF
--- a/controllers/topolvm_controller.go
+++ b/controllers/topolvm_controller.go
@@ -117,6 +117,7 @@ func (c topolvmController) setTopolvmControllerDesiredState(existing, desired *a
 	// for update, topolvm controller is interested in only updating container images
 	// labels, volumes, service account etc can remain unchanged
 	existing.Spec.Template.Spec.Containers = desired.Spec.Template.Spec.Containers
+	existing.Spec.Template.Spec.InitContainers = desired.Spec.Template.Spec.InitContainers
 
 	return nil
 }

--- a/controllers/topolvm_node.go
+++ b/controllers/topolvm_node.go
@@ -66,10 +66,13 @@ func (n topolvmNode) ensureCreated(r *LVMClusterReconciler, ctx context.Context,
 			return nil
 		}
 		// if update, update only mutable fields
-		// For topolvm Node, we have containers, node selector and toleration terms
+		// For topolvm Node, we have containers, initcontainers, node selector and toleration terms
 
 		// containers
 		ds.Spec.Template.Spec.Containers = dsTemplate.Spec.Template.Spec.Containers
+
+		// initcontainers
+		ds.Spec.Template.Spec.InitContainers = dsTemplate.Spec.Template.Spec.InitContainers
 
 		// tolerations
 		ds.Spec.Template.Spec.Tolerations = dsTemplate.Spec.Template.Spec.Tolerations


### PR DESCRIPTION
This PR provides a fix for non-changing initcontainer images during an upgrade. 

`controllers/topolvm_controller.go`: Adds initcontainers to reconciliation of TopoLVM Controller so that they are properly reconciled. 
`controllers/topolvm_node.go`: Adds initcontainers to reconciliation of TopoLVM Node so that they are properly reconciled.