### PR TITLE
OCPVE-677: fix: allow deleting all storageclasses / vgs in case one is already gone

### DIFF
--- a/controllers/lvm_volumegroup.go
+++ b/controllers/lvm_volumegroup.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	cutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -81,7 +83,10 @@ func (c lvmVG) ensureDeleted(r *LVMClusterReconciler, ctx context.Context, lvmCl
 		logger := logger.WithValues("LVMVolumeGroup", volumeGroup.GetName())
 
 		if err := r.Client.Get(ctx, vgName, volumeGroup); err != nil {
-			return client.IgnoreNotFound(err)
+			if errors.IsNotFound(err) {
+				continue
+			}
+			return err
 		}
 
 		// if not marked for deletion, mark now.

--- a/controllers/scc.go
+++ b/controllers/scc.go
@@ -79,7 +79,10 @@ func (c openshiftSccs) ensureDeleted(r *LVMClusterReconciler, ctx context.Contex
 		name := types.NamespacedName{Name: scName}
 		logger := logger.WithValues("SecurityContextConstraint", scName)
 		if err := r.Client.Get(ctx, name, scc); err != nil {
-			return client.IgnoreNotFound(err)
+			if errors.IsNotFound(err) {
+				continue
+			}
+			return err
 		}
 
 		if !scc.GetDeletionTimestamp().IsZero() {

--- a/controllers/topolvm_snapshotclass.go
+++ b/controllers/topolvm_snapshotclass.go
@@ -21,13 +21,13 @@ import (
 	"fmt"
 
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	"github.com/openshift/lvm-operator/pkg/labels"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	cutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -76,7 +76,10 @@ func (s topolvmVolumeSnapshotClass) ensureDeleted(r *LVMClusterReconciler, ctx c
 
 		vsc := &snapapi.VolumeSnapshotClass{}
 		if err := r.Client.Get(ctx, types.NamespacedName{Name: vscName}, vsc); err != nil {
-			return client.IgnoreNotFound(err)
+			if errors.IsNotFound(err) {
+				continue
+			}
+			return err
 		}
 
 		if !vsc.GetDeletionTimestamp().IsZero() {

--- a/controllers/topolvm_storageclass.go
+++ b/controllers/topolvm_storageclass.go
@@ -24,9 +24,9 @@ import (
 	"github.com/openshift/lvm-operator/pkg/labels"
 
 	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	cutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -76,7 +76,10 @@ func (s topolvmStorageClass) ensureDeleted(r *LVMClusterReconciler, ctx context.
 
 		sc := &storagev1.StorageClass{}
 		if err := r.Client.Get(ctx, types.NamespacedName{Name: scName}, sc); err != nil {
-			return client.IgnoreNotFound(err)
+			if errors.IsNotFound(err) {
+				continue
+			}
+			return err
 		}
 
 		if !sc.GetDeletionTimestamp().IsZero() {


### PR DESCRIPTION
Part of vgmanager refactor. For resourceManagers managing multiple resources, previously the delete aborted if one of the managed resources was not found. Now it properly continues until all resources are no longer found. This applies to LVMVolumeGroup, SCCs, VolumeSnapshotClass and StorageClass