### PR TITLE
OCPVE-766: feat: use embed-lvmd instead of container

### DIFF
--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -14,7 +14,6 @@ The following table provides a view of the containers in these components:
 |                      |            | [liveness-probe](https://github.com/kubernetes-csi/livenessprobe#liveness-probe)                    |
 |                      |            | [csi-snapshotter](https://github.com/kubernetes-csi/external-snapshotter#csi-snapshotter)           |
 | TopoLVM Node         | DaemonSet  | [topolvm-node](https://github.com/topolvm/topolvm/blob/main/docs/topolvm-node.md)                   |
-|                      |            | [lvmd](https://github.com/topolvm/topolvm/blob/main/docs/lvmd.md)                                   |
 |                      |            | [csi-registrar](https://github.com/kubernetes-csi/node-driver-registrar#node-driver-registrar)      |
 |                      |            | [liveness-probe](https://github.com/kubernetes-csi/livenessprobe#liveness-probe)                    |
 |                      |            | [kube-rbac-proxy](https://github.com/brancz/kube-rbac-proxy#kube-rbac-proxy)                        |

--- a/docs/design/lvm-operator-manager.md
+++ b/docs/design/lvm-operator-manager.md
@@ -37,7 +37,7 @@ The `topolvmController` reconcile unit is responsible for deploying a single ins
 
 ### Topolvm Node and lvmd
 
-The `topolvmNode` reconcile unit is responsible for deploying and managing the TopoLVM Node plugin and lvmd daemon set. It scales the DaemonSet based on the node selector specified in the devicesClasses field in the `LVMCluster` CR. During initialization, an init container polls for the availability of the lvmd configuration file before starting the `lvmd` and `topolvm-node` containers.
+The `topolvmNode` reconcile unit is responsible for deploying and managing the TopoLVM Node daemon set. It scales the DaemonSet based on the node selector specified in the devicesClasses field in the `LVMCluster` CR. During initialization, an init container polls for the availability of the lvmd configuration file before starting the `topolvm-node` container.
 
 ### TopoLVM Scheduler
 
@@ -57,7 +57,7 @@ The `lvmVG` reconcile unit is responsible for deploying and managing the LVMVolu
 
 ## Openshift Security Context Constraints (SCCs)
 
-The Operator requires elevated permissions to interact with the host's LVM commands, which are executed through `nsenter`. When deployed on an OpenShift cluster, all the necessary Security Context Constraints (SCCs) are created by the `openshiftSccs` reconcile unit. This ensures that the `vg-manager`, `topolvm-node`, and `lvmd` containers have the required permissions to function properly.
+The Operator requires elevated permissions to interact with the host's LVM commands, which are executed through `nsenter`. When deployed on an OpenShift cluster, all the necessary Security Context Constraints (SCCs) are created by the `openshiftSccs` reconcile unit. This ensures that the `vg-manager` and `topolvm-node` containers have the required permissions to function properly.
 
 ## Implementation Notes
 

--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -52,11 +52,8 @@ const (
 	VgManagerCPURequest = "2m"
 
 	// topoLVM Node resource requests
-	TopolvmNodeMemRequest = "25Mi"
-	TopolvmNodeCPURequest = "1m"
-
-	TopolvmdMemRequest = "30Mi"
-	TopolvmdCPURequest = "2m"
+	TopolvmNodeMemRequest = "35Mi"
+	TopolvmNodeCPURequest = "3m"
 
 	CSIRegistrarMemRequest = "15Mi"
 	CSIRegistrarCPURequest = "1m"
@@ -74,9 +71,8 @@ const (
 	NodeContainerName               = "topolvm-node"
 	TopolvmNodeContainerHealthzName = "healthz"
 
-	DefaultCSISocket  = "/run/topolvm/csi-topolvm.sock"
-	DefaultLVMdSocket = "/run/lvmd/lvmd.sock"
-	DeviceClassKey    = "topolvm.io/device-class"
+	DefaultCSISocket = "/run/topolvm/csi-topolvm.sock"
+	DeviceClassKey   = "topolvm.io/device-class"
 
 	// name of the lvm-operator container
 	LVMOperatorContainerName = "manager"

--- a/internal/controllers/lvmcluster/logpassthrough/options.go
+++ b/internal/controllers/lvmcluster/logpassthrough/options.go
@@ -22,7 +22,6 @@ type Options struct {
 	TopoLVMController *TopoLVMControllerOptions
 	TopoLVMNode       *TopoLVMNodeOptions
 	VGManager         *VGmanagerOptions
-	LVMD              *LVMDOptions
 }
 
 // NewOptions creates a new option set and binds it's values against a given flagset.
@@ -32,7 +31,6 @@ func NewOptions() *Options {
 		TopoLVMController: &TopoLVMControllerOptions{},
 		TopoLVMNode:       &TopoLVMNodeOptions{},
 		VGManager:         &VGmanagerOptions{},
-		LVMD:              &LVMDOptions{},
 	}
 	return opts
 }
@@ -42,7 +40,6 @@ func (o *Options) BindFlags(fs *pflag.FlagSet) {
 	o.TopoLVMController.BindFlags(fs)
 	o.TopoLVMNode.BindFlags(fs)
 	o.VGManager.BindFlags(fs)
-	o.LVMD.BindFlags(fs)
 }
 
 // ZapOptions contains a list of all passed options from zap-logging
@@ -87,25 +84,6 @@ func (o *KlogOptions) AsArgs() []string {
 func (o *KlogOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.V, "v", "", "number for the log level verbosity")
 	fs.StringVar(&o.VModule, "vmodule", "", "comma-separated list of pattern=N settings for file-filtered logging")
-}
-
-// LVMDOptions contains options that will be passed to the legacy logging library of lvmd
-// see https://github.com/cybozu-go/well/blob/main/log.go#L15 as lvmd uses a legacy log kit
-type LVMDOptions struct {
-	// LogLevel is the LVMD Log level [critical,error,warning,info,debug]
-	LogLevel string
-}
-
-func (o *LVMDOptions) AsArgs() []string {
-	var args []string
-	if len(o.LogLevel) > 0 {
-		args = append(args, fmt.Sprintf("--%s=%s", "loglevel", o.LogLevel))
-	}
-	return args
-}
-
-func (o *LVMDOptions) BindFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&o.LogLevel, "lvmd-loglevel", "", "Log level [critical,error,warning,info,debug]")
 }
 
 type CSISideCarOptions struct {

--- a/internal/controllers/lvmcluster/logpassthrough/options_test.go
+++ b/internal/controllers/lvmcluster/logpassthrough/options_test.go
@@ -27,7 +27,6 @@ func TestCSISideCarOptions_BindFlags(t *testing.T) {
 				"--vgmanager-v=4",
 				"--vgmanager-vmodule=bla=4",
 				"--vgmanager-zap-log-level=debug",
-				"--lvmd-loglevel=debug",
 			},
 			func(a *assert.Assertions, o *Options) {
 				a.Equal(o.CSISideCar.VModule, "bla=1")
@@ -54,10 +53,7 @@ func TestCSISideCarOptions_BindFlags(t *testing.T) {
 				a.Equal(o.VGManager.ZapLogLevel, "debug")
 				a.Contains(o.VGManager.AsArgs(), "--v=4")
 				a.Contains(o.VGManager.AsArgs(), "--vmodule=bla=4")
-				a.Contains(o.TopoLVMNode.AsArgs(), "--zap-log-level=debug")
-
-				a.Equal(o.LVMD.LogLevel, "debug")
-				a.Contains(o.LVMD.AsArgs(), "--loglevel=debug")
+				a.Contains(o.VGManager.AsArgs(), "--zap-log-level=debug")
 			},
 		},
 	}

--- a/internal/controllers/vgmanager/controller.go
+++ b/internal/controllers/vgmanager/controller.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
-	"github.com/openshift/lvm-operator/internal/controllers/constants"
 	"github.com/openshift/lvm-operator/internal/controllers/vgmanager/dmsetup"
 	"github.com/openshift/lvm-operator/internal/controllers/vgmanager/filter"
 	"github.com/openshift/lvm-operator/internal/controllers/vgmanager/lsblk"
@@ -301,9 +300,7 @@ func (r *Reconciler) applyLVMDConfig(ctx context.Context, volumeGroup *lvmv1alph
 	lvmdConfigWasMissing := false
 	if lvmdConfig == nil {
 		lvmdConfigWasMissing = true
-		lvmdConfig = &lvmd.Config{
-			SocketName: constants.DefaultLVMdSocket,
-		}
+		lvmdConfig = &lvmd.Config{}
 	}
 	existingLvmdConfig := *lvmdConfig
 

--- a/internal/controllers/vgmanager/controller_test.go
+++ b/internal/controllers/vgmanager/controller_test.go
@@ -16,7 +16,6 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	secv1 "github.com/openshift/api/security/v1"
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
-	"github.com/openshift/lvm-operator/internal/controllers/constants"
 	"github.com/openshift/lvm-operator/internal/controllers/vgmanager/filter"
 	"github.com/openshift/lvm-operator/internal/controllers/vgmanager/lsblk"
 	lsblkmocks "github.com/openshift/lvm-operator/internal/controllers/vgmanager/lsblk/mocks"
@@ -306,7 +305,6 @@ func testMockedBlockDeviceOnHost(ctx context.Context) {
 		lvmdConfig, err := instances.LVMD.Load()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(lvmdConfig).ToNot(BeNil())
-		Expect(lvmdConfig.SocketName).To(Equal(constants.DefaultLVMdSocket))
 		Expect(lvmdConfig.DeviceClasses).ToNot(BeNil())
 		Expect(lvmdConfig.DeviceClasses).To(HaveLen(1))
 		Expect(lvmdConfig.DeviceClasses).To(ContainElement(&lvmd.DeviceClass{


### PR DESCRIPTION
uses embed-lvmd as a feature in order to reduce memory footprint and container count