### PR TITLE
OCPBUGS-11486: fix: use native leader lock implementation

### DIFF
--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -170,10 +170,14 @@ func run(cmd *cobra.Command, _ []string, opts *Options) error {
 				&appsv1.DaemonSet{}:                     {Namespaces: map[string]cache.Config{operatorNamespace: {}}},
 			},
 		},
-		HealthProbeBindAddress:              opts.healthProbeAddr,
-		LeaderElectionResourceLockInterface: le.Lock,
-		LeaderElection:                      !leaderElectionConfig.Disable,
-		LeaderElectionReleaseOnCancel:       true,
+		HealthProbeBindAddress:        opts.healthProbeAddr,
+		RetryPeriod:                   &le.RetryPeriod,
+		LeaseDuration:                 &le.LeaseDuration,
+		RenewDeadline:                 &le.RenewDeadline,
+		LeaderElectionNamespace:       operatorNamespace,
+		LeaderElectionID:              leaderElectionConfig.Name,
+		LeaderElection:                !leaderElectionConfig.Disable,
+		LeaderElectionReleaseOnCancel: true,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to start manager: %w", err)


### PR DESCRIPTION
Turns out that the openshift leader election Lock is not 1:1 compatible to the controller runtime lock interface even though it can be passed. This is because the Lock looses communication to the API server through a context cancel and thus is forced by controller runtime to restart. The new lock configuration this PR provides only uses the correct Lease/Retry/Skew values, but uses the native controller runtime implementation for actually setting up the Lease object and tracking it. That way the restart is prohibited.