### PR TITLE
OCPVE-341: Add csi to infrastructure-features on CSV

### DIFF
--- a/bundle/manifests/lvms-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvms-operator.clusterserviceversion.yaml
@@ -57,7 +57,7 @@ metadata:
           }
         }
     operatorframework.io/suggested-namespace: openshift-storage
-    operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.openshift.io/infrastructure-features: '["csi", "disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.23.0
     operators.operatorframework.io/internal-objects: '["logicalvolumes.topolvm.io",
       "lvmvolumegroups.lvm.topolvm.io", "lvmvolumegroupnodestatuses.lvm.topolvm.io"]'

--- a/config/manifests/bases/clusterserviceversion.yaml.in
+++ b/config/manifests/bases/clusterserviceversion.yaml.in
@@ -32,7 +32,7 @@ metadata:
         }
     repository: https://github.com/openshift/lvm-operator
     operatorframework.io/suggested-namespace: openshift-storage
-    operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.openshift.io/infrastructure-features: '["csi", "disconnected"]'
     operators.operatorframework.io/internal-objects: '["logicalvolumes.topolvm.io", "lvmvolumegroups.lvm.topolvm.io", "lvmvolumegroupnodestatuses.lvm.topolvm.io"]'
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:

--- a/config/manifests/bases/lvms-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/lvms-operator.clusterserviceversion.yaml
@@ -32,7 +32,7 @@ metadata:
         }
     repository: https://github.com/openshift/lvm-operator
     operatorframework.io/suggested-namespace: openshift-storage
-    operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.openshift.io/infrastructure-features: '["csi", "disconnected"]'
     operators.operatorframework.io/internal-objects: '["logicalvolumes.topolvm.io", "lvmvolumegroups.lvm.topolvm.io", "lvmvolumegroupnodestatuses.lvm.topolvm.io"]'
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:


### PR DESCRIPTION
This PR adds `csi` to `infrastructure-features` on CSV. 

Further details for the label: https://docs.openshift.com/container-platform/4.12/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-manual-annotations_osdk-generating-csvs  