### PR TITLE
OCPVE-310: Reduce reconcile interval for delayed devices

### DIFF
--- a/pkg/vgmanager/vgmanager_controller.go
+++ b/pkg/vgmanager/vgmanager_controller.go
@@ -106,7 +106,7 @@ func (r *VGReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 }
 
 var reconcileInterval = time.Minute * 1
-var reconcileAgain ctrl.Result = ctrl.Result{Requeue: true, RequeueAfter: reconcileInterval}
+var reconcileAgain = ctrl.Result{Requeue: true, RequeueAfter: reconcileInterval}
 
 //TODO: Refactor this function to move the ctrl result to a single place
 
@@ -162,9 +162,9 @@ func (r *VGReconciler) reconcile(ctx context.Context, req ctrl.Request, volumeGr
 	}
 
 	if len(matchingDevices) == 0 {
-		r.Log.Info("no matching devices for volume group", "VGName", volumeGroup.Name)
+		r.Log.Info("no matching devices found for volume group", "VGName", volumeGroup.Name)
 		if len(delayedDevices) > 0 {
-			return reconcileAgain, nil
+			return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil //30 seconds to make sure delayed devices become available
 		}
 
 		if found {
@@ -563,7 +563,7 @@ func deleteLVMDConfig() error {
 	return err
 }
 
-func (r *VGReconciler) getMatchingDevicesForVG(volumeGroup *lvmv1alpha1.LVMVolumeGroup) (matching []internal.BlockDevice, delayed []internal.BlockDevice, err error) {
+func (r *VGReconciler) getMatchingDevicesForVG(volumeGroup *lvmv1alpha1.LVMVolumeGroup) ([]internal.BlockDevice, []internal.BlockDevice, error) {
 	// The LVMVolumeGroup was created/modified
 	r.Log.Info("getting block devices for volumegroup", "VGName", volumeGroup.Name)
 


### PR DESCRIPTION
This PR reduces reconcile interval for delayed devices from one minute to thirty seconds. This improves the waiting time for the users by reducing the time for `vg-manager` to create the lvmd config file and let `topolvm-node` start working.  

Before:

<img width="638" alt="Screenshot 2023-04-24 at 10 51 25" src="https://user-images.githubusercontent.com/5543238/234038352-4108ad6e-1fc0-4d7c-91e7-81f478ca200e.png">

After:

<img width="670" alt="Screenshot 2023-04-21 at 12 41 41" src="https://user-images.githubusercontent.com/5543238/234038398-bd5f0756-1c1d-44bc-9b4e-4f79248236be.png">

`topolvm-node` starting time is almost halved. 