### PR TITLE
OCPVE-667: fix: allow no default deviceClass to be set

### DIFF
--- a/controllers/topolvm_storageclass.go
+++ b/controllers/topolvm_storageclass.go
@@ -138,11 +138,9 @@ func getTopolvmStorageClasses(r *LVMClusterReconciler, ctx context.Context, lvmC
 			},
 		}
 		// reconcile will pick up any existing LVMO storage classes as well
-		if setDefaultStorageClass && (defaultStorageClassName == "" || defaultStorageClassName == scName) {
-			if len(lvmCluster.Spec.Storage.DeviceClasses) == 1 || deviceClass.Default {
-				storageClass.Annotations[defaultSCAnnotation] = "true"
-				defaultStorageClassName = scName
-			}
+		if deviceClass.Default && setDefaultStorageClass && (defaultStorageClassName == "" || defaultStorageClassName == scName) {
+			storageClass.Annotations[defaultSCAnnotation] = "true"
+			defaultStorageClassName = scName
 		}
 		sc = append(sc, storageClass)
 	}


### PR DESCRIPTION
This allows no default deviceClass to be present. Since this is a change from previous validation it now includes a warning if no default is set: "no default deviceClass was specified, it will be mandatory to specify the storage class"

TODO:

- [x] Test case using no default deviceClass that succeeds in e2e tests