### PR TITLE
OCPVE-330: Add add owner reference to created objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,7 +313,7 @@ jsonnet: ## Download jsonnet locally if necessary.
 
 GINKGO = $(shell pwd)/bin/ginkgo
 ginkgo: ## Download ginkgo and gomega locally if necessary.
-	$(call go-get-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo@v2)
+	$(call go-get-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo@v2.9.4)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/controllers/lvm_volumegroup.go
+++ b/controllers/lvm_volumegroup.go
@@ -49,6 +49,13 @@ func (c lvmVG) ensureCreated(r *LVMClusterReconciler, ctx context.Context, lvmCl
 				Namespace: volumeGroup.Namespace,
 			},
 		}
+
+		err := cutil.SetControllerReference(lvmCluster, existingVolumeGroup, r.Scheme)
+		if err != nil {
+			r.Log.Error(err, "failed to set controller reference to LVMVolumeGroup with name", volumeGroup.Name)
+			return err
+		}
+
 		result, err := cutil.CreateOrUpdate(ctx, r.Client, existingVolumeGroup, func() error {
 			existingVolumeGroup.Finalizers = volumeGroup.Finalizers
 			existingVolumeGroup.Spec = volumeGroup.Spec

--- a/controllers/topolvm_controller.go
+++ b/controllers/topolvm_controller.go
@@ -59,6 +59,12 @@ func (c topolvmController) ensureCreated(r *LVMClusterReconciler, ctx context.Co
 		},
 	}
 
+	err := cutil.SetControllerReference(lvmCluster, existingDeployment, r.Scheme)
+	if err != nil {
+		r.Log.Error(err, "failed to set controller reference to topolvm controller deployment with name", existingDeployment.Name)
+		return err
+	}
+
 	result, err := cutil.CreateOrUpdate(ctx, r.Client, existingDeployment, func() error {
 		return c.setTopolvmControllerDesiredState(existingDeployment, desiredDeployment)
 	})

--- a/controllers/topolvm_csi_driver.go
+++ b/controllers/topolvm_csi_driver.go
@@ -45,6 +45,7 @@ func (c csiDriver) getName() string {
 
 func (c csiDriver) ensureCreated(r *LVMClusterReconciler, ctx context.Context, lvmCluster *lvmv1alpha1.LVMCluster) error {
 	csiDriverResource := getCSIDriverResource()
+
 	result, err := cutil.CreateOrUpdate(ctx, r.Client, csiDriverResource, func() error {
 		// no need to mutate any field
 		return nil

--- a/controllers/topolvm_node.go
+++ b/controllers/topolvm_node.go
@@ -58,6 +58,13 @@ func (n topolvmNode) ensureCreated(r *LVMClusterReconciler, ctx context.Context,
 			Namespace: dsTemplate.Namespace,
 		},
 	}
+
+	err := cutil.SetControllerReference(lvmCluster, ds, r.Scheme)
+	if err != nil {
+		r.Log.Error(err, "failed to set controller reference to topolvm node daemonset with name", ds.Name)
+		return err
+	}
+
 	unitLogger.Info("running CreateOrUpdate")
 	result, err := cutil.CreateOrUpdate(ctx, r.Client, ds, func() error {
 		// at creation, deep copy the whole daemonSet

--- a/test/e2e/setup_teardown.go
+++ b/test/e2e/setup_teardown.go
@@ -27,38 +27,38 @@ import (
 func beforeTestSuiteSetup(ctx context.Context) {
 
 	if diskInstall {
-		debug("Creating disk for e2e tests\n")
+		debug("Creating disk for e2e tests")
 		err := diskSetup(ctx)
 		gomega.Expect(err).To(gomega.BeNil())
 	}
 
 	if lvmOperatorInstall {
-		debug("BeforeTestSuite: deploying LVM Operator\n")
+		debug("BeforeTestSuite: deploying LVM Operator")
 		err := deployLVMWithOLM(ctx, lvmCatalogSourceImage, lvmSubscriptionChannel)
 		gomega.Expect(err).To(gomega.BeNil())
 	}
 }
 
 func lvmClusterSetup(clusterConfig *v1alpha1.LVMCluster, ctx context.Context) {
-	debug("BeforeTestSuite: starting LVM Cluster\n")
+	debug("BeforeTestSuite: starting LVM Cluster")
 	err := startLVMCluster(clusterConfig, ctx)
 	gomega.Expect(err).To(gomega.BeNil())
 }
 
 func lvmNamespaceSetup(ctx context.Context) {
-	debug("BeforeTestSuite: creating Namespace %s\n", testNamespace)
+	debug("BeforeTestSuite: creating Namespace", testNamespace)
 	err := createNamespace(ctx, testNamespace)
 	gomega.Expect(err).To(gomega.BeNil())
 }
 
 func lvmNamespaceCleanup(ctx context.Context) {
-	debug("AfterTestSuite: deleting Namespace %s\n", testNamespace)
+	debug("AfterTestSuite: deleting Namespace", testNamespace)
 	err := deleteNamespaceAndWait(ctx, testNamespace)
 	gomega.Expect(err).To(gomega.BeNil())
 }
 
 func lvmClusterCleanup(clusterConfig *v1alpha1.LVMCluster, ctx context.Context) {
-	debug("AfterTestSuite: deleting default LVM Cluster\n")
+	debug("AfterTestSuite: deleting default LVM Cluster")
 	err := deleteLVMCluster(clusterConfig, ctx)
 	gomega.Expect(err).To(gomega.BeNil())
 }
@@ -67,13 +67,13 @@ func lvmClusterCleanup(clusterConfig *v1alpha1.LVMCluster, ctx context.Context) 
 func afterTestSuiteCleanup(ctx context.Context) {
 
 	if lvmOperatorUninstall {
-		debug("AfterTestSuite: uninstalling LVM Operator\n")
+		debug("AfterTestSuite: uninstalling LVM Operator")
 		err := uninstallLVM(ctx, lvmCatalogSourceImage, lvmSubscriptionChannel)
 		gomega.Expect(err).To(gomega.BeNil(), "error uninstalling the LVM Operator: %v", err)
 	}
 
 	if diskInstall {
-		debug("Cleaning up disk\n")
+		debug("Cleaning up disk")
 		err := diskRemoval(ctx)
 		gomega.Expect(err).To(gomega.BeNil())
 	}


### PR DESCRIPTION
Add owner reference to created objects. CR owns all created objects for given cluster