### PR TITLE
OCPBUGS-13364: fix: Added a tag for arm64 to have it pulled into Openshift for ARM

### DIFF
--- a/bundle/manifests/lvms-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvms-operator.clusterserviceversion.yaml
@@ -66,6 +66,7 @@ metadata:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
   name: lvms-operator.v0.0.1

--- a/config/manifests/bases/clusterserviceversion.yaml.in
+++ b/config/manifests/bases/clusterserviceversion.yaml.in
@@ -37,6 +37,7 @@ metadata:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
   name: @BUNDLE_PACKAGE@.v0.0.0

--- a/config/manifests/bases/lvms-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/lvms-operator.clusterserviceversion.yaml
@@ -37,6 +37,7 @@ metadata:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
   name: lvms-operator.v0.0.0


### PR DESCRIPTION
This should list the operator in Openshift for ARM as brought up in https://github.com/openshift/lvm-operator/issues/335