### PR TITLE
OCPBUGS-11486: fix: immediately drop leader election in case of shutdown to quicken restart

### DIFF
--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -173,6 +173,7 @@ func run(cmd *cobra.Command, _ []string, opts *Options) error {
 		HealthProbeBindAddress:              opts.healthProbeAddr,
 		LeaderElectionResourceLockInterface: le.Lock,
 		LeaderElection:                      !leaderElectionConfig.Disable,
+		LeaderElectionReleaseOnCancel:       true,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to start manager: %w", err)


### PR DESCRIPTION
Since we dont have any shutdown logic on LVMS post manager exit, we can safely drop leader election and quicken the restart process.