### PR TITLE
OCPBUGS-18354: fix: remove volumesnapshotclass from default resource deletion list

### DIFF
--- a/controllers/lvmcluster_controller.go
+++ b/controllers/lvmcluster_controller.go
@@ -382,7 +382,6 @@ func (r *LVMClusterReconciler) logicalVolumesExist(ctx context.Context) (bool, e
 func (r *LVMClusterReconciler) processDelete(ctx context.Context, instance *lvmv1alpha1.LVMCluster) error {
 	if controllerutil.ContainsFinalizer(instance, lvmClusterFinalizer) {
 		resourceDeletionList := []resourceManager{
-			&topolvmVolumeSnapshotClass{},
 			&topolvmStorageClass{},
 			&lvmVG{},
 			&topolvmController{},


### PR DESCRIPTION
This removes an accidentally leftover part in the default resources that should have been replaced with a conditional removal in https://github.com/openshift/lvm-operator/pull/422/files#diff-2149d6865f2c29cbc9e17358f35e710ddf91b49d334e66a3211b432dea0ba747L398-L400
instead.