### PR TITLE
OCPBUGS-13558: fix: refactor node removal controller

### DIFF
--- a/bundle/manifests/lvms-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvms-operator.clusterserviceversion.yaml
@@ -154,8 +154,6 @@ spec:
           verbs:
           - get
           - list
-          - patch
-          - update
           - watch
         - apiGroups:
           - ""

--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -193,19 +193,9 @@ func run(cmd *cobra.Command, _ []string, opts *Options) error {
 		return fmt.Errorf("unable to create LVMCluster controller: %w", err)
 	}
 
-	if isSNO, err := snoCheck.IsSNO(cmd.Context()); err != nil {
-		return fmt.Errorf("unable to determine if cluster is SNO: %w", err)
-	} else if !isSNO {
-		opts.SetupLog.Info("starting node-removal controller to observe node removal in MultiNode")
-		if err = (&removal.Reconciler{Client: mgr.GetClient()}).SetupWithManager(mgr); err != nil {
-			return fmt.Errorf("unable to create NodeRemovalController controller: %w", err)
-		}
-	}
-
-	if err = mgr.GetFieldIndexer().IndexField(context.Background(), &lvmv1alpha1.LVMVolumeGroupNodeStatus{}, "metadata.name", func(object client.Object) []string {
-		return []string{object.GetName()}
-	}); err != nil {
-		return fmt.Errorf("unable to create name index on LVMVolumeGroupNodeStatus: %w", err)
+	opts.SetupLog.Info("starting node-removal controller")
+	if err = removal.NewReconciler(mgr.GetClient(), operatorNamespace).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create NodeRemovalController controller: %w", err)
 	}
 
 	if err = (&lvmv1alpha1.LVMCluster{}).SetupWebhookWithManager(mgr); err != nil {

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -56,8 +56,6 @@ rules:
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - ""

--- a/internal/controllers/lvmcluster/suite_test.go
+++ b/internal/controllers/lvmcluster/suite_test.go
@@ -142,15 +142,8 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = (&removal.Reconciler{
-		Client: k8sManager.GetClient(),
-	}).SetupWithManager(k8sManager)
+	err = removal.NewReconciler(k8sManager.GetClient(), testLvmClusterNamespace).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
-
-	err = k8sManager.GetFieldIndexer().IndexField(ctx, &lvmv1alpha1.LVMVolumeGroupNodeStatus{}, "metadata.name", func(object client.Object) []string {
-		return []string{object.GetName()}
-	})
-	Expect(err).ToNot(HaveOccurred(), "unable to create name index on LVMVolumeGroupNodeStatus")
 
 	go func() {
 		defer GinkgoRecover()


### PR DESCRIPTION
This refactors the node removal controller to not require a finalizer anymore on the node.

It does this by watching LVMVolumeGroupNodeStatus instead of Node as its base reconciled object. This allows us to drop the Field Indexer for Nodes and also 2 permissions on the Node reconciler. Additionally it should make the deletion much more stable and we now run the reconciler not only on SNO, but on all topologies because even SNO can technically add worker nodes.

Cases:
1. Node and NodeStatus are present - nothing happens
2. Node is present but NodeStatus isn't - removal reconciler ignores the node because its not finding a status to check
3. NodeStatus is present but Node isn't - removal controller fetches the node status on startup and on cache refresh, sees that the node is gone, and triggers a delete for the node status
4. NodeStatus is present and Node is about to get deleted - removal controller gets an event for the Node deletion and immediately reacts by removing the node status