### PR TITLE
OCPVE-361: chore: allow multi-arch with ARCH / OS Flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETPLATFORM
 # Build the manager binary
 FROM golang:1.20 as builder
 
@@ -17,12 +21,12 @@ COPY cmd/ cmd/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build --ldflags "-s -w" -a -o manager main.go
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build --ldflags "-s -w" -a -o vgmanager cmd/vgmanager/main.go
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build --ldflags "-s -w" -a -o metricsexporter cmd/metricsexporter/exporter.go
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build --ldflags "-s -w" -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build --ldflags "-s -w" -a -o vgmanager cmd/vgmanager/main.go
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build --ldflags "-s -w" -a -o metricsexporter cmd/metricsexporter/exporter.go
 
 # vgmanager needs 'nsenter' and other basic linux utils to correctly function
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:9.2
 
 # Update the image to get the latest CVE updates
 RUN microdnf update -y && \

--- a/Makefile
+++ b/Makefile
@@ -169,20 +169,22 @@ run: manifests generate ## Run the Operator from your host.
 ##@ Build
 
 IMAGE_BUILD_CMD ?= $(shell command -v docker 2>&1 >/dev/null && echo docker || echo podman)
+OS ?= linux
+ARCH ?= amd64
 
 all: build
 
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/manager main.go
 
 build-vgmanager: generate fmt vet ## Build vg manager binary.
-	go build -o bin/vgmanager cmd/vgmanager/main.go
+	GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/vgmanager cmd/vgmanager/main.go
 
 build-prometheus-alert-rules: jsonnet monitoring/mixin.libsonnet monitoring/alerts/alerts.jsonnet monitoring/alerts/*.libsonnet
 	$(JSONNET) -S monitoring/alerts/alerts.jsonnet > config/prometheus/prometheus_rules.yaml
 
 docker-build: ## Build docker image with the manager.
-	$(IMAGE_BUILD_CMD) build -t ${IMG} .
+	$(IMAGE_BUILD_CMD) build --platform=${OS}/${ARCH} -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.
 	$(IMAGE_BUILD_CMD) push ${IMG}


### PR DESCRIPTION
Allows building multi-arch images with ARCH / OS Flag from makefile. Also adjusts dockerfile to have the correct flags passed to the builder and running platform image.