### PR TITLE
OCPVE-603: Add lvms tag to volume groups

### DIFF
--- a/cmd/vgmanager/vgmanager_test.go
+++ b/cmd/vgmanager/vgmanager_test.go
@@ -1,0 +1,183 @@
+package vgmanager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openshift/lvm-operator/api/v1alpha1"
+	"github.com/openshift/lvm-operator/internal/controllers/vgmanager/lvm"
+	lvmmocks "github.com/openshift/lvm-operator/internal/controllers/vgmanager/lvm/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestAddTagToVGs(t *testing.T) {
+	namespace := "test-namespace"
+	nodeName := "test-node"
+	hostnameLabelKey := "kubernetes.io/hostname"
+	vgName := "vgtest1"
+
+	testCases := []struct {
+		name          string
+		clientObjects []client.Object
+		volumeGroups  []lvm.VolumeGroup
+		addTagCount   int
+	}{
+		{
+			name: "there is a matching CR in the same namespace, add a tag",
+			clientObjects: []client.Object{
+				&v1alpha1.LVMVolumeGroup{ObjectMeta: metav1.ObjectMeta{
+					Name:      vgName,
+					Namespace: namespace,
+				}},
+			},
+			volumeGroups: []lvm.VolumeGroup{
+				{
+					Name: vgName,
+				},
+			},
+			addTagCount: 1,
+		},
+		{
+			name: "there are two matching CRs in the same namespace, add tags",
+			clientObjects: []client.Object{
+				&v1alpha1.LVMVolumeGroup{ObjectMeta: metav1.ObjectMeta{
+					Name:      vgName,
+					Namespace: namespace,
+				}},
+				&v1alpha1.LVMVolumeGroup{ObjectMeta: metav1.ObjectMeta{
+					Name:      "vgtest2",
+					Namespace: namespace,
+				}},
+			},
+			volumeGroups: []lvm.VolumeGroup{
+				{
+					Name: vgName,
+				},
+				{
+					Name: "vgtest2",
+				},
+			},
+			addTagCount: 2,
+		},
+		{
+			name:          "there is no matching CR, do not add a tag",
+			clientObjects: []client.Object{},
+			volumeGroups: []lvm.VolumeGroup{
+				{
+					Name: vgName,
+				},
+			},
+			addTagCount: 0,
+		},
+		{
+			name: "there is a matching CR in a different namespace, do not add a tag",
+			clientObjects: []client.Object{
+				&v1alpha1.LVMVolumeGroup{ObjectMeta: metav1.ObjectMeta{
+					Name:      vgName,
+					Namespace: "test-namespace-2",
+				}},
+			},
+			volumeGroups: []lvm.VolumeGroup{
+				{
+					Name: vgName,
+				},
+			},
+			addTagCount: 0,
+		},
+		{
+			name: "there is a matching CR with a matching node selector, add a tag",
+			clientObjects: []client.Object{
+				&v1alpha1.LVMVolumeGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      vgName,
+						Namespace: namespace,
+					},
+					Spec: v1alpha1.LVMVolumeGroupSpec{
+						NodeSelector: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+								{
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										{
+											Key:      hostnameLabelKey,
+											Operator: corev1.NodeSelectorOpIn,
+											Values:   []string{nodeName},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName, Labels: map[string]string{
+					hostnameLabelKey: nodeName,
+				}}},
+			},
+			volumeGroups: []lvm.VolumeGroup{
+				{
+					Name: vgName,
+				},
+			},
+			addTagCount: 1,
+		},
+		{
+			name: "there is a matching CR with a non-matching node selector, do not add a tag",
+			clientObjects: []client.Object{
+				&v1alpha1.LVMVolumeGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      vgName,
+						Namespace: namespace,
+					},
+					Spec: v1alpha1.LVMVolumeGroupSpec{
+						NodeSelector: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+								{
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										{
+											Key:      hostnameLabelKey,
+											Operator: corev1.NodeSelectorOpIn,
+											Values:   []string{"other-node-name"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName, Labels: map[string]string{
+					hostnameLabelKey: nodeName,
+				}}},
+			},
+			volumeGroups: []lvm.VolumeGroup{
+				{
+					Name: vgName,
+				},
+			},
+			addTagCount: 0,
+		},
+	}
+
+	mockLVM := lvmmocks.NewMockLVM(t)
+
+	scheme, err := v1alpha1.SchemeBuilder.Build()
+	assert.NoError(t, err, "creating scheme")
+	err = corev1.AddToScheme(scheme)
+	assert.NoError(t, err, "adding corev1 to scheme")
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.clientObjects...).Build()
+			if tc.addTagCount > 0 {
+				mockLVM.EXPECT().AddTagToVG(mock.Anything).Return(nil).Times(tc.addTagCount)
+			}
+			mockLVM.EXPECT().ListVGs().Return(tc.volumeGroups, nil).Once()
+			err := addTagToVGs(context.Background(), c, mockLVM, nodeName, namespace)
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/internal/controllers/vgmanager/lvm/mocks/mock_lvm.go
+++ b/internal/controllers/vgmanager/lvm/mocks/mock_lvm.go
@@ -20,6 +20,48 @@ func (_m *MockLVM) EXPECT() *MockLVM_Expecter {
 	return &MockLVM_Expecter{mock: &_m.Mock}
 }
 
+// AddTagToVG provides a mock function with given fields: vgName
+func (_m *MockLVM) AddTagToVG(vgName string) error {
+	ret := _m.Called(vgName)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(vgName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockLVM_AddTagToVG_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddTagToVG'
+type MockLVM_AddTagToVG_Call struct {
+	*mock.Call
+}
+
+// AddTagToVG is a helper method to define mock.On call
+//   - vgName string
+func (_e *MockLVM_Expecter) AddTagToVG(vgName interface{}) *MockLVM_AddTagToVG_Call {
+	return &MockLVM_AddTagToVG_Call{Call: _e.mock.On("AddTagToVG", vgName)}
+}
+
+func (_c *MockLVM_AddTagToVG_Call) Run(run func(vgName string)) *MockLVM_AddTagToVG_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockLVM_AddTagToVG_Call) Return(_a0 error) *MockLVM_AddTagToVG_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockLVM_AddTagToVG_Call) RunAndReturn(run func(string) error) *MockLVM_AddTagToVG_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateLV provides a mock function with given fields: lvName, vgName, sizePercent
 func (_m *MockLVM) CreateLV(lvName string, vgName string, sizePercent int) error {
 	ret := _m.Called(lvName, vgName, sizePercent)


### PR DESCRIPTION
This PR adds an `lvms` tag to the volume groups used by LVMS. Also, this implements a temporary logic to add the tag to the existing volume groups, which is useful especially for upgrades.