### PR TITLE
OCPBUGS-18354: owns watches config updates

### DIFF
--- a/controllers/lvmcluster_controller_watches.go
+++ b/controllers/lvmcluster_controller_watches.go
@@ -39,7 +39,6 @@ func (r *LVMClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&lvmv1alpha1.LVMCluster{}).
 		Owns(&appsv1.DaemonSet{}).
 		Owns(&lvmv1alpha1.LVMVolumeGroup{}).
-		Owns(&lvmv1alpha1.LVMVolumeGroupNodeStatus{}).
 		Watches(
 			&lvmv1alpha1.LVMVolumeGroupNodeStatus{},
 			handler.EnqueueRequestsFromMapFunc(r.getLVMClusterObjsForReconcile),

--- a/controllers/lvmcluster_controller_watches.go
+++ b/controllers/lvmcluster_controller_watches.go
@@ -19,17 +19,23 @@ package controllers
 import (
 	"context"
 
+	snapapiv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	corev1helper "k8s.io/component-helpers/scheduling/corev1"
+
 	secv1 "github.com/openshift/api/security/v1"
+
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	"github.com/openshift/lvm-operator/pkg/cluster"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	"github.com/openshift/lvm-operator/pkg/labels"
 
 	appsv1 "k8s.io/api/apps/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -38,45 +44,111 @@ func (r *LVMClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&lvmv1alpha1.LVMCluster{}).
 		Owns(&appsv1.DaemonSet{}).
+		Owns(&appsv1.Deployment{}).
 		Owns(&lvmv1alpha1.LVMVolumeGroup{}).
 		Watches(
 			&lvmv1alpha1.LVMVolumeGroupNodeStatus{},
-			handler.EnqueueRequestsFromMapFunc(r.getLVMClusterObjsForReconcile),
+			handler.EnqueueRequestsFromMapFunc(r.getLVMClusterObjsByNameFittingNodeSelector),
 		).
 		Watches(
 			&storagev1.StorageClass{},
-			handler.EnqueueRequestsFromMapFunc(r.getLVMClusterObjsForReconcile),
+			handler.EnqueueRequestsFromMapFunc(r.getManagedLabelObjsForReconcile),
 		)
 
 	if r.ClusterType == cluster.TypeOCP {
 		builder = builder.Watches(
 			&secv1.SecurityContextConstraints{},
-			handler.EnqueueRequestsFromMapFunc(r.getLVMClusterObjsForReconcile),
+			handler.EnqueueRequestsFromMapFunc(r.getManagedLabelObjsForReconcile),
+		)
+	}
+	if r.EnableSnapshotting {
+		builder = builder.Watches(
+			&snapapiv1.VolumeSnapshotClass{},
+			handler.EnqueueRequestsFromMapFunc(r.getManagedLabelObjsForReconcile),
 		)
 	}
 
 	return builder.Complete(r)
 }
 
-func (r *LVMClusterReconciler) getLVMClusterObjsForReconcile(ctx context.Context, obj client.Object) []reconcile.Request {
-
+// getManagedLabelObjsForReconcile reconciles the object anytime the given object has all management labels
+// set to the available lvmclusters. This can be used especially if owner references are not a valid option (e.g.
+// the namespaced LVMCluster needs to "own" a cluster-scoped resource, in which case owner references are invalid).
+// This should generally only be used for cluster-scoped resources. Also it should be noted that deletion logic must
+// be handled manually as garbage collection is not handled automatically like for owner references.
+func (r *LVMClusterReconciler) getManagedLabelObjsForReconcile(ctx context.Context, obj client.Object) []reconcile.Request {
 	foundLVMClusterList := &lvmv1alpha1.LVMClusterList{}
 	listOps := &client.ListOptions{
 		Namespace: obj.GetNamespace(),
 	}
 
 	if err := r.Client.List(ctx, foundLVMClusterList, listOps); err != nil {
-		log.FromContext(ctx).Error(err, "getLVMClusterObjsForReconcile: Failed to get LVMCluster objs")
+		log.FromContext(ctx).Error(err, "getManagedLabelObjsForReconcile: Failed to get LVMCluster objs")
 		return []reconcile.Request{}
 	}
 
-	requests := make([]reconcile.Request, len(foundLVMClusterList.Items))
-	for i, item := range foundLVMClusterList.Items {
-		requests[i] = reconcile.Request{
+	var requests []reconcile.Request
+	for _, lvmCluster := range foundLVMClusterList.Items {
+		if !labels.MatchesManagedLabels(r.Scheme, obj, &lvmCluster) {
+			continue
+		}
+		requests = append(requests, reconcile.Request{
 			NamespacedName: types.NamespacedName{
-				Name:      item.GetName(),
-				Namespace: item.GetNamespace(),
+				Name:      lvmCluster.GetName(),
+				Namespace: lvmCluster.GetNamespace(),
 			},
+		})
+	}
+	return requests
+}
+
+// getLVMClusterObjsByNameFittingNodeSelector enqueues the cluster in case the object name fits the node name.
+// this means that as if the obj name fits to a given node on the cluster and that node is part of the node selector,
+// then the lvm cluster will get updated as well. Should only be used in conjunction with LVMVolumeGroupNodeStatus
+// as other objects do not use the node name as resource name.
+func (r *LVMClusterReconciler) getLVMClusterObjsByNameFittingNodeSelector(ctx context.Context, obj client.Object) []reconcile.Request {
+	foundLVMClusterList := &lvmv1alpha1.LVMClusterList{}
+	listOps := &client.ListOptions{
+		Namespace: obj.GetNamespace(),
+	}
+
+	if err := r.Client.List(ctx, foundLVMClusterList, listOps); err != nil {
+		log.FromContext(ctx).Error(err, "getLVMClusterObjsByNameFittingNodeSelector: Failed to get LVMCluster objs")
+		return []reconcile.Request{}
+	}
+
+	node := &v1.Node{}
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(obj), node); err != nil {
+		log.FromContext(ctx).Error(err, "getLVMClusterObjsByNameFittingNodeSelector: Failed to get Node")
+		return []reconcile.Request{}
+	}
+
+	var requests []reconcile.Request
+	for _, lvmCluster := range foundLVMClusterList.Items {
+		selector, _ := extractNodeSelectorAndTolerations(&lvmCluster)
+		// if the selector is nil then the default behavior is to match all nodes
+		if selector == nil {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      lvmCluster.GetName(),
+					Namespace: lvmCluster.GetNamespace(),
+				},
+			})
+			continue
+		}
+
+		match, err := corev1helper.MatchNodeSelectorTerms(node, selector)
+		if err != nil {
+			log.FromContext(ctx).Error(err, "getLVMClusterObjsByNameFittingNodeSelector: node selector matching in event handler failed")
+			return []reconcile.Request{}
+		}
+		if match {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      lvmCluster.GetName(),
+					Namespace: lvmCluster.GetNamespace(),
+				},
+			})
 		}
 	}
 	return requests

