### PR TITLE
OCPVE-738: feat: migrate to FBC for catalog in makefile

### DIFF
--- a/catalog.Dockerfile
+++ b/catalog.Dockerfile
@@ -1,0 +1,15 @@
+# The base image is expected to contain
+# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM quay.io/operator-framework/opm:latest
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+# Copy declarative config root into image at /configs and pre-populate serve cache
+ADD catalog /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+# Set DC-specific label for the location of the DC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/catalog/channel.yaml
+++ b/catalog/channel.yaml
@@ -1,0 +1,6 @@
+---
+schema: olm.channel
+package: lvms-operator
+name: alpha
+entries:
+  - name: lvms-operator.v0.0.1

--- a/catalog/lvms-operator/operator.yaml
+++ b/catalog/lvms-operator/operator.yaml
@@ -1,0 +1,148 @@
+---
+image: quay.io/lvms_dev/lvms-operator-bundle:latest
+name: lvms-operator.v0.0.1
+package: lvms-operator
+properties:
+- type: olm.gvk
+  value:
+    group: lvm.topolvm.io
+    kind: LVMCluster
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: lvm.topolvm.io
+    kind: LVMVolumeGroup
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: lvm.topolvm.io
+    kind: LVMVolumeGroupNodeStatus
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: topolvm.io
+    kind: LogicalVolume
+    version: v1
+- type: olm.package
+  value:
+    packageName: lvms-operator
+    version: 0.0.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "lvm.topolvm.io/v1alpha1",
+            "kind": "LVMCluster",
+            "metadata": {
+              "name": "my-lvmcluster"
+            },
+            "spec": {
+              "storage": {
+                "deviceClasses": [
+                  {
+                    "default": true,
+                    "fstype": "xfs",
+                    "name": "vg1",
+                    "thinPoolConfig": {
+                      "name": "thin-pool-1",
+                      "overprovisionRatio": 10,
+                      "sizePercent": 90
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      capabilities: Seamless Upgrades
+      categories: Storage
+      containerImage: quay.io/lvms_dev/lvms-operator:latest
+      description: Logical volume manager storage provides dynamically provisioned
+        local storage for container workloads
+      olm.skipRange: ""
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/initialization-resource: |-
+        {
+            "apiVersion": "lvm.topolvm.io/v1alpha1",
+            "kind": "LVMCluster",
+            "metadata": {
+              "name": "test-lvmcluster"
+            },
+            "spec": {
+              "storage": {
+                "deviceClasses": [
+                  {
+                    "name": "vg1",
+                    "thinPoolConfig": {
+                      "name": "thin-pool-1",
+                      "overprovisionRatio": 10,
+                      "sizePercent": 90
+                    }
+                  }
+                ]
+              }
+            }
+          }
+      operatorframework.io/suggested-namespace: openshift-storage
+      operators.openshift.io/infrastructure-features: '["csi", "disconnected"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.25.3
+      operators.operatorframework.io/internal-objects: '["logicalvolumes.topolvm.io",
+        "lvmvolumegroups.lvm.topolvm.io", "lvmvolumegroupnodestatuses.lvm.topolvm.io"]'
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+      repository: https://github.com/openshift/lvm-operator
+      target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - kind: LogicalVolume
+        name: logicalvolumes.topolvm.io
+        version: v1
+      - description: LVMCluster is the Schema for the lvmclusters API
+        displayName: LVMCluster
+        kind: LVMCluster
+        name: lvmclusters.lvm.topolvm.io
+        version: v1alpha1
+      - kind: LVMVolumeGroupNodeStatus
+        name: lvmvolumegroupnodestatuses.lvm.topolvm.io
+        version: v1alpha1
+      - kind: LVMVolumeGroup
+        name: lvmvolumegroups.lvm.topolvm.io
+        version: v1alpha1
+    description: Logical volume manager storage provides dynamically provisioned local
+      storage.
+    displayName: LVM Storage
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+    keywords:
+    - local storage
+    - operator
+    - LVM
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+    links:
+    - name: Source Repository
+      url: https://github.com/openshift/lvm-operator
+    maintainers:
+    - email: ocs-support@redhat.com
+      name: Red Hat Support
+    maturity: alpha
+    provider:
+      name: Red Hat
+relatedImages:
+- image: quay.io/lvms_dev/lvms-operator-bundle:latest
+  name: ""
+- image: quay.io/lvms_dev/lvms-operator:latest
+  name: ""
+schema: olm.bundle

--- a/catalog/package.yaml
+++ b/catalog/package.yaml
@@ -1,0 +1,4 @@
+---
+schema: olm.package
+name: lvms-operator
+defaultChannel: alpha

--- a/hack/verify-catalog.sh
+++ b/hack/verify-catalog.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+function print_failure {
+    echo "There are unexpected changes to the tree when running 'make catalog-render'. Please"
+    echo "run these commands locally and double-check the Git repository for unexpected changes which may"
+    echo "need to be committed."
+    exit 1
+}
+
+if [ "${OPENSHIFT_CI:-false}" = true ]; then
+    echo "> generating the OLM catalog"
+    make catalog-render
+
+    test -z "$(git status --porcelain | \grep -v '^??')" || print_failure
+    echo "> verified generated catalog"
+fi


### PR DESCRIPTION
Migrates the index based bundling to the File Based Catalog format https://olm.operatorframework.io/docs/reference/file-based-catalogs/#opm-init

Creates a `catalog` directory in the repo that contains the FBC data. Also introduces a new `verify-catalog` script together with adjustments to the makefile to ensure that a catalog can always be built from the bundle image. 

Existing commands `catalog-build` and `catalog-push` are not touched, they simply now use a newer version of OPM and different commands under the hood. behavior is exactly the same as before in terms of use, and the `deploy-with-olm` command works the same as before