### PR TITLE
OCPVE-677: chore: separate filter and lvm package from vgmanager

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package vgmanager
+package filter
 
 import (
 	"fmt"
 	"strings"
 
 	"github.com/openshift/lvm-operator/pkg/internal"
+	"github.com/openshift/lvm-operator/pkg/lvm"
 )
 
 const (
@@ -69,7 +70,7 @@ var FilterMap = map[string]func(internal.BlockDevice, internal.Executor) (bool, 
 		// if fstype is set to LVM2_member then it already was created as a PV
 		// this means that if the disk has no children, we can safely reuse it if it's a valid LVM PV.
 		if dev.FSType == "LVM2_member" && !dev.HasChildren() {
-			pvs, err := ListPhysicalVolumes(e, "")
+			pvs, err := lvm.ListPhysicalVolumes(e, "")
 			if err != nil {
 				return false, fmt.Errorf("could not determine if block device has valid filesystem signature, since it is flagged as LVM2_member but physical volumes could not be verified: %w", err)
 			}

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -1,4 +1,4 @@
-package vgmanager
+package filter
 
 import (
 	"testing"

--- a/pkg/lvm/lvm_test.go
+++ b/pkg/lvm/lvm_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package vgmanager
+package lvm
 
 import (
 	"fmt"

--- a/pkg/vgmanager/devices_test.go
+++ b/pkg/vgmanager/devices_test.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/go-logr/logr/testr"
 	"github.com/openshift/lvm-operator/api/v1alpha1"
+	"github.com/openshift/lvm-operator/pkg/filter"
 	"github.com/openshift/lvm-operator/pkg/internal"
+	"github.com/openshift/lvm-operator/pkg/lvm"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -34,13 +36,13 @@ func TestAvailableDevicesForVG(t *testing.T) {
 	r := &VGReconciler{}
 
 	// remove noBindMounts filter as it reads `proc/1/mountinfo` file.
-	delete(FilterMap, "noBindMounts")
+	delete(filter.FilterMap, "noBindMounts")
 
 	testCases := []struct {
 		description           string
 		volumeGroup           v1alpha1.LVMVolumeGroup
 		existingBlockDevices  []internal.BlockDevice
-		existingVGs           []VolumeGroup
+		existingVGs           []lvm.VolumeGroup
 		numOfAvailableDevices int
 		expectError           bool
 	}{
@@ -310,10 +312,10 @@ func TestAvailableDevicesForVG(t *testing.T) {
 					},
 				},
 			},
-			existingVGs: []VolumeGroup{
+			existingVGs: []lvm.VolumeGroup{
 				{
 					Name: "vg1",
-					PVs: []PhysicalVolume{
+					PVs: []lvm.PhysicalVolume{
 						{PvName: calculateDevicePath(t, "nvme1n1p1")},
 						{PvName: calculateDevicePath(t, "nvme1n1p2")},
 					},
@@ -354,7 +356,7 @@ func TestAvailableDevicesForVG(t *testing.T) {
 					},
 				},
 			},
-			existingVGs: []VolumeGroup{
+			existingVGs: []lvm.VolumeGroup{
 				{
 					Name: "vg1",
 				},
@@ -386,7 +388,7 @@ func TestAvailableDevicesForVG(t *testing.T) {
 					},
 				},
 			},
-			existingVGs: []VolumeGroup{
+			existingVGs: []lvm.VolumeGroup{
 				{
 					Name: "vg1",
 				},

--- a/pkg/vgmanager/status.go
+++ b/pkg/vgmanager/status.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
+	"github.com/openshift/lvm-operator/pkg/lvm"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -165,7 +166,7 @@ func (r *VGReconciler) removeVolumeGroupStatus(ctx context.Context, vg *lvmv1alp
 }
 
 func (r *VGReconciler) setDevices(status *lvmv1alpha1.VGStatus) (bool, error) {
-	vgs, err := ListVolumeGroups(r.executor)
+	vgs, err := lvm.ListVolumeGroups(r.executor)
 	if err != nil {
 		return false, fmt.Errorf("failed to list volume groups. %v", err)
 	}


### PR DESCRIPTION
Part of the findings of vgmanager testing. This separates vgmanager into 3 packages:

1. lvm, now contains ALL calls to LVM in the codebase
2. filter, now contains our filter methods and gets included from vgmanager
3. vgmanager, now only calls to lvm and filter in the correct places

Also the previously raw command executor calls for thinpool creation/extension were moved into separate methods in lvm package so that the perogative to contain all lvm calls still remains.