### PR TITLE
OCPVE-346: fix: remove build cache mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,7 @@ COPY cmd/ cmd/
 COPY internal/ internal/
 
 # Build
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=$TARGETOS GOARCH=$TARGETARCH go build -mod=vendor --ldflags "-s -w" -a -o lvms cmd/main.go
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -mod=vendor --ldflags "-s -w" -a -o lvms cmd/main.go
 
 # vgmanager needs 'nsenter' and other basic linux utils to correctly function
 FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:9.2


### PR DESCRIPTION
removes a wrongly introduced mount for the docker build cache that was committed by accident