### PR TITLE
OCPVE-343: feat: allow passthrough for log flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/operator-framework/api v0.17.7
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.7.0
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
 	github.com/topolvm/topolvm v0.21.0
 	go.uber.org/zap v1.26.0
@@ -89,7 +90,6 @@ require (
 	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.10.1 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/internal/controllers/lvmcluster/logpassthrough/options.go
+++ b/internal/controllers/lvmcluster/logpassthrough/options.go
@@ -1,0 +1,172 @@
+package logpassthrough
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+type Bindable interface {
+	// BindFlags binds all values against a given flag-set.
+	BindFlags(fs *pflag.FlagSet)
+}
+
+type ArgPassable interface {
+	// AsArgs outputs all fields that can be passed to a commandline.
+	AsArgs() []string
+}
+
+// Options represents all pass-through options for logging verbosity
+type Options struct {
+	CSISideCar        *CSISideCarOptions
+	TopoLVMController *TopoLVMControllerOptions
+	TopoLVMNode       *TopoLVMNodeOptions
+	VGManager         *VGmanagerOptions
+	LVMD              *LVMDOptions
+}
+
+// NewOptions creates a new option set and binds it's values against a given flagset.
+func NewOptions() *Options {
+	opts := &Options{
+		CSISideCar:        &CSISideCarOptions{},
+		TopoLVMController: &TopoLVMControllerOptions{},
+		TopoLVMNode:       &TopoLVMNodeOptions{},
+		VGManager:         &VGmanagerOptions{},
+		LVMD:              &LVMDOptions{},
+	}
+	return opts
+}
+
+func (o *Options) BindFlags(fs *pflag.FlagSet) {
+	o.CSISideCar.BindFlags(fs)
+	o.TopoLVMController.BindFlags(fs)
+	o.TopoLVMNode.BindFlags(fs)
+	o.VGManager.BindFlags(fs)
+	o.LVMD.BindFlags(fs)
+}
+
+// ZapOptions contains a list of all passed options from zap-logging
+type ZapOptions struct {
+	// ZapLogLevel is the Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
+	ZapLogLevel string
+}
+
+func (o *ZapOptions) AsArgs() []string {
+	var args []string
+	if len(o.ZapLogLevel) > 0 {
+		args = append(args, fmt.Sprintf("--%s=%s", "zap-log-level", o.ZapLogLevel))
+	}
+	return args
+}
+
+func (o *ZapOptions) BindFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.ZapLogLevel, "zap-log-level", "",
+		"Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', "+
+			"or any integer value > 0 which corresponds to custom debug levels of increasing verbosity")
+}
+
+// KlogOptions contains a list of all passed options from the klog library
+type KlogOptions struct {
+	// V is number for the log level verbosity
+	V string
+	// VModule is comma-separated list of pattern=N settings for file-filtered logging
+	VModule string
+}
+
+func (o *KlogOptions) AsArgs() []string {
+	var args []string
+	if len(o.V) > 0 {
+		args = append(args, fmt.Sprintf("--%s=%s", "v", o.V))
+	}
+	if len(o.VModule) > 0 {
+		args = append(args, fmt.Sprintf("--%s=%s", "vmodule", o.VModule))
+	}
+	return args
+}
+
+func (o *KlogOptions) BindFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.V, "v", "", "number for the log level verbosity")
+	fs.StringVar(&o.VModule, "vmodule", "", "comma-separated list of pattern=N settings for file-filtered logging")
+}
+
+// LVMDOptions contains options that will be passed to the legacy logging library of lvmd
+// see https://github.com/cybozu-go/well/blob/main/log.go#L15 as lvmd uses a legacy log kit
+type LVMDOptions struct {
+	// LogLevel is the LVMD Log level [critical,error,warning,info,debug]
+	LogLevel string
+}
+
+func (o *LVMDOptions) AsArgs() []string {
+	var args []string
+	if len(o.LogLevel) > 0 {
+		args = append(args, fmt.Sprintf("--%s=%s", "loglevel", o.LogLevel))
+	}
+	return args
+}
+
+func (o *LVMDOptions) BindFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.LogLevel, "lvmd-loglevel", "", "Log level [critical,error,warning,info,debug]")
+}
+
+type CSISideCarOptions struct {
+	KlogOptions
+}
+
+func (o *CSISideCarOptions) BindFlags(fs *pflag.FlagSet) {
+	bindFlagsWithPrefix(&o.KlogOptions, fs, "csi-sidecar")
+}
+
+type TopoLVMControllerOptions struct {
+	KlogOptions
+	ZapOptions
+}
+
+func (o *TopoLVMControllerOptions) AsArgs() []string {
+	return append(o.ZapOptions.AsArgs(), o.KlogOptions.AsArgs()...)
+}
+
+func (o *TopoLVMControllerOptions) BindFlags(fs *pflag.FlagSet) {
+	bindFlagsWithPrefix(&o.KlogOptions, fs, "topolvm-controller")
+	bindFlagsWithPrefix(&o.ZapOptions, fs, "topolvm-controller")
+}
+
+type TopoLVMNodeOptions struct {
+	KlogOptions
+	ZapOptions
+}
+
+func (o *TopoLVMNodeOptions) BindFlags(fs *pflag.FlagSet) {
+	bindFlagsWithPrefix(&o.KlogOptions, fs, "topolvm-node")
+	bindFlagsWithPrefix(&o.ZapOptions, fs, "topolvm-node")
+}
+
+func (o *TopoLVMNodeOptions) AsArgs() []string {
+	return append(o.ZapOptions.AsArgs(), o.KlogOptions.AsArgs()...)
+}
+
+type VGmanagerOptions struct {
+	KlogOptions
+	ZapOptions
+}
+
+func (o *VGmanagerOptions) BindFlags(fs *pflag.FlagSet) {
+	bindFlagsWithPrefix(&o.KlogOptions, fs, "vgmanager")
+	bindFlagsWithPrefix(&o.ZapOptions, fs, "vgmanager")
+}
+
+func (o *VGmanagerOptions) AsArgs() []string {
+	return append(o.ZapOptions.AsArgs(), o.KlogOptions.AsArgs()...)
+}
+
+// bindFlagsWithPrefix takes a given bindable and binds it to the flagset by
+// 1. appending a prefix to the name of the argument to avoid collisions
+// 2. appending a prefix to the usage description to identify it in the help documentation
+func bindFlagsWithPrefix(bindable Bindable, fs *pflag.FlagSet, prefix string) {
+	temp := pflag.NewFlagSet(prefix, pflag.ExitOnError)
+	bindable.BindFlags(temp)
+	temp.VisitAll(func(f *pflag.Flag) {
+		f.Name = fmt.Sprintf("%s-%s", prefix, f.Name)
+		f.Usage = fmt.Sprintf("%s: %s", prefix, f.Usage)
+	})
+	fs.AddFlagSet(temp)
+}

