### PR TITLE
OCPVE-627: fix: concurrent apply / status checks -> LVMCluster

### DIFF
--- a/controllers/internal/multierror.go
+++ b/controllers/internal/multierror.go
@@ -1,0 +1,25 @@
+package internal
+
+import (
+	"strings"
+)
+
+// NewMultiErrorWithNewLineSeparator creates a MultiError that uses "\n" as separator for each error.
+func NewMultiErrorWithNewLineSeparator(errs []error) error {
+	return &MultiError{Errors: errs, Separator: "\n"}
+}
+
+// MultiError is an error that aggregates multiple errors together and uses
+// a separator to aggregate them when called with Error.
+type MultiError struct {
+	Errors    []error
+	Separator string
+}
+
+func (m *MultiError) Error() string {
+	errs := make([]string, len(m.Errors))
+	for i, err := range m.Errors {
+		errs[i] = err.Error()
+	}
+	return strings.Join(errs, m.Separator)
+}

--- a/controllers/internal/multierror.go
+++ b/controllers/internal/multierror.go
@@ -4,9 +4,11 @@ import (
 	"strings"
 )
 
-// NewMultiErrorWithNewLineSeparator creates a MultiError that uses "\n" as separator for each error.
-func NewMultiErrorWithNewLineSeparator(errs []error) error {
-	return &MultiError{Errors: errs, Separator: "\n"}
+const DefaultMultiErrorSeparator = ";"
+
+// NewMultiError creates a MultiError that uses the default separator for each error.
+func NewMultiError(errs []error) error {
+	return &MultiError{Errors: errs, Separator: DefaultMultiErrorSeparator}
 }
 
 // MultiError is an error that aggregates multiple errors together and uses

--- a/controllers/lvmcluster_controller.go
+++ b/controllers/lvmcluster_controller.go
@@ -227,9 +227,8 @@ func (r *LVMClusterReconciler) reconcile(ctx context.Context, instance *lvmv1alp
 
 	resourceSyncElapsedTime := time.Since(resourceSyncStart)
 	if len(errs) > 0 {
-		err := internal.NewMultiErrorWithNewLineSeparator(errs)
-		r.Log.Error(err, "failed to reconcile resources managed by LVMCluster", "resourceSyncElapsedTime", resourceSyncElapsedTime)
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile resources managed by LVMCluster within %v: %w",
+			resourceSyncElapsedTime, internal.NewMultiError(errs))
 	}
 
 	r.Log.Info("successfully reconciled LVMCluster", "resourceSyncElapsedTime", resourceSyncElapsedTime)

--- a/controllers/lvmcluster_controller.go
+++ b/controllers/lvmcluster_controller.go
@@ -25,8 +25,8 @@ import (
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
 	secv1client "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
-
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
+	"github.com/openshift/lvm-operator/controllers/internal"
 
 	topolvmv1 "github.com/topolvm/topolvm/api/v1"
 
@@ -165,7 +165,7 @@ func (r *LVMClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 // errors returned by this will be updated in the reconcileSucceeded condition of the LVMCluster
 func (r *LVMClusterReconciler) reconcile(ctx context.Context, instance *lvmv1alpha1.LVMCluster) (ctrl.Result, error) {
 
-	//The resource was deleted
+	// The resource was deleted
 	if !instance.DeletionTimestamp.IsZero() {
 		// Check for existing LogicalVolumes
 		lvsExist, err := r.logicalVolumesExist(ctx, instance)
@@ -197,7 +197,7 @@ func (r *LVMClusterReconciler) reconcile(ctx context.Context, instance *lvmv1alp
 		r.Log.Info("successfully added finalizer")
 	}
 
-	resourceCreationList := []resourceManager{
+	resources := []resourceManager{
 		&csiDriver{},
 		&topolvmController{r.TopoLVMLeaderElectionPassthrough},
 		&openshiftSccs{},
@@ -208,16 +208,31 @@ func (r *LVMClusterReconciler) reconcile(ctx context.Context, instance *lvmv1alp
 		&topolvmVolumeSnapshotClass{},
 	}
 
-	// handle create/update
-	for _, unit := range resourceCreationList {
-		err := unit.ensureCreated(r, ctx, instance)
-		if err != nil {
-			r.Log.Error(err, "failed to reconcile", "resource", unit.getName())
-			return ctrl.Result{}, err
+	resourceSyncStart := time.Now()
+	results := make(chan error, len(resources))
+	create := func(i int) {
+		results <- resources[i].ensureCreated(r, ctx, instance)
+	}
+
+	for i := range resources {
+		go create(i)
+	}
+
+	var errs []error
+	for i := 0; i < len(resources); i++ {
+		if err := <-results; err != nil {
+			errs = append(errs, err)
 		}
 	}
 
-	r.Log.Info("successfully reconciled LVMCluster")
+	resourceSyncElapsedTime := time.Since(resourceSyncStart)
+	if len(errs) > 0 {
+		err := internal.NewMultiErrorWithNewLineSeparator(errs)
+		r.Log.Error(err, "failed to reconcile resources managed by LVMCluster", "resourceSyncElapsedTime", resourceSyncElapsedTime)
+		return ctrl.Result{}, err
+	}
+
+	r.Log.Info("successfully reconciled LVMCluster", "resourceSyncElapsedTime", resourceSyncElapsedTime)
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/topolvm_controller.go
+++ b/controllers/topolvm_controller.go
@@ -19,9 +19,9 @@ package controllers
 import (
 	"context"
 	"fmt"
-	v1 "github.com/openshift/api/config/v1"
 	"path/filepath"
 
+	v1 "github.com/openshift/api/config/v1"
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -74,6 +74,11 @@ func (c topolvmController) ensureCreated(r *LVMClusterReconciler, ctx context.Co
 
 	if err != nil {
 		r.Log.Error(err, "csi controller reconcile failure", "name", desiredDeployment.Name)
+		return err
+	}
+
+	if err := verifyDeploymentReadiness(existingDeployment); err != nil {
+		r.Log.Error(err, "csi controller is not considered ready", "deployment", existingDeployment.Name)
 		return err
 	}
 

--- a/controllers/topolvm_node.go
+++ b/controllers/topolvm_node.go
@@ -97,6 +97,12 @@ func (n topolvmNode) ensureCreated(r *LVMClusterReconciler, ctx context.Context,
 	} else {
 		r.Log.Info(topolvmNodeName, "operation", result, "name", ds.Name)
 	}
+
+	if err := verifyDaemonSetReadiness(ds); err != nil {
+		r.Log.Error(err, "DaemonSet is not considered ready", "DaemonSet", topolvmNodeName)
+		return err
+	}
+
 	return err
 }
 

--- a/controllers/topolvm_node.go
+++ b/controllers/topolvm_node.go
@@ -61,8 +61,7 @@ func (n topolvmNode) ensureCreated(r *LVMClusterReconciler, ctx context.Context,
 
 	err := cutil.SetControllerReference(lvmCluster, ds, r.Scheme)
 	if err != nil {
-		r.Log.Error(err, "failed to set controller reference to topolvm node daemonset with name", ds.Name)
-		return err
+		return fmt.Errorf("failed to set controller reference to topolvm node daemonset: %w", err)
 	}
 
 	unitLogger.Info("running CreateOrUpdate")
@@ -93,17 +92,17 @@ func (n topolvmNode) ensureCreated(r *LVMClusterReconciler, ctx context.Context,
 	})
 
 	if err != nil {
-		r.Log.Error(err, fmt.Sprintf("%s reconcile failure", topolvmNodeName), "name", ds.Name)
-	} else {
-		r.Log.Info(topolvmNodeName, "operation", result, "name", ds.Name)
+		return fmt.Errorf("%s failed to reconcile: %w", n.getName(), err)
 	}
+
+	unitLogger.Info("DaemonSet applied to cluster", "operation", result, "name", ds.Name)
 
 	if err := verifyDaemonSetReadiness(ds); err != nil {
-		r.Log.Error(err, "DaemonSet is not considered ready", "DaemonSet", topolvmNodeName)
-		return err
+		return fmt.Errorf("DaemonSet is not considered ready: %w", err)
 	}
+	unitLogger.Info("DaemonSet is ready", "name", ds.Name)
 
-	return err
+	return nil
 }
 
 // ensureDeleted should wait for the resources to be cleaned up

--- a/controllers/vgmanager.go
+++ b/controllers/vgmanager.go
@@ -110,6 +110,12 @@ func (v vgManager) ensureCreated(r *LVMClusterReconciler, ctx context.Context, l
 	} else {
 		unitLogger.Info("daemonset unchanged")
 	}
+
+	if err := verifyDaemonSetReadiness(ds); err != nil {
+		r.Log.Error(err, "DaemonSet is not considered ready", "DaemonSet", topolvmNodeName)
+		return err
+	}
+
 	return err
 }
 

--- a/controllers/vgmanager.go
+++ b/controllers/vgmanager.go
@@ -24,7 +24,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 type vgManager struct{}
@@ -103,20 +102,17 @@ func (v vgManager) ensureCreated(r *LVMClusterReconciler, ctx context.Context, l
 	})
 
 	if err != nil {
-		r.Log.Error(err, "failed to create or update vgManager daemonset", "name", ds.Name)
-		return err
-	} else if result != controllerutil.OperationResultNone {
-		unitLogger.Info("daemonset modified", "operation", result, "name", ds.Name)
-	} else {
-		unitLogger.Info("daemonset unchanged")
+		return fmt.Errorf("%s failed to reconcile: %w", v.getName(), err)
 	}
+
+	unitLogger.Info("DaemonSet applied to cluster", "operation", result, "name", ds.Name)
 
 	if err := verifyDaemonSetReadiness(ds); err != nil {
-		r.Log.Error(err, "DaemonSet is not considered ready", "DaemonSet", topolvmNodeName)
-		return err
+		return fmt.Errorf("DaemonSet is not considered ready: %w", err)
 	}
+	unitLogger.Info("DaemonSet is ready", "name", ds.Name)
 
-	return err
+	return nil
 }
 
 // ensureDeleted is a noop. Deletion will be handled by ownerref


### PR DESCRIPTION
This PR introduces concurrent processing for the ensureCreated operations for each resourceManager in the LVMClusterReconciler controller, which significantly improves the overall reconciliation time for the `LVMCluster` custom resource.

The newly added `multierror.go` groups multiple errors into a single error, thereby helping to manage multiple errors generated from concurrent ensureCreated calls. This helps the concurrent apply since errors are not cancelled when one call fails, and multiple failures can occur at once.

Moreover, readiness checks have been added after the creation of Deployment and DaemonSet resources in the `topolvm_controller.go`, `topolvm_node.go`, and `vgmanager.go` files respectively.
These checks ensure that the deployment or `DaemonSet` has been completely initialized and is ready for use.
It also adds `verifyDeploymentReadiness` and `verifyDaemonSetReadiness` functions in `utils.go` to verify the readiness of Deployment and DaemonSet resources respectively.

Note: The checks currently do not get propagated to LVMCluster yet because the LVMCluster State is independant from the Readiness checks done during reconciliation. We will need an API Change to propagate this correctly (in a later change) as otherwise we would set LVMCluster to Degraded/Failed but couldnt show why (because the only status message fields in LVMCluster are for volume group failures, not any of the basic deployed components, and there is no vg present at the time of the readiness check)