### PR TITLE
feat: switch to SSA for resource reconciliation

### DIFF
--- a/controllers/scc.go
+++ b/controllers/scc.go
@@ -25,13 +25,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
 	sccName = "topolvm-scc"
 )
 
-type openshiftSccs struct{}
+type openshiftSccs struct{ *runtime.Scheme }
 
 // openshiftSccs unit satisfies resourceManager interface
 var _ resourceManager = openshiftSccs{}

--- a/controllers/vgmanager.go
+++ b/controllers/vgmanager.go
@@ -22,12 +22,13 @@ import (
 
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type vgManager struct{}
+type vgManager struct{ *runtime.Scheme }
 
 var _ resourceManager = vgManager{}
 
@@ -43,72 +44,26 @@ func (v vgManager) ensureCreated(r *LVMClusterReconciler, ctx context.Context, l
 	unitLogger := r.Log.WithValues("resourceManager", v.getName())
 
 	// get desired daemonset spec
-	dsTemplate := newVGManagerDaemonset(lvmCluster, r.Namespace, r.ImageName)
+	ds := newVGManagerDaemonset(lvmCluster, r.Namespace, r.ImageName)
+	if versioned, err := v.Scheme.ConvertToVersion(ds,
+		runtime.GroupVersioner(schema.GroupVersions(v.Scheme.PrioritizedVersionsAllGroups()))); err == nil {
+		ds = versioned.(*appsv1.DaemonSet)
+	}
 
 	// controller reference
-	err := ctrl.SetControllerReference(lvmCluster, &dsTemplate, r.Scheme)
+	err := ctrl.SetControllerReference(lvmCluster, ds, r.Scheme)
 	if err != nil {
-		return fmt.Errorf("failed to set controller reference on vgManager daemonset %q. %v", dsTemplate.Name, err)
+		return fmt.Errorf("failed to set controller reference on vgManager daemonset %q. %v", ds.Name, err)
 	}
 
-	// create desired daemonset or update mutable fields on existing one
-	ds := &appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      dsTemplate.Name,
-			Namespace: dsTemplate.Namespace,
-		},
-	}
-	unitLogger.Info("running CreateOrUpdate")
+	unitLogger.Info("Apply")
 	// the anonymous mutate function modifies the daemonset object after fetching it.
 	// if the daemonset does not already exist, it creates it, otherwise, it updates it
-	result, err := ctrl.CreateOrUpdate(ctx, r.Client, ds, func() error {
-		// at creation, deep copy the whole daemonset
-		if ds.CreationTimestamp.IsZero() {
-			dsTemplate.DeepCopyInto(ds)
-			return nil
-		}
-		// if update, update only mutable fields
 
-		// copy selector labels to daemonset and template
-		initMapIfNil(&ds.ObjectMeta.Labels)
-		initMapIfNil(&ds.Spec.Template.ObjectMeta.Labels)
-		for key, value := range dsTemplate.Labels {
-			ds.ObjectMeta.Labels[key] = value
-			ds.Spec.Template.ObjectMeta.Labels[key] = value
-		}
-
-		// containers
-		ds.Spec.Template.Spec.Containers = dsTemplate.Spec.Template.Spec.Containers
-
-		// volumes
-		ds.Spec.Template.Spec.Volumes = dsTemplate.Spec.Template.Spec.Volumes
-
-		// service account
-		ds.Spec.Template.Spec.ServiceAccountName = dsTemplate.Spec.Template.Spec.ServiceAccountName
-
-		// controller reference
-		err := ctrl.SetControllerReference(lvmCluster, ds, r.Scheme)
-		if err != nil {
-			return fmt.Errorf("failed to update controller reference on vgManager daemonset %q. %v", ds.Name, err)
-		}
-		// tolerations
-		ds.Spec.Template.Spec.Tolerations = dsTemplate.Spec.Template.Spec.Tolerations
-
-		// nodeSelector if non-nil
-		if dsTemplate.Spec.Template.Spec.Affinity != nil {
-			setDaemonsetNodeSelector(dsTemplate.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution, ds)
-		}
-
-		return nil
-	})
-
+	err = r.Client.Patch(ctx, ds, client.Apply, client.ForceOwnership, client.FieldOwner(ControllerName))
 	if err != nil {
 		r.Log.Error(err, "failed to create or update vgManager daemonset", "name", ds.Name)
 		return err
-	} else if result != controllerutil.OperationResultNone {
-		unitLogger.Info("daemonset modified", "operation", result, "name", ds.Name)
-	} else {
-		unitLogger.Info("daemonset unchanged")
 	}
 	return err
 }