--- a/internal/controllers/lvmcluster/logpassthrough/options_test.go
+++ b/internal/controllers/lvmcluster/logpassthrough/options_test.go
@@ -1,0 +1,75 @@
+package logpassthrough
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCSISideCarOptions_BindFlags(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string
+		assertOnOptions func(a *assert.Assertions, o *Options)
+	}{
+		{
+			"pass-all",
+			[]string{
+				"--csi-sidecar-v=1",
+				"--csi-sidecar-vmodule=bla=1",
+				"--topolvm-controller-v=2",
+				"--topolvm-controller-vmodule=bla=2",
+				"--topolvm-controller-zap-log-level=debug",
+				"--topolvm-node-v=3",
+				"--topolvm-node-vmodule=bla=3",
+				"--topolvm-node-zap-log-level=debug",
+				"--vgmanager-v=4",
+				"--vgmanager-vmodule=bla=4",
+				"--vgmanager-zap-log-level=debug",
+				"--lvmd-loglevel=debug",
+			},
+			func(a *assert.Assertions, o *Options) {
+				a.Equal(o.CSISideCar.VModule, "bla=1")
+				a.Equal(o.CSISideCar.V, "1")
+				a.Contains(o.CSISideCar.AsArgs(), "--v=1")
+				a.Contains(o.CSISideCar.AsArgs(), "--vmodule=bla=1")
+
+				a.Equal(o.TopoLVMController.VModule, "bla=2")
+				a.Equal(o.TopoLVMController.V, "2")
+				a.Equal(o.TopoLVMController.ZapLogLevel, "debug")
+				a.Contains(o.TopoLVMController.AsArgs(), "--v=2")
+				a.Contains(o.TopoLVMController.AsArgs(), "--vmodule=bla=2")
+				a.Contains(o.TopoLVMController.AsArgs(), "--zap-log-level=debug")
+
+				a.Equal(o.TopoLVMNode.VModule, "bla=3")
+				a.Equal(o.TopoLVMNode.V, "3")
+				a.Equal(o.TopoLVMNode.ZapLogLevel, "debug")
+				a.Contains(o.TopoLVMNode.AsArgs(), "--v=3")
+				a.Contains(o.TopoLVMNode.AsArgs(), "--vmodule=bla=3")
+				a.Contains(o.TopoLVMNode.AsArgs(), "--zap-log-level=debug")
+
+				a.Equal(o.VGManager.VModule, "bla=4")
+				a.Equal(o.VGManager.V, "4")
+				a.Equal(o.VGManager.ZapLogLevel, "debug")
+				a.Contains(o.VGManager.AsArgs(), "--v=4")
+				a.Contains(o.VGManager.AsArgs(), "--vmodule=bla=4")
+				a.Contains(o.TopoLVMNode.AsArgs(), "--zap-log-level=debug")
+
+				a.Equal(o.LVMD.LogLevel, "debug")
+				a.Contains(o.LVMD.AsArgs(), "--loglevel=debug")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+			o := NewOptions()
+			flagSet := pflag.NewFlagSet(tt.name, pflag.ContinueOnError)
+
+			o.BindFlags(flagSet)
+			a.NoError(flagSet.Parse(tt.args))
+			tt.assertOnOptions(a, o)
+		})
+	}
+}

