### PR TITLE
OCPVE-334: Add verify target to check go formatting and generated files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,12 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+verify: ## Verify go formatting and generated files
+	hack/verify-gofmt.sh
+	hack/verify-deps.sh
+	hack/verify-bundle.sh
+	hack/verify-generated.sh
+
 godeps-update: ## Run go mod tidy and go mod vendor.
 	go mod tidy && go mod vendor
 

--- a/config/default/manager_custom_env.yaml
+++ b/config/default/manager_custom_env.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: operator
+  namespace: system
+  annotations:
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: TOPOLVM_CSI_IMAGE
+          value: quay.io/lvms_dev/topolvm:latest
+        - name: CSI_LIVENESSPROBE_IMAGE
+          value: k8s.gcr.io/sig-storage/livenessprobe:v2.8.0
+        - name: CSI_PROVISIONER_IMAGE
+          value: k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
+        - name: CSI_REGISTRAR_IMAGE
+          value: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.2
+        - name: CSI_RESIZER_IMAGE
+          value: k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
+        - name: CSI_SNAPSHOTTER_IMAGE
+          value: k8s.gcr.io/sig-storage/csi-snapshotter:v6.1.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,3 +3,10 @@ resources:
 
 generatorOptions:
   disableNameSuffixHash: true
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: quay.io/lvms_dev/lvms-operator
+  newTag: latest
+namePrefix: lvms-

--- a/hack/verify-bundle.sh
+++ b/hack/verify-bundle.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+function print_failure {
+  echo "There are unexpected changes to the tree when running 'make bundle'. Please"
+  echo "run these commands locally and double-check the Git repository for unexpected changes which may"
+  echo "need to be committed."
+  exit 1
+}
+
+if [ "${OPENSHIFT_CI:-false}" = true ]; then
+  echo "> generating the OLM bundle"
+  make bundle
+
+  test -z "$(git status --porcelain | \grep -v '^??')" || print_failure
+  echo "> verified generated bundle and deep copy"
+fi

--- a/hack/verify-deps.sh
+++ b/hack/verify-deps.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+function print_failure {
+  echo "There are unexpected changes to the vendor tree following 'go mod vendor' and 'go mod tidy'. Please"
+  echo "run these commands locally and double-check the Git repository for unexpected changes which may"
+  echo "need to be committed."
+  exit 1
+}
+
+if [ "${OPENSHIFT_CI:-false}" = true ]; then
+  go mod vendor
+  go mod tidy
+
+  test -z "$(git status --porcelain)" || print_failure
+  echo "verified Go modules"
+fi

--- a/hack/verify-generated.sh
+++ b/hack/verify-generated.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+function print_failure {
+  echo "There are unexpected changes to the tree when running 'make generate' and 'make manifests'. Please"
+  echo "run these commands locally and double-check the Git repository for unexpected changes which may"
+  echo "need to be committed."
+  exit 1
+}
+
+if [ "${OPENSHIFT_CI:-false}" = true ]; then
+  make generate
+  make manifests
+
+  test -z "$(git status --porcelain | \grep -v '^??')" || print_failure
+  echo "verified generated manifests and deep copy"
+fi

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+go_files=$( find . -name '*.go' -not -path './vendor/*' -print )
+bad_files=$(gofmt -s -l ${go_files})
+if [[ -n "${bad_files}" ]]; then
+    (>&2 echo "!!! gofmt needs to be run on the listed files")
+	echo "${bad_files}"
+    (>&2 echo "Try running 'gofmt -s -d [path]' or autocorrect with 'hack/verify-gofmt.sh | xargs -n 1 gofmt -s -w'")
+    exit 1
+fi


### PR DESCRIPTION
This PR adds some verifications to run on OpenShift CI. This will make it easier for multiple people to work on the same codebase. 

`config/default/manager_custom_env.yaml` and `config/manager/kustomization.yaml` are both generated, so this PR adds them as well to make a clean start.  