### PR TITLE
OCPVE-707: chore: unify build binaries and optimize dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,10 +179,7 @@ ARCH ?= amd64
 all: build
 
 build: generate fmt vet ## Build manager binary.
-	GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/manager main.go
-
-build-vgmanager: generate fmt vet ## Build vg manager binary.
-	GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/vgmanager cmd/vgmanager/main.go
+	GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/lvms cmd/main.go
 
 build-prometheus-alert-rules: jsonnet monitoring/mixin.libsonnet monitoring/alerts/alerts.jsonnet monitoring/alerts/*.libsonnet
 	$(JSONNET) -S monitoring/alerts/alerts.jsonnet > config/prometheus/prometheus_rules.yaml

--- a/bundle/manifests/lvms-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvms-operator.clusterserviceversion.yaml
@@ -593,7 +593,8 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 command:
-                - /manager
+                - /lvms
+                - operator
                 env:
                 - name: TOPOLVM_CSI_IMAGE
                   value: quay.io/lvms_dev/topolvm:latest

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"flag"
+	"os"
+
+	"github.com/go-logr/logr"
+	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
+	configv1 "github.com/openshift/api/config/v1"
+	secv1 "github.com/openshift/api/security/v1"
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
+	"github.com/openshift/lvm-operator/cmd/operator"
+	"github.com/openshift/lvm-operator/cmd/vgmanager"
+	"github.com/spf13/cobra"
+	topolvmv1 "github.com/topolvm/topolvm/api/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func main() {
+	logr := ctrl.Log.WithName("setup")
+	if err := NewCmd(logr).Execute(); err != nil {
+		logr.Error(err, "fatal error encountered")
+		os.Exit(1)
+	}
+}
+
+// NewCmd creates a new CLI command
+func NewCmd(setupLog logr.Logger) *cobra.Command {
+	scheme := runtime.NewScheme()
+
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(lvmv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(topolvmv1.AddToScheme(scheme))
+	utilruntime.Must(snapapi.AddToScheme(scheme))
+	utilruntime.Must(secv1.Install(scheme))
+	utilruntime.Must(configv1.Install(scheme))
+
+	cmd := &cobra.Command{
+		Use:           "lvms",
+		Short:         "Commands for running LVMS",
+		Long:          `Contains commands that control various components reconciling of the main cluster resources within LVMS`,
+		SilenceErrors: false,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+
+	zapOpts := zap.Options{}
+	zapFlagSet := flag.NewFlagSet("zap", flag.ExitOnError)
+	zapOpts.BindFlags(zapFlagSet)
+	cmd.PersistentFlags().AddGoFlagSet(zapFlagSet)
+	zapLogger := zap.New(zap.UseFlagOptions(&zapOpts))
+	ctrl.SetLogger(zapLogger)
+	klog.SetLogger(zapLogger)
+
+	cmd.AddCommand(
+		operator.NewCmd(&operator.Options{
+			Scheme:   scheme,
+			SetupLog: setupLog,
+		}),
+		vgmanager.NewCmd(&vgmanager.Options{
+			Scheme:   scheme,
+			SetupLog: setupLog,
+		}),
+	)
+
+	return cmd
+}

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,7 +39,8 @@ spec:
         runAsNonRoot: true
       containers:
       - command:
-        - /manager
+        - /lvms
+        - operator
         args:
         - --leader-elect
         image: controller:latest

--- a/controllers/vgmanager_daemonset.go
+++ b/controllers/vgmanager_daemonset.go
@@ -122,7 +122,7 @@ func newVGManagerDaemonset(lvmCluster *lvmv1alpha1.LVMCluster, namespace string,
 	var zero int64 = 0
 
 	command := []string{
-		"/vgmanager",
+		"/lvms", "vgmanager",
 	}
 
 	resourceRequirements := corev1.ResourceRequirements{

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/openshift/library-go v0.0.0-20230915122714-b753831a0dce
 	github.com/operator-framework/api v0.17.7
 	github.com/pkg/errors v0.9.1
+	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
 	github.com/topolvm/topolvm v0.21.0
 	go.uber.org/zap v1.26.0
@@ -75,7 +76,6 @@ require (
 	github.com/sirupsen/logrus v1.9.2 // indirect
 	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
-	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.10.1 // indirect


### PR DESCRIPTION
This uses cobra to unify the vgmanager and lvm operator binaries under a single binary so we only have to run go build once (speeds up compile time x2), and also optimizes the dockerfile to reuse the vendor directory instead of calling `go mod download` every time, further speeding up builds by about 10-20s (depending on how long downloading takes, much faster for slower connections). Also moves all binaries under `cmd` and removes top level `main.go`