### PR TITLE
USHIFT-1059: fix: setup microshift kustomization target for use in microshift rebases

### DIFF
--- a/config/microshift/kustomization.yaml
+++ b/config/microshift/kustomization.yaml
@@ -1,0 +1,20 @@
+## These resources are used for a microshift deployment.
+## They differ in that lvm operator is not used but topo lvm is deployed directly
+## they should be referenced within microshift as their go-to resource for a release
+resources:
+  - topolvm-controller_rbac.authorization.k8s.io_v1_clusterrole.yaml
+  - topolvm-controller_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+  - topolvm-controller_v1_serviceaccount.yaml
+  - topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_clusterrole.yaml
+  - topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+  - topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_role.yaml
+  - topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_rolebinding.yaml
+  - topolvm-csi-resizer_rbac.authorization.k8s.io_v1_clusterrole.yaml
+  - topolvm-csi-resizer_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+  - topolvm-csi-resizer_rbac.authorization.k8s.io_v1_role.yaml
+  - topolvm-csi-resizer_rbac.authorization.k8s.io_v1_rolebinding.yaml
+  - topolvm-csi-snapshotter_rbac.authorization.k8s.io_v1_clusterrole.yaml
+  - topolvm-csi-snapshotter_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+  - topolvm-node_rbac.authorization.k8s.io_v1_clusterrole.yaml
+  - topolvm-node_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+  - topolvm-node_v1_serviceaccount.yaml

--- a/config/microshift/topolvm-controller_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/config/microshift/topolvm-controller_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,57 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: topolvm-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - csidrivers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - topolvm.io
+  resources:
+  - logicalvolumes
+  - logicalvolumes/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/config/microshift/topolvm-controller_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/config/microshift/topolvm-controller_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: topolvm-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: topolvm-controller
+subjects:
+- kind: ServiceAccount
+  name: topolvm-controller
+  namespace: openshift-storage

--- a/config/microshift/topolvm-controller_v1_serviceaccount.yaml
+++ b/config/microshift/topolvm-controller_v1_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: topolvm-controller

--- a/config/microshift/topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/config/microshift/topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,81 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: topolvm-csi-provisioner
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csinodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/microshift/topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/config/microshift/topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: topolvm-csi-provisioner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: topolvm-csi-provisioner
+subjects:
+- kind: ServiceAccount
+  name: topolvm-controller
+  namespace: openshift-storage

--- a/config/microshift/topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_role.yaml
+++ b/config/microshift/topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,41 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: topolvm-csi-provisioner
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - watch
+  - list
+  - delete
+  - update
+  - create
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csistoragecapacities
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get

--- a/config/microshift/topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/config/microshift/topolvm-csi-provisioner_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: topolvm-csi-provisioner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: topolvm-csi-provisioner
+subjects:
+- kind: ServiceAccount
+  name: topolvm-controller
+  namespace: openshift-storage

--- a/config/microshift/topolvm-csi-resizer_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/config/microshift/topolvm-csi-resizer_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,47 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: topolvm-csi-resizer
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch
+  - create
+  - update
+  - patch

--- a/config/microshift/topolvm-csi-resizer_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/config/microshift/topolvm-csi-resizer_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: topolvm-csi-resizer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: topolvm-csi-resizer
+subjects:
+- kind: ServiceAccount
+  name: topolvm-controller
+  namespace: openshift-storage

--- a/config/microshift/topolvm-csi-resizer_rbac.authorization.k8s.io_v1_role.yaml
+++ b/config/microshift/topolvm-csi-resizer_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: topolvm-csi-resizer
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - watch
+  - list
+  - delete
+  - update
+  - create

--- a/config/microshift/topolvm-csi-resizer_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/config/microshift/topolvm-csi-resizer_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: topolvm-csi-resizer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: topolvm-csi-resizer
+subjects:
+- kind: ServiceAccount
+  name: topolvm-controller
+  namespace: openshift-storage

--- a/config/microshift/topolvm-csi-snapshotter_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/config/microshift/topolvm-csi-snapshotter_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,41 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: topolvm-csi-snapshotter
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - watch
+  - list
+  - update
+  - create
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - update
+  - patch

--- a/config/microshift/topolvm-csi-snapshotter_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/config/microshift/topolvm-csi-snapshotter_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: topolvm-csi-snapshotter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: topolvm-csi-snapshotter
+subjects:
+- kind: ServiceAccount
+  name: topolvm-controller
+  namespace: openshift-storage

--- a/config/microshift/topolvm-node_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/config/microshift/topolvm-node_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: topolvm-node
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - topolvm.io
+  resources:
+  - logicalvolumes
+  - logicalvolumes/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/microshift/topolvm-node_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/config/microshift/topolvm-node_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: topolvm-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: topolvm-node
+subjects:
+- kind: ServiceAccount
+  name: topolvm-node
+  namespace: openshift-storage

--- a/config/microshift/topolvm-node_v1_serviceaccount.yaml
+++ b/config/microshift/topolvm-node_v1_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: topolvm-node


### PR DESCRIPTION
avoids missing synced RBACs that have now gone into SCV. In general, this needs to be removed at some point and unified with the actual RBACs used by LVM operator.

Needs to be verified with rebase dry run before it can be merged