### PR TITLE
OCPVE-606: fix: reenable falsly disabled integration tests

### DIFF
--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -50,6 +50,7 @@ var cancel context.CancelFunc
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
+	RunSpecs(t, "Webhook Suite")
 }
 
 var _ = BeforeSuite(func() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -52,6 +52,7 @@ var (
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controller Suite")
 }
 
 const (


### PR DESCRIPTION
This enables the test suites that were disabled in https://github.com/openshift/lvm-operator/commit/3ce11a8bfccbde2032e489abc82b4e35348e7251 back in may by accident. Potentially the ginkgo logs could cause issues in pipeline parsers if the stdout is parsed, not sure if that changed since then. Other than that it should run fine