--- a/controllers/scc.go
+++ b/controllers/scc.go
@@ -21,7 +21,10 @@ import (
 	"fmt"
 
 	secv1 "github.com/openshift/api/security/v1"
+
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
+	"github.com/openshift/lvm-operator/pkg/labels"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,7 +46,7 @@ func (c openshiftSccs) getName() string {
 	return sccName
 }
 
-func (c openshiftSccs) ensureCreated(r *LVMClusterReconciler, ctx context.Context, _ *lvmv1alpha1.LVMCluster) error {
+func (c openshiftSccs) ensureCreated(r *LVMClusterReconciler, ctx context.Context, cluster *lvmv1alpha1.LVMCluster) error {
 	logger := log.FromContext(ctx).WithValues("resourceManager", c.getName())
 	sccs := getAllSCCs(r.Namespace)
 	for _, scc := range sccs {
@@ -58,6 +61,7 @@ func (c openshiftSccs) ensureCreated(r *LVMClusterReconciler, ctx context.Contex
 			return fmt.Errorf("something went wrong when checking for SecurityContextConstraint: %w", err)
 		}
 
+		labels.SetManagedLabels(r.Scheme, scc, cluster)
 		if err := r.Create(ctx, scc); err != nil {
 			return fmt.Errorf("%s failed to reconcile: %w", c.getName(), err)
 		}

--- a/controllers/topolvm_csi_driver.go
+++ b/controllers/topolvm_csi_driver.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
+	"github.com/openshift/lvm-operator/pkg/labels"
+
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -44,11 +46,12 @@ func (c csiDriver) getName() string {
 
 //+kubebuilder:rbac:groups=storage.k8s.io,resources=csidrivers,verbs=get;create;delete;watch;list
 
-func (c csiDriver) ensureCreated(r *LVMClusterReconciler, ctx context.Context, _ *lvmv1alpha1.LVMCluster) error {
+func (c csiDriver) ensureCreated(r *LVMClusterReconciler, ctx context.Context, cluster *lvmv1alpha1.LVMCluster) error {
 	logger := log.FromContext(ctx).WithValues("resourceManager", c.getName())
 	csiDriverResource := getCSIDriverResource()
 
 	result, err := cutil.CreateOrUpdate(ctx, r.Client, csiDriverResource, func() error {
+		labels.SetManagedLabels(r.Scheme, csiDriverResource, cluster)
 		// no need to mutate any field
 		return nil
 	})

--- a/controllers/vgmanager.go
+++ b/controllers/vgmanager.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
+	"github.com/openshift/lvm-operator/pkg/labels"
+
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -56,6 +58,7 @@ func (v vgManager) ensureCreated(r *LVMClusterReconciler, ctx context.Context, l
 	// the anonymous mutate function modifies the daemonset object after fetching it.
 	// if the daemonset does not already exist, it creates it, otherwise, it updates it
 	result, err := ctrl.CreateOrUpdate(ctx, r.Client, ds, func() error {
+		labels.SetManagedLabels(r.Scheme, ds, lvmCluster)
 		if err := ctrl.SetControllerReference(lvmCluster, ds, r.Scheme); err != nil {
 			return fmt.Errorf("failed to set controller reference on vgManager daemonset %q. %v", dsTemplate.Name, err)
 		}

--- a/pkg/labels/managed.go
+++ b/pkg/labels/managed.go
@@ -1,0 +1,58 @@
+package labels
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// orients itself on https://sdk.operatorframework.io/docs/building-operators/ansible/reference/retroactively-owned-resources/#for-objects-which-are-not-in-the-same-namespace-as-the-owner-cr
+// but uses labels and split apiVersion,kind and namespace,name to make label searches and filters possible.
+const (
+	OwnedByPrefix    = "owned-by.topolvm.io"
+	OwnedByName      = OwnedByPrefix + "/name"
+	OwnedByNamespace = OwnedByPrefix + "/namespace"
+	OwnedByUID       = OwnedByPrefix + "/uid"
+	OwnedByGroup     = OwnedByPrefix + "/group"
+	OwnedByVersion   = OwnedByPrefix + "/version"
+	OwnedByKind      = OwnedByPrefix + "/kind"
+)
+
+func SetManagedLabels(scheme *runtime.Scheme, obj client.Object, owner client.Object) {
+	lbls := obj.GetLabels()
+	if lbls == nil {
+		lbls = make(map[string]string)
+	}
+	lbls[OwnedByName] = owner.GetName()
+	lbls[OwnedByNamespace] = owner.GetNamespace()
+	lbls[OwnedByUID] = string(owner.GetUID())
+	if runtimeObj, ok := owner.(runtime.Object); ok {
+		if gvk, err := apiutil.GVKForObject(runtimeObj, scheme); err == nil {
+			lbls[OwnedByGroup] = gvk.Group
+			lbls[OwnedByVersion] = gvk.Version
+			lbls[OwnedByKind] = gvk.Kind
+		}
+	}
+	obj.SetLabels(lbls)
+}
+
+func MatchesManagedLabels(scheme *runtime.Scheme, obj client.Object, owner client.Object) bool {
+	if lbls := obj.GetLabels(); lbls != nil {
+		baseMatch := lbls[OwnedByName] == owner.GetName() &&
+			lbls[OwnedByNamespace] == owner.GetNamespace() &&
+			lbls[OwnedByUID] == string(owner.GetUID())
+
+		if !baseMatch {
+			return false
+		}
+
+		if ownerRuntimeObj, ok := owner.(runtime.Object); ok {
+			if gvk, err := apiutil.GVKForObject(ownerRuntimeObj, scheme); err == nil {
+				return lbls[OwnedByGroup] == gvk.Group &&
+					lbls[OwnedByVersion] == gvk.Version &&
+					lbls[OwnedByKind] == gvk.Kind
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This updates all cluster-scoped subresources to have 6 new labels useful for filtering and assignments (in place of the usual ownerreference) - csidriver, volumesnapshotclass,scc,storageclass will now receive these labels. These labels are also used to filter the watch to stop watching for unnecessary objects in the cluster.

On top of this, now LVMVolumeGroupNodeStatus receives OwnerReferences from LVMVolumeGroup. We can later decide to upgrade them to blockOwnerDeletion as well, but currently its a normal OwnerReference (no controller reference to avoid conflicts between multiple volume groups on one NodeStatus). If the volumegroup disappears from the node, so does the owner reference.

Snapshotting was moved to a similar check as SecurityContextConstraints to also allow a watch on the correct snapshot class. Sideeffect: if LVMS is installed after snapshot apis, a manual restart is necessary. For all openshift distros and people aware of this, this shouldnt be an issue since the APIs are usually installed before extension operators.

Also adds an Owns configuration to the LVMCluster for the deployment controller of topo lvm in addition to the already watched daemon set.

Now all resources except for the initially created CSIDriver are watched and reacted to on status.  