### PR TITLE
chore: codespell exclusion for go.sum

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,8 @@ repos:
           "afterall",
           "--check-filenames",
           "--check-hidden",
+          "--exclude-file",
+          "go.sum"
         ]
         exclude: ^vendor/
         pass_filenames: true


### PR DESCRIPTION
Adds a codespell exclusion for go.sum as spelling mistakes are false positives in this file