### PR TITLE
OCPVE-605: Allow recovering from existing volume groups

### DIFF
--- a/internal/controllers/vgmanager/devices.go
+++ b/internal/controllers/vgmanager/devices.go
@@ -109,7 +109,7 @@ func (r *Reconciler) filterDevices(ctx context.Context, devices []lsblk.BlockDev
 		for name, filterFunc := range filters {
 			logger := logger.WithValues("filter.Name", name)
 			if err := filterFunc(device); err != nil {
-				logger.Error(err, "excluded")
+				logger.Info("excluded", "reason", err)
 				filterErrs = append(filterErrs, err)
 			}
 		}


### PR DESCRIPTION
This PR allows LVMS to pick up and use an existing volume group if it has the same name as the reconciled LVMVolumeGroup name. 