### PR TITLE
OCPBUGS-17848: fix: don't fail if devices already in vg

### DIFF
--- a/pkg/vgmanager/devices.go
+++ b/pkg/vgmanager/devices.go
@@ -112,6 +112,7 @@ DeviceLoop:
 // filterMatchingDevices filters devices based on DeviceSelector.Paths if specified.
 func (r *VGReconciler) filterMatchingDevices(blockDevices []internal.BlockDevice, vgs []VolumeGroup, volumeGroup *lvmv1alpha1.LVMVolumeGroup) ([]internal.BlockDevice, error) {
 	var filteredBlockDevices []internal.BlockDevice
+	devicesAlreadyInVG := false
 
 	if volumeGroup.Spec.DeviceSelector != nil {
 
@@ -131,6 +132,7 @@ func (r *VGReconciler) filterMatchingDevices(blockDevices []internal.BlockDevice
 				// Check if we should skip this device
 				if blockDevice.DevicePath == "" {
 					r.Log.Info(fmt.Sprintf("skipping required device that is already part of volume group %s: %s", volumeGroup.Name, path))
+					devicesAlreadyInVG = true
 					continue
 				}
 
@@ -145,13 +147,14 @@ func (r *VGReconciler) filterMatchingDevices(blockDevices []internal.BlockDevice
 
 				// Check if we should skip this device
 				if err != nil {
-					r.Log.Info(fmt.Sprintf("skipping optional device path due to error: %v", err))
+					r.Log.Info(fmt.Sprintf("skipping optional device path: %v", err))
 					continue
 				}
 
 				// Check if we should skip this device
 				if blockDevice.DevicePath == "" {
 					r.Log.Info(fmt.Sprintf("skipping optional device path that is already part of volume group %s: %s", volumeGroup.Name, path))
+					devicesAlreadyInVG = true
 					continue
 				}
 
@@ -161,8 +164,10 @@ func (r *VGReconciler) filterMatchingDevices(blockDevices []internal.BlockDevice
 			// At least 1 of the optional paths are required if:
 			//   - OptionalPaths was specified AND
 			//   - There were no required paths
+			//   - Devices were not already part of the volume group (meaning this was run after vg creation)
 			// This guarantees at least 1 device could be found between optionalPaths and paths
-			if len(filteredBlockDevices) == 0 {
+			//if len(filteredBlockDevices) == 0 && !devicesAlreadyInVG {
+			if len(filteredBlockDevices) == 0 && !devicesAlreadyInVG {
 				return nil, errors.New("at least 1 valid device is required if DeviceSelector paths or optionalPaths are specified")
 			}
 		}

--- a/pkg/vgmanager/devices_test.go
+++ b/pkg/vgmanager/devices_test.go
@@ -291,7 +291,7 @@ func TestAvailableDevicesForVG(t *testing.T) {
 			numOfAvailableDevices: 0,
 		},
 		{
-			description: "vg has device path that is already a part of the existing vg",
+			description: "vg has device paths that are already a part of the existing vg",
 			volumeGroup: v1alpha1.LVMVolumeGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "vg1",
@@ -301,6 +301,9 @@ func TestAvailableDevicesForVG(t *testing.T) {
 						Paths: []string{
 							devicePaths["nvme1n1p1"],
 						},
+						OptionalPaths: []string{
+							devicePaths["nvme1n1p2"],
+						},
 					},
 				},
 			},
@@ -309,6 +312,7 @@ func TestAvailableDevicesForVG(t *testing.T) {
 					Name: "vg1",
 					PVs: []string{
 						calculateDevicePath(t, "nvme1n1p1"),
+						calculateDevicePath(t, "nvme1n1p2"),
 					},
 				},
 			},
@@ -316,6 +320,14 @@ func TestAvailableDevicesForVG(t *testing.T) {
 				{
 					Name:     "nvme1n1p1",
 					KName:    calculateDevicePath(t, "nvme1n1p1"),
+					Type:     "disk",
+					Size:     "279.4G",
+					ReadOnly: false,
+					State:    "live",
+				},
+				{
+					Name:     "nvme1n1p2",
+					KName:    calculateDevicePath(t, "nvme1n1p2"),
 					Type:     "disk",
 					Size:     "279.4G",
 					ReadOnly: false,


### PR DESCRIPTION
It was discovered as part of the 4.14 verification process that the available devices check was creating an error due to not properly skipping devices that were already part of the volume group. This error would lead to a degraded state of the lvmcluster when the first reconciliation loop was initiated.