--- a/internal/controllers/lvmcluster/lvmcluster_controller.go
+++ b/internal/controllers/lvmcluster/lvmcluster_controller.go
@@ -27,6 +27,7 @@ import (
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	"github.com/openshift/lvm-operator/internal/cluster"
 	"github.com/openshift/lvm-operator/internal/controllers/constants"
+	"github.com/openshift/lvm-operator/internal/controllers/lvmcluster/logpassthrough"
 	"github.com/openshift/lvm-operator/internal/controllers/lvmcluster/resource"
 
 	topolvmv1 "github.com/topolvm/topolvm/api/v1"
@@ -70,6 +71,9 @@ type LVMClusterReconciler struct {
 	// TopoLVMLeaderElectionPassthrough uses the given leaderElection when initializing TopoLVM to synchronize
 	// leader election configuration
 	TopoLVMLeaderElectionPassthrough configv1.LeaderElection
+
+	// LogPassthroughOptions define multiple settings for passing down log settings to created resources
+	LogPassthroughOptions *logpassthrough.Options
 }
 
 func (r *LVMClusterReconciler) GetNamespace() string {
@@ -94,6 +98,10 @@ func (r *LVMClusterReconciler) GetVGManagerCommand() []string {
 
 func (r *LVMClusterReconciler) GetTopoLVMLeaderElectionPassthrough() configv1.LeaderElection {
 	return r.TopoLVMLeaderElectionPassthrough
+}
+
+func (r *LVMClusterReconciler) GetLogPassthroughOptions() *logpassthrough.Options {
+	return r.LogPassthroughOptions
 }
 
 //+kubebuilder:rbac:groups=lvm.topolvm.io,resources=lvmclusters,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controllers/lvmcluster/resource/manager.go
+++ b/internal/controllers/lvmcluster/resource/manager.go
@@ -5,6 +5,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
+	"github.com/openshift/lvm-operator/internal/controllers/lvmcluster/logpassthrough"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -19,6 +20,9 @@ type Reconciler interface {
 	// GetTopoLVMLeaderElectionPassthrough uses the given leaderElection when initializing TopoLVM to synchronize
 	// leader election configuration
 	GetTopoLVMLeaderElectionPassthrough() configv1.LeaderElection
+
+	// GetLogPassthroughOptions passes log information for resource managers to consume
+	GetLogPassthroughOptions() *logpassthrough.Options
 }
 
 // Manager NOTE: when updating this, please also update docs/design/lvm-operator-manager.md

--- a/internal/controllers/lvmcluster/resource/vgmanager.go
+++ b/internal/controllers/lvmcluster/resource/vgmanager.go
@@ -47,7 +47,13 @@ func (v vgManager) EnsureCreated(r Reconciler, ctx context.Context, lvmCluster *
 	logger := log.FromContext(ctx).WithValues("resourceManager", v.GetName())
 
 	// get desired daemonset spec
-	dsTemplate := newVGManagerDaemonset(lvmCluster, r.GetNamespace(), r.GetImageName(), r.GetVGManagerCommand())
+	dsTemplate := newVGManagerDaemonset(
+		lvmCluster,
+		r.GetNamespace(),
+		r.GetImageName(),
+		r.GetVGManagerCommand(),
+		r.GetLogPassthroughOptions().VGManager.AsArgs(),
+	)
 
 	// create desired daemonset or update mutable fields on existing one
 	ds := &appsv1.DaemonSet{

--- a/internal/controllers/lvmcluster/suite_test.go
+++ b/internal/controllers/lvmcluster/suite_test.go
@@ -26,6 +26,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	secv1 "github.com/openshift/api/security/v1"
 	"github.com/openshift/lvm-operator/internal/cluster"
+	"github.com/openshift/lvm-operator/internal/controllers/lvmcluster/logpassthrough"
 	"github.com/openshift/lvm-operator/internal/controllers/node"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -131,12 +132,13 @@ var _ = BeforeSuite(func() {
 	}
 
 	err = (&LVMClusterReconciler{
-		Client:             k8sManager.GetClient(),
-		EventRecorder:      k8sManager.GetEventRecorderFor("LVMClusterReconciler"),
-		EnableSnapshotting: enableSnapshotting,
-		ClusterType:        clusterType,
-		Namespace:          testLvmClusterNamespace,
-		ImageName:          testImageName,
+		Client:                k8sManager.GetClient(),
+		EventRecorder:         k8sManager.GetEventRecorderFor("LVMClusterReconciler"),
+		EnableSnapshotting:    enableSnapshotting,
+		ClusterType:           clusterType,
+		Namespace:             testLvmClusterNamespace,
+		ImageName:             testImageName,
+		LogPassthroughOptions: logpassthrough.NewOptions(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controllers/lvmcluster/vgmanager_test.go
+++ b/internal/controllers/lvmcluster/vgmanager_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/openshift/lvm-operator/internal/controllers/lvmcluster/logpassthrough"
 	"github.com/openshift/lvm-operator/internal/controllers/lvmcluster/resource"
 	"gotest.tools/v3/assert"
 
@@ -57,8 +58,9 @@ func newFakeLVMClusterReconciler(t *testing.T, objs ...client.Object) *LVMCluste
 	assert.NilError(t, err, "adding snapshot api to scheme")
 
 	return &LVMClusterReconciler{
-		Client:    fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
-		Namespace: "default",
+		Client:                fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+		Namespace:             "default",
+		LogPassthroughOptions: logpassthrough.NewOptions(),
 	}
 }
 


### PR DESCRIPTION
Allows passing through log verbosity settings for `vgmanager`, `topolvm-controller`, `topolvm-node` and `lvmd` and all csi-sidecar containers (resizer, snapshotter, external-provisioner, registrar). The flags are passed generically with a prefix that is attached to them and they will only be passed if they differ from the default value. LVMD supports less than usual flags as it uses a legacy logging library from cybozu.

This is the new help with all flags available in the operator:

```
./bin/lvms operator --help
Operator reconciling LVMCluster LVMVolumeGroup and LVMVolumeGroupNodeStatus

Usage:
  lvms operator [flags]

Flags:
      --csi-sidecar-v string                      csi-sidecar: number for the log level verbosity
      --csi-sidecar-vmodule string                csi-sidecar: comma-separated list of pattern=N settings for file-filtered logging
      --diagnostics-address string                The address the diagnostics endpoint binds to. (default ":8443")
      --health-probe-bind-address string          The address the probe endpoint binds to. (default ":8081")
  -h, --help                                      help for operator
      --leader-elect                              Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.
      --lvmd-loglevel string                      Log level [critical,error,warning,info,debug]
      --topolvm-controller-v string               topolvm-controller: number for the log level verbosity
      --topolvm-controller-vmodule string         topolvm-controller: comma-separated list of pattern=N settings for file-filtered logging
      --topolvm-controller-zap-log-level string   topolvm-controller: Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
      --topolvm-node-v string                     topolvm-node: number for the log level verbosity
      --topolvm-node-vmodule string               topolvm-node: comma-separated list of pattern=N settings for file-filtered logging
      --topolvm-node-zap-log-level string         topolvm-node: Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
      --vgmanager-cmd strings                     The command that should be used to start vgmanager on the node. Useful for debugging purposes but normally not changed. (default [/lvms,vgmanager])
      --vgmanager-v string                        vgmanager: number for the log level verbosity
      --vgmanager-vmodule string                  vgmanager: comma-separated list of pattern=N settings for file-filtered logging
      --vgmanager-zap-log-level string            vgmanager: Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
```