--- a/controllers/vgmanager_daemonset.go
+++ b/controllers/vgmanager_daemonset.go
@@ -113,7 +113,7 @@ var (
 )
 
 // newVGManagerDaemonset returns the desired vgmanager daemonset for a given LVMCluster
-func newVGManagerDaemonset(lvmCluster *lvmv1alpha1.LVMCluster, namespace string, vgImage string) appsv1.DaemonSet {
+func newVGManagerDaemonset(lvmCluster *lvmv1alpha1.LVMCluster, namespace string, vgImage string) *appsv1.DaemonSet {
 	// aggregate nodeSelector and tolerations from all deviceClasses
 	nodeSelector, tolerations := extractNodeSelectorAndTolerations(lvmCluster)
 	volumes := []corev1.Volume{LVMDConfVol, DevHostDirVol, UDevHostDirVol, SysHostDirVol}
@@ -207,5 +207,5 @@ func newVGManagerDaemonset(lvmCluster *lvmv1alpha1.LVMCluster, namespace string,
 
 	// set nodeSelector
 	setDaemonsetNodeSelector(nodeSelector, &ds)
-	return ds
+	return &ds
 }

--- a/controllers/vgmanager_test.go
+++ b/controllers/vgmanager_test.go
@@ -18,18 +18,23 @@ package controllers
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
+
+	"gotest.tools/v3/assert"
 
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
-	"gotest.tools/v3/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -53,10 +58,31 @@ func newFakeLVMClusterReconciler(t *testing.T, objs ...client.Object) *LVMCluste
 	err = snapapi.AddToScheme(scheme)
 	assert.NilError(t, err, "adding snapshot api to scheme")
 
-	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	// needed due to lack of apply fake support in controller-runtime https://github.com/kubernetes-sigs/controller-runtime/issues/2341
+	interceptorForApplyWorkaround := func(ctx context.Context, clnt client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+		// Apply patches are supposed to upsert, but fake client fails if the object doesn't exist,
+		// if an apply patch occurs for a deployment that doesn't yet exist, create it.
+		// However, we already hold the fakeclient lock, so we can't use the front door.
+		if patch.Type() != types.ApplyPatchType {
+			return clnt.Patch(ctx, obj, patch, opts...)
+		}
+		check, ok := obj.DeepCopyObject().(client.Object)
+		if !ok {
+			return errors.New("could not check for object in fake client")
+		}
+		if err := clnt.Get(ctx, client.ObjectKeyFromObject(obj), check); k8serror.IsNotFound(err) {
+			if err := clnt.Create(ctx, check); err != nil {
+				return fmt.Errorf("could not inject object creation for fake: %w", err)
+			}
+		}
+		return clnt.Patch(ctx, obj, patch, opts...)
+	}
+
+	clnt := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
+		WithInterceptorFuncs(interceptor.Funcs{Patch: interceptorForApplyWorkaround}).Build()
 
 	return &LVMClusterReconciler{
-		Client:    client,
+		Client:    clnt,
 		Scheme:    scheme,
 		Log:       logf.Log.WithName("LVMCLusterTest"),
 		Namespace: "default",
@@ -94,7 +120,7 @@ func TestVGManagerEnsureCreated(t *testing.T) {
 			Spec: testCase.lvmclusterSpec,
 		}
 		r := newFakeLVMClusterReconciler(t, lvmcluster)
-		var unit resourceManager = vgManager{}
+		var unit resourceManager = vgManager{Scheme: r.Scheme}
 		err := unit.ensureCreated(r, context.Background(), lvmcluster)
 		assert.NilError(t, err, "running ensureCreated")
 		ds := &appsv1.DaemonSet{}


### PR DESCRIPTION
This is a sample implementation for SSA within lvm-operator and changes resource synchronization to no longer use Create/Update but use the k8s API Server for conflict resolution