### PR TITLE
OCPBUGS-18708: fix: disallow creation of LVMCluster outside of operator namespace and restrict cache

### DIFF
--- a/api/v1alpha1/lvmcluster_test.go
+++ b/api/v1alpha1/lvmcluster_test.go
@@ -1,0 +1,137 @@
+package v1alpha1
+
+import (
+	"errors"
+	"fmt"
+	"hash/fnv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/lvm-operator/pkg/cluster"
+
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func generateUniqueNameForTestCase(ctx SpecContext) string {
+	GinkgoHelper()
+	hash := fnv.New32()
+	_, err := hash.Write([]byte(ctx.SpecReport().LeafNodeText))
+	Expect(err).ToNot(HaveOccurred())
+	name := fmt.Sprintf("test-%v", hash.Sum32())
+	By(fmt.Sprintf("Test Case %q mapped to Unique Name %q", ctx.SpecReport().LeafNodeText, name))
+	return name
+}
+
+var _ = Describe("webhook acceptance tests", func() {
+	defaultClusterTemplate := &LVMCluster{
+		Spec: LVMClusterSpec{
+			Storage: Storage{
+				DeviceClasses: []DeviceClass{{
+					Name: "test-device-class",
+					ThinPoolConfig: &ThinPoolConfig{
+						Name:               "thin-pool-1",
+						SizePercent:        90,
+						OverprovisionRatio: 10,
+					},
+					Default:        true,
+					FilesystemType: "xfs",
+				}},
+			},
+		},
+	}
+
+	It("minimum viable configuration", func(ctx SpecContext) {
+		generatedName := generateUniqueNameForTestCase(ctx)
+		GinkgoT().Setenv(cluster.OperatorNamespaceEnvVar, generatedName)
+		namespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: generatedName}}
+		Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(k8sClient.Delete(ctx, namespace)).To(Succeed())
+		})
+
+		resource := defaultClusterTemplate.DeepCopy()
+		resource.SetName(generatedName)
+		resource.SetNamespace(namespace.GetName())
+
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+	})
+
+	It("duplicate LVMClusters get rejected", func(ctx SpecContext) {
+		generatedName := generateUniqueNameForTestCase(ctx)
+		GinkgoT().Setenv(cluster.OperatorNamespaceEnvVar, generatedName)
+		namespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: generatedName}}
+		Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(k8sClient.Delete(ctx, namespace)).To(Succeed())
+		})
+
+		resource := defaultClusterTemplate.DeepCopy()
+		resource.SetName(generatedName)
+		resource.SetNamespace(namespace.GetName())
+
+		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+
+		duplicate := resource.DeepCopy()
+		duplicate.SetName(fmt.Sprintf("%s-dupe", duplicate.GetName()))
+
+		err := k8sClient.Create(ctx, duplicate)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(Satisfy(k8serrors.IsForbidden))
+
+		statusError := &k8serrors.StatusError{}
+		Expect(errors.As(err, &statusError)).To(BeTrue())
+		Expect(statusError.Status().Message).To(ContainSubstring(ErrDuplicateLVMCluster.Error()))
+
+		Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+	})
+
+	It("namespace cannot be looked up via ENV", func(ctx SpecContext) {
+		generatedName := generateUniqueNameForTestCase(ctx)
+		inacceptableNamespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: generatedName}}
+		Expect(k8sClient.Create(ctx, inacceptableNamespace)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(k8sClient.Delete(ctx, inacceptableNamespace)).To(Succeed())
+		})
+
+		resource := defaultClusterTemplate.DeepCopy()
+		resource.SetName(generatedName)
+		resource.SetNamespace(inacceptableNamespace.GetName())
+
+		err := k8sClient.Create(ctx, resource)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(Satisfy(k8serrors.IsForbidden))
+
+		statusError := &k8serrors.StatusError{}
+		Expect(errors.As(err, &statusError)).To(BeTrue())
+		Expect(statusError.Status().Message).To(ContainSubstring(
+			fmt.Sprintf("%s not found", cluster.OperatorNamespaceEnvVar)))
+	})
+
+	It("invalid namespace gets rejected", func(ctx SpecContext) {
+		acceptableNamespace := "openshift-storage"
+		GinkgoT().Setenv(cluster.OperatorNamespaceEnvVar, acceptableNamespace)
+		generatedName := generateUniqueNameForTestCase(ctx)
+		inacceptableNamespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: generatedName}}
+		Expect(k8sClient.Create(ctx, inacceptableNamespace)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(k8sClient.Delete(ctx, inacceptableNamespace)).To(Succeed())
+		})
+
+		resource := defaultClusterTemplate.DeepCopy()
+		resource.SetName(generatedName)
+		resource.SetNamespace(inacceptableNamespace.GetName())
+
+		err := k8sClient.Create(ctx, resource)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(Satisfy(k8serrors.IsForbidden))
+
+		statusError := &k8serrors.StatusError{}
+		Expect(errors.As(err, &statusError)).To(BeTrue())
+		Expect(statusError.Status().Message).To(ContainSubstring(ErrInvalidNamespace.Error()))
+	})
+
+})

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -27,12 +27,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	//+kubebuilder:scaffold:imports
-	"k8s.io/apimachinery/pkg/runtime"
+
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -75,23 +75,22 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	scheme := runtime.NewScheme()
-	err = AddToScheme(scheme)
+	err = AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = admissionv1beta1.AddToScheme(scheme)
+	err = admissionv1beta1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
 	// start webhook server using Manager
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme,
+		Scheme: scheme.Scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: "0",
 		},

--- a/pkg/cluster/namespace.go
+++ b/pkg/cluster/namespace.go
@@ -1,0 +1,20 @@
+package cluster
+
+import (
+	"fmt"
+	"os"
+)
+
+const OperatorNamespaceEnvVar = "POD_NAMESPACE"
+
+// GetOperatorNamespace returns the Namespace the operator should be watching for changes
+func GetOperatorNamespace() (string, error) {
+	// The env variable POD_NAMESPACE which specifies the Namespace the pod is running in
+	// and hence will watch.
+
+	ns, found := os.LookupEnv(OperatorNamespaceEnvVar)
+	if !found {
+		return "", fmt.Errorf("%s not found", OperatorNamespaceEnvVar)
+	}
+	return ns, nil
+}


### PR DESCRIPTION
Introduces 2 new Limitations and tests for them in the Creation of LVMClusters:

1. LVMCluster Duplicates in one namespace are not allowed
2. LVMCluster can only be created in the Namespace of the Operator introspected by `POD_NAMESPACE`

This leads to us only being allowed exactly one LVMCluster in the Namespace of the operator