### PR TITLE
OCPVE-349: Add PV and PVC controllers to publish events

### DIFF
--- a/bundle/manifests/lvms-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvms-operator.clusterserviceversion.yaml
@@ -126,10 +126,44 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - events
+          verbs:
+          - create
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - node
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
           - nodes
           verbs:
           - get
           - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - get
+          - list
+          - update
           - watch
         - apiGroups:
           - ""

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -32,10 +32,44 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - node
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - update
   - watch
 - apiGroups:
   - ""

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -115,7 +115,7 @@ const (
 	PartOfLabelVal            = "lvms-provisioner"
 	CsiDriverNameVal          = "topolvm-csi-driver"
 
-	storageClassPrefix        = "lvms-"
+	StorageClassPrefix        = "lvms-"
 	volumeSnapshotClassPrefix = "lvms-"
 	sccPrefix                 = "lvms-"
 )

--- a/controllers/lvmcluster_controller.go
+++ b/controllers/lvmcluster_controller.go
@@ -208,7 +208,7 @@ func (r *LVMClusterReconciler) reconcile(ctx context.Context, instance *lvmv1alp
 		}
 	}
 
-	r.Log.Info("successfully reconciled LvmCluster")
+	r.Log.Info("successfully reconciled LVMCluster")
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/persistent-volume-claim/controller.go
+++ b/controllers/persistent-volume-claim/controller.go
@@ -1,0 +1,135 @@
+package persistent_volume_claim
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/openshift/lvm-operator/controllers"
+	"github.com/pkg/errors"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const (
+	capacityAnnotation = "capacity.topolvm.io/00default"
+)
+
+// PersistentVolumeClaimReconciler reconciles a PersistentVolumeClaim object
+type PersistentVolumeClaimReconciler struct {
+	client    client.Client
+	apiReader client.Reader
+	recorder  record.EventRecorder
+}
+
+// NewPersistentVolumeClaimReconciler returns PersistentVolumeClaimReconciler.
+func NewPersistentVolumeClaimReconciler(client client.Client, apiReader client.Reader, eventRecorder record.EventRecorder) *PersistentVolumeClaimReconciler {
+	return &PersistentVolumeClaimReconciler{
+		client:    client,
+		apiReader: apiReader,
+		recorder:  eventRecorder,
+	}
+}
+
+//+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;update
+//+kubebuilder:rbac:groups=core,resources=node,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=events,verbs=create;update;patch
+
+// Reconcile PVC
+func (r *PersistentVolumeClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.Log.WithName("persistentvolume-controller").WithValues("Request.Name", req.Name, "Request.Namespace", req.Namespace)
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	err := r.client.Get(ctx, req.NamespacedName, pvc)
+	switch {
+	case err == nil:
+	case apierrors.IsNotFound(err):
+		return ctrl.Result{}, nil
+	default:
+		return ctrl.Result{}, err
+	}
+
+	// Skip if the PVC is deleted or does not use the lvms storage class.
+	if pvc.DeletionTimestamp != nil || !strings.HasPrefix(*pvc.Spec.StorageClassName, controllers.StorageClassPrefix) {
+		return ctrl.Result{}, nil
+	}
+
+	// Skip if the PVC is not in Pending state.
+	if pvc.Status.Phase != "Pending" {
+		return ctrl.Result{}, nil
+	}
+
+	// List the nodes
+	nodeList := &corev1.NodeList{}
+	err = r.client.List(ctx, nodeList)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Check if there is any node that has enough storage capacity for the PVC
+	found := false
+	requestedStorage := pvc.Spec.Resources.Requests.Storage()
+	var nodeMessage []string
+	for _, node := range nodeList.Items {
+		capacity, ok := node.Annotations[capacityAnnotation]
+		if !ok {
+			errMessage := fmt.Sprintf("could not find capacity annotation on the node %s", node.Name)
+			logger.Error(fmt.Errorf(errMessage), errMessage)
+			return ctrl.Result{}, nil
+		}
+
+		capacityQuantity, err := resource.ParseQuantity(capacity)
+		if err != nil {
+			logger.Error(errors.Wrapf(err, "failed to parse capacity for node %s", node.Name), "failed to parse capacity")
+			return ctrl.Result{}, nil
+		}
+		if requestedStorage.Cmp(capacityQuantity) < 0 {
+			found = true
+			break
+		}
+		nodeMessage = append(nodeMessage, fmt.Sprintf("node %s has %s free storage", node.Name, prettyByteSize(capacityQuantity.Value())))
+	}
+
+	// Publish an event if the requested storage is greater than the available capacity
+	if !found {
+		r.recorder.Event(pvc, "Warning", "NotEnoughCapacity",
+			fmt.Sprintf("Requested storage (%s) is greater than available capacity on any node (%s).", requestedStorage.String(), strings.Join(nodeMessage, ",")))
+		logger.Info("Event published for the PVC", "PVC", req.NamespacedName)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *PersistentVolumeClaimReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	pred := predicate.Funcs{
+		CreateFunc:  func(event.CreateEvent) bool { return true },
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		UpdateFunc:  func(event.UpdateEvent) bool { return true },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+	return ctrl.NewControllerManagedBy(mgr).
+		WithEventFilter(pred).
+		For(&corev1.PersistentVolumeClaim{}).
+		Complete(r)
+}
+
+func prettyByteSize(b int64) string {
+	bf := float64(b)
+	for _, unit := range []string{"", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"} {
+		if math.Abs(bf) < 1024.0 {
+			return fmt.Sprintf("%3.1f%sB", bf, unit)
+		}
+		bf /= 1024.0
+	}
+	return fmt.Sprintf("%.1fYiB", bf)
+}

--- a/controllers/persistent-volume/controller.go
+++ b/controllers/persistent-volume/controller.go
@@ -1,0 +1,78 @@
+package persistent_volume
+
+import (
+	"context"
+	"strings"
+
+	"github.com/openshift/lvm-operator/controllers"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// PersistentVolumeReconciler reconciles a PersistentVolume object
+type PersistentVolumeReconciler struct {
+	client    client.Client
+	apiReader client.Reader
+	recorder  record.EventRecorder
+}
+
+// NewPersistentVolumeReconciler returns PersistentVolumeReconciler.
+func NewPersistentVolumeReconciler(client client.Client, apiReader client.Reader, eventRecorder record.EventRecorder) *PersistentVolumeReconciler {
+	return &PersistentVolumeReconciler{
+		client:    client,
+		apiReader: apiReader,
+		recorder:  eventRecorder,
+	}
+}
+
+//+kubebuilder:rbac:groups=core,resources=persistentvolumes,verbs=get;list;watch;update
+//+kubebuilder:rbac:groups=core,resources=events,verbs=create;update;patch
+
+// Reconcile PV
+func (r *PersistentVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.Log.WithName("persistentvolume-controller").WithValues("Request.Name", req.Name, "Request.Namespace", req.Namespace)
+
+	pv := &corev1.PersistentVolume{}
+	err := r.client.Get(ctx, req.NamespacedName, pv)
+	switch {
+	case err == nil:
+	case apierrors.IsNotFound(err):
+		return ctrl.Result{}, nil
+	default:
+		return ctrl.Result{}, err
+	}
+
+	// Skip if the PV is deleted or PV does not use the lvms storage class.
+	if pv.DeletionTimestamp != nil || !strings.HasPrefix(pv.Spec.StorageClassName, controllers.StorageClassPrefix) {
+		return ctrl.Result{}, nil
+	}
+
+	// Publish an event if PV has no claimRef
+	if pv.Spec.ClaimRef == nil {
+		r.recorder.Event(pv, "Warning", "ClaimReferenceRemoved", "Claim reference has been removed. This PV is no longer dynamically managed by LVM Storage and will need to be cleaned up manually.")
+		logger.Info("Event published for the PV", "PV", req.NamespacedName)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *PersistentVolumeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	pred := predicate.Funcs{
+		CreateFunc:  func(event.CreateEvent) bool { return true },
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		UpdateFunc:  func(event.UpdateEvent) bool { return true },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+	return ctrl.NewControllerManagedBy(mgr).
+		WithEventFilter(pred).
+		For(&corev1.PersistentVolume{}).
+		Complete(r)
+}

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -58,7 +58,7 @@ func setDaemonsetNodeSelector(nodeSelector *corev1.NodeSelector, ds *appsv1.Daem
 }
 
 func getStorageClassName(deviceName string) string {
-	return storageClassPrefix + deviceName
+	return StorageClassPrefix + deviceName
 }
 
 func getVolumeSnapshotClassName(deviceName string) string {

--- a/docs/design/lvm-operator-manager.md
+++ b/docs/design/lvm-operator-manager.md
@@ -41,11 +41,11 @@ The `topolvmNode` reconcile unit is responsible for deploying and managing the T
 
 ### TopoLVM Scheduler
 
-The TopoLVM Scheduler is **not** used in LVMS for scheduling Pods. Instead, the CSI StorageCapacity tracking feature is utilized by the Kubernetes scheduler to determine the Node on which to provision storage. This feature provides the necessary information to the scheduler regarding the available storage on each Node, allowing it to make an informed decision about where to place the Pod.
+The TopoLVM Scheduler is **not** used in LVMS for scheduling Pods. Instead, the CSI StorageCapacity tracking feature is utilized by the Kubernetes scheduler to determine the Node on which to provision storage. This feature provides the necessary information to the scheduler regarding the available storage on each node, allowing it to make an informed decision about where to place the Pod.
 
 ## Storage Classes
 
-The `topolvmStorageClass` reconcile unit is responsible for creating and managing all storage classes associated with the device classes specified in the LVMCluster CR. Each storage class is named with a prefix of 'lvms-' followed by the name of the corresponding device class in the LVMCluster CR.
+The `topolvmStorageClass` reconcile unit is responsible for creating and managing all storage classes associated with the device classes specified in the LVMCluster CR. Each storage class is named with a prefix of `lvms-` followed by the name of the corresponding device class in the LVMCluster CR.
 
 ## Volume Group Manager
 

--- a/pkg/vgmanager/vgmanager_controller.go
+++ b/pkg/vgmanager/vgmanager_controller.go
@@ -157,7 +157,7 @@ func (r *VGReconciler) reconcile(ctx context.Context, volumeGroup *lvmv1alpha1.L
 		return reconcileAgain, err
 	}
 
-	r.Log.Info("listing matching and delayed devices", "availableDevices", availableDevices, "delayedDevices", delayedDevices)
+	r.Log.Info("listing available and delayed devices", "availableDevices", availableDevices, "delayedDevices", delayedDevices)
 
 	// If there are no available devices, that could mean either
 	// - There is no available devices to attach to the volume group


### PR DESCRIPTION
This PR adds a PV and a PVC controller to the LVM Operator. 
- The PV controller watches for PVs created by LVMS and publishes an event if their `spec.claimRef` gets deleted: 

  <img width="1906" alt="Screenshot 2023-06-01 at 16 26 41" src="https://github.com/openshift/lvm-operator/assets/5543238/6570cefb-197d-4a58-b7de-ab455c457b61">

- The PVC controller watches for the PVCs created by LVMS and publishes an event if the PVC requests a storage greater than available capacity on any node:

  <img width="1268" alt="Screenshot 2023-06-06 at 12 22 11" src="https://github.com/openshift/lvm-operator/assets/5543238/dbdc0f96-c12f-4026-85ba-5fb75a4153d3">


