### PR TITLE
OCPVE-677: test: reduce footprint of requested pvc to 1G from 5G

### DIFF
--- a/test/e2e/testdata/pvc_tests/pvc-clone-template.yaml
+++ b/test/e2e/testdata/pvc_tests/pvc-clone-template.yaml
@@ -9,7 +9,7 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 5Gi
+      storage: 1Gi
   storageClassName: %s
   dataSource:
     name: %s

--- a/test/e2e/testdata/pvc_tests/pvc-snapshot-restore-template.yaml
+++ b/test/e2e/testdata/pvc_tests/pvc-snapshot-restore-template.yaml
@@ -9,7 +9,7 @@ spec:
   volumeMode: %s
   resources:
     requests:
-      storage: 5Gi
+      storage: 1Gi
   storageClassName: %s 
   dataSource:
     name: %s

--- a/test/e2e/testdata/pvc_tests/pvc-template.yaml
+++ b/test/e2e/testdata/pvc_tests/pvc-template.yaml
@@ -9,5 +9,5 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 5Gi
+      storage: 1Gi
   storageClassName: %s


### PR DESCRIPTION
Part of findings during testing. E2E tests partially consume 5G of Storage, reducing to 1G as we don't actually need that much for testing