### PR TITLE
OCPVE-760: Save lvmd config to a configmap instead of a file

### DIFF
--- a/bundle/manifests/lvms-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvms-operator.clusterserviceversion.yaml
@@ -853,6 +853,18 @@ spec:
           - create
           - patch
           - update
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         serviceAccountName: vg-manager
     strategy: deployment
   installModes:

--- a/config/rbac/vg_manager_role.yaml
+++ b/config/rbac/vg_manager_role.yaml
@@ -66,3 +66,15 @@ rules:
     - create
     - patch
     - update
+- apiGroups:
+    - ""
+  resources:
+    - configmaps
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch

--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -61,9 +61,6 @@ const (
 	LivenessProbeMemRequest = "15Mi"
 	LivenessProbeCPURequest = "1m"
 
-	FileCheckerMemRequest = "10Mi"
-	FileCheckerCPURequest = "1m"
-
 	// topoLVM Node
 	TopolvmNodeServiceAccount       = "topolvm-node"
 	TopolvmNodeDaemonsetName        = "topolvm-node"
@@ -73,6 +70,10 @@ const (
 
 	DefaultCSISocket = "/run/topolvm/csi-topolvm.sock"
 	DeviceClassKey   = "topolvm.io/device-class"
+
+	LVMDConfigMapName         = "lvmd-config"
+	LVMDDefaultConfigDir      = "/etc/topolvm"
+	LVMDDefaultFileConfigPath = "/etc/topolvm/lvmd.yaml"
 
 	// name of the lvm-operator container
 	LVMOperatorContainerName = "manager"

--- a/internal/controllers/vgmanager/controller.go
+++ b/internal/controllers/vgmanager/controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/lvm-operator/internal/controllers/vgmanager/lvm"
 	"github.com/openshift/lvm-operator/internal/controllers/vgmanager/lvmd"
 	"github.com/openshift/lvm-operator/internal/controllers/vgmanager/wipefs"
+
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,8 +44,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const (
@@ -79,7 +82,36 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&lvmv1alpha1.LVMVolumeGroup{}).
 		Owns(&lvmv1alpha1.LVMVolumeGroupNodeStatus{}, builder.MatchEveryOwner, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(r.getObjsInNamespaceForReconcile)).
 		Complete(r)
+}
+
+// getObjsInNamespaceForReconcile reconciles the object anytime the given object is in the same namespace
+// as the available LVMVolumeGroups.
+func (r *Reconciler) getObjsInNamespaceForReconcile(ctx context.Context, obj client.Object) []reconcile.Request {
+	foundLVMVolumeGroupList := &lvmv1alpha1.LVMVolumeGroupList{}
+	listOps := &client.ListOptions{
+		Namespace: obj.GetNamespace(),
+	}
+
+	if err := r.List(ctx, foundLVMVolumeGroupList, listOps); err != nil {
+		log.FromContext(ctx).Error(err, "getObjsInNamespaceForReconcile: Failed to get LVMVolumeGroup objs")
+		return []reconcile.Request{}
+	}
+	if len(foundLVMVolumeGroupList.Items) < 1 {
+		return []reconcile.Request{}
+	}
+
+	var requests []reconcile.Request
+	for _, lvmVG := range foundLVMVolumeGroupList.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      lvmVG.GetName(),
+				Namespace: lvmVG.GetNamespace(),
+			},
+		})
+	}
+	return requests
 }
 
 type Reconciler struct {
@@ -288,7 +320,7 @@ func (r *Reconciler) applyLVMDConfig(ctx context.Context, volumeGroup *lvmv1alph
 	logger := log.FromContext(ctx).WithValues("VGName", volumeGroup.Name)
 
 	// Read the lvmd config file
-	lvmdConfig, err := r.LVMD.Load()
+	lvmdConfig, err := r.LVMD.Load(ctx)
 	if err != nil {
 		err = fmt.Errorf("failed to read the lvmd config file: %w", err)
 		if _, err := r.setVolumeGroupFailedStatus(ctx, volumeGroup, nil, err); err != nil {
@@ -354,7 +386,7 @@ func (r *Reconciler) updateLVMDConfigAfterReconcile(
 			r.NormalEvent(ctx, volumeGroup, EventReasonLVMDConfigMissing, msg)
 		}
 
-		if err := r.LVMD.Save(newCFG); err != nil {
+		if err := r.LVMD.Save(ctx, newCFG); err != nil {
 			return fmt.Errorf("failed to update lvmd config file to update volume group %s: %w", volumeGroup.GetName(), err)
 		}
 		msg := "updated lvmd config with new deviceClasses"
@@ -369,7 +401,7 @@ func (r *Reconciler) processDelete(ctx context.Context, volumeGroup *lvmv1alpha1
 	logger.Info("deleting")
 
 	// Read the lvmd config file
-	lvmdConfig, err := r.LVMD.Load()
+	lvmdConfig, err := r.LVMD.Load(ctx)
 	if err != nil {
 		// Failed to read lvmdconfig file. Reconcile again
 		return fmt.Errorf("failed to read the lvmd config file: %w", err)
@@ -437,14 +469,14 @@ func (r *Reconciler) processDelete(ctx context.Context, volumeGroup *lvmv1alpha1
 	// if there was no config file in the first place, nothing has to be removed.
 	if lvmdConfig != nil {
 		if len(lvmdConfig.DeviceClasses) > 0 {
-			if err = r.LVMD.Save(lvmdConfig); err != nil {
+			if err = r.LVMD.Save(ctx, lvmdConfig); err != nil {
 				return fmt.Errorf("failed to update lvmd.conf file for volume group %s: %w", volumeGroup.GetName(), err)
 			}
 			msg := "updated lvmd config after deviceClass was removed"
 			logger.Info(msg)
 			r.NormalEvent(ctx, volumeGroup, EventReasonLVMDConfigUpdated, msg)
 		} else {
-			if err = r.LVMD.Delete(); err != nil {
+			if err = r.LVMD.Delete(ctx); err != nil {
 				return fmt.Errorf("failed to delete lvmd.conf file for volume group %s: %w", volumeGroup.GetName(), err)
 			}
 			msg := "removed lvmd config after last deviceClass was removed"

--- a/internal/controllers/vgmanager/controller_test.go
+++ b/internal/controllers/vgmanager/controller_test.go
@@ -24,11 +24,15 @@ import (
 	"github.com/openshift/lvm-operator/internal/controllers/vgmanager/lvmd"
 	lvmdmocks "github.com/openshift/lvm-operator/internal/controllers/vgmanager/lvmd/mocks"
 	wipefsmocks "github.com/openshift/lvm-operator/internal/controllers/vgmanager/wipefs/mocks"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	topolvmv1 "github.com/topolvm/topolvm/api/v1"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -107,7 +111,6 @@ func setupInstances() testInstances {
 	mockLSBLK := lsblkmocks.NewMockLSBLK(t)
 	mockLVM := lvmmocks.NewMockLVM(t)
 	mockWipefs := wipefsmocks.NewMockWipefs(t)
-	testLVMD := lvmd.NewFileConfigurator(filepath.Join(t.TempDir(), "lvmd.yaml"))
 
 	hostname := "test-host.vgmanager.test.io"
 	hostnameLabelKey := "kubernetes.io/hostname"
@@ -122,6 +125,8 @@ func setupInstances() testInstances {
 		Build()
 	fakeRecorder := record.NewFakeRecorder(100)
 	fakeRecorder.IncludeObject = true
+
+	testLVMD := lvmd.NewFileConfigurator(fakeClient, namespace.GetName())
 
 	return testInstances{
 		LVM:       mockLVM,
@@ -302,7 +307,7 @@ func testMockedBlockDeviceOnHost(ctx context.Context) {
 	By("verifying the lvmd config generation", func() {
 		checkDistributedEvent(corev1.EventTypeNormal, "lvmd config file doesn't exist, will attempt to create a fresh config")
 		checkDistributedEvent(corev1.EventTypeNormal, "updated lvmd config with new deviceClasses")
-		lvmdConfig, err := instances.LVMD.Load()
+		lvmdConfig, err := instances.LVMD.Load(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(lvmdConfig).ToNot(BeNil())
 		Expect(lvmdConfig.DeviceClasses).ToNot(BeNil())
@@ -392,7 +397,7 @@ func testMockedBlockDeviceOnHost(ctx context.Context) {
 		_, err := instances.Reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(vg)})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(instances.client.Get(ctx, client.ObjectKeyFromObject(vg), vg)).ToNot(Succeed())
-		lvmdConfig, err := instances.LVMD.Load()
+		lvmdConfig, err := instances.LVMD.Load(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(lvmdConfig).To(BeNil())
 	})
@@ -547,13 +552,13 @@ func testLVMD(ctx context.Context) {
 	mockLVM := lvmmocks.NewMockLVM(GinkgoT())
 	r.LVM = mockLVM
 
-	mockLVMD.EXPECT().Load().Once().Return(nil, fmt.Errorf("mock load failure"))
+	mockLVMD.EXPECT().Load(ctx).Once().Return(nil, fmt.Errorf("mock load failure"))
 	mockLVM.EXPECT().ListVGs().Once().Return(nil, fmt.Errorf("mock list failure"))
 	err := r.applyLVMDConfig(ctx, vg, devices)
 	Expect(err).To(HaveOccurred(), "should error if lvmd config cannot be loaded and/or status cannot be set")
 
-	mockLVMD.EXPECT().Load().Once().Return(&lvmd.Config{}, nil)
-	mockLVMD.EXPECT().Save(mock.Anything).Once().Return(fmt.Errorf("mock save failure"))
+	mockLVMD.EXPECT().Load(ctx).Once().Return(&lvmd.Config{}, nil)
+	mockLVMD.EXPECT().Save(ctx, mock.Anything).Once().Return(fmt.Errorf("mock save failure"))
 	mockLVM.EXPECT().ListVGs().Once().Return(nil, fmt.Errorf("mock list failure"))
 	err = r.applyLVMDConfig(ctx, vg, devices)
 	Expect(err).To(HaveOccurred(), "should error if lvmd config cannot be saved and/or status cannot be set")
@@ -822,4 +827,53 @@ func testReconcileFailure(ctx context.Context) {
 		_, err := instances.Reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(vg)})
 		Expect(err).To(HaveOccurred())
 	})
+}
+
+func TestGetObjsInNamespaceForReconcile(t *testing.T) {
+	tests := []struct {
+		name   string
+		objs   []client.Object
+		list   error
+		expect []reconcile.Request
+	}{
+		{
+			name: "test lvmvolumegroup not fetch error",
+			list: assert.AnError,
+		},
+		{
+			name: "test lvmvolumegroup found in a different namespace",
+			objs: []client.Object{
+				&lvmv1alpha1.LVMVolumeGroup{ObjectMeta: metav1.ObjectMeta{Name: "test-vg", Namespace: "not-test"}},
+			},
+		},
+		{
+			name: "test lvmvolumegroup found in the same namespace",
+			objs: []client.Object{
+				&lvmv1alpha1.LVMVolumeGroup{ObjectMeta: metav1.ObjectMeta{Name: "test-vg", Namespace: "test"}},
+			},
+			expect: []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "test-vg", Namespace: "test"}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			newScheme := runtime.NewScheme()
+			assert.NoError(t, lvmv1alpha1.AddToScheme(newScheme))
+			assert.NoError(t, corev1.AddToScheme(newScheme))
+			clnt := fake.NewClientBuilder().WithObjects(tt.objs...).
+				WithScheme(newScheme).WithInterceptorFuncs(interceptor.Funcs{
+				List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					if tt.list != nil {
+						return tt.list
+					}
+					return client.List(ctx, list, opts...)
+				},
+			}).Build()
+
+			r := &Reconciler{Client: clnt}
+			requests := r.getObjsInNamespaceForReconcile(context.Background(),
+				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test-vg", Namespace: "test"}})
+			assert.ElementsMatch(t, tt.expect, requests)
+		})
+	}
 }

--- a/internal/controllers/vgmanager/lvmd/mocks/mock_configurator.go
+++ b/internal/controllers/vgmanager/lvmd/mocks/mock_configurator.go
@@ -3,6 +3,8 @@
 package lvmd
 
 import (
+	context "context"
+
 	cmd "github.com/topolvm/topolvm/pkg/lvmd/cmd"
 
 	mock "github.com/stretchr/testify/mock"
@@ -21,13 +23,13 @@ func (_m *MockConfigurator) EXPECT() *MockConfigurator_Expecter {
 	return &MockConfigurator_Expecter{mock: &_m.Mock}
 }
 
-// Delete provides a mock function with given fields:
-func (_m *MockConfigurator) Delete() error {
-	ret := _m.Called()
+// Delete provides a mock function with given fields: ctx
+func (_m *MockConfigurator) Delete(ctx context.Context) error {
+	ret := _m.Called(ctx)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -41,13 +43,14 @@ type MockConfigurator_Delete_Call struct {
 }
 
 // Delete is a helper method to define mock.On call
-func (_e *MockConfigurator_Expecter) Delete() *MockConfigurator_Delete_Call {
-	return &MockConfigurator_Delete_Call{Call: _e.mock.On("Delete")}
+//   - ctx context.Context
+func (_e *MockConfigurator_Expecter) Delete(ctx interface{}) *MockConfigurator_Delete_Call {
+	return &MockConfigurator_Delete_Call{Call: _e.mock.On("Delete", ctx)}
 }
 
-func (_c *MockConfigurator_Delete_Call) Run(run func()) *MockConfigurator_Delete_Call {
+func (_c *MockConfigurator_Delete_Call) Run(run func(ctx context.Context)) *MockConfigurator_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -57,30 +60,30 @@ func (_c *MockConfigurator_Delete_Call) Return(_a0 error) *MockConfigurator_Dele
 	return _c
 }
 
-func (_c *MockConfigurator_Delete_Call) RunAndReturn(run func() error) *MockConfigurator_Delete_Call {
+func (_c *MockConfigurator_Delete_Call) RunAndReturn(run func(context.Context) error) *MockConfigurator_Delete_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// Load provides a mock function with given fields:
-func (_m *MockConfigurator) Load() (*cmd.Config, error) {
-	ret := _m.Called()
+// Load provides a mock function with given fields: ctx
+func (_m *MockConfigurator) Load(ctx context.Context) (*cmd.Config, error) {
+	ret := _m.Called(ctx)
 
 	var r0 *cmd.Config
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*cmd.Config, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(context.Context) (*cmd.Config, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func() *cmd.Config); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) *cmd.Config); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*cmd.Config)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -94,13 +97,14 @@ type MockConfigurator_Load_Call struct {
 }
 
 // Load is a helper method to define mock.On call
-func (_e *MockConfigurator_Expecter) Load() *MockConfigurator_Load_Call {
-	return &MockConfigurator_Load_Call{Call: _e.mock.On("Load")}
+//   - ctx context.Context
+func (_e *MockConfigurator_Expecter) Load(ctx interface{}) *MockConfigurator_Load_Call {
+	return &MockConfigurator_Load_Call{Call: _e.mock.On("Load", ctx)}
 }
 
-func (_c *MockConfigurator_Load_Call) Run(run func()) *MockConfigurator_Load_Call {
+func (_c *MockConfigurator_Load_Call) Run(run func(ctx context.Context)) *MockConfigurator_Load_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -110,18 +114,18 @@ func (_c *MockConfigurator_Load_Call) Return(_a0 *cmd.Config, _a1 error) *MockCo
 	return _c
 }
 
-func (_c *MockConfigurator_Load_Call) RunAndReturn(run func() (*cmd.Config, error)) *MockConfigurator_Load_Call {
+func (_c *MockConfigurator_Load_Call) RunAndReturn(run func(context.Context) (*cmd.Config, error)) *MockConfigurator_Load_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// Save provides a mock function with given fields: config
-func (_m *MockConfigurator) Save(config *cmd.Config) error {
-	ret := _m.Called(config)
+// Save provides a mock function with given fields: ctx, config
+func (_m *MockConfigurator) Save(ctx context.Context, config *cmd.Config) error {
+	ret := _m.Called(ctx, config)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*cmd.Config) error); ok {
-		r0 = rf(config)
+	if rf, ok := ret.Get(0).(func(context.Context, *cmd.Config) error); ok {
+		r0 = rf(ctx, config)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -135,14 +139,15 @@ type MockConfigurator_Save_Call struct {
 }
 
 // Save is a helper method to define mock.On call
+//   - ctx context.Context
 //   - config *cmd.Config
-func (_e *MockConfigurator_Expecter) Save(config interface{}) *MockConfigurator_Save_Call {
-	return &MockConfigurator_Save_Call{Call: _e.mock.On("Save", config)}
+func (_e *MockConfigurator_Expecter) Save(ctx interface{}, config interface{}) *MockConfigurator_Save_Call {
+	return &MockConfigurator_Save_Call{Call: _e.mock.On("Save", ctx, config)}
 }
 
-func (_c *MockConfigurator_Save_Call) Run(run func(config *cmd.Config)) *MockConfigurator_Save_Call {
+func (_c *MockConfigurator_Save_Call) Run(run func(ctx context.Context, config *cmd.Config)) *MockConfigurator_Save_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*cmd.Config))
+		run(args[0].(context.Context), args[1].(*cmd.Config))
 	})
 	return _c
 }
@@ -152,7 +157,7 @@ func (_c *MockConfigurator_Save_Call) Return(_a0 error) *MockConfigurator_Save_C
 	return _c
 }
 
-func (_c *MockConfigurator_Save_Call) RunAndReturn(run func(*cmd.Config) error) *MockConfigurator_Save_Call {
+func (_c *MockConfigurator_Save_Call) RunAndReturn(run func(context.Context, *cmd.Config) error) *MockConfigurator_Save_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
This PR changes the way how VG Manager supplies lvmd config to TopoLVM Node. The config file was saved as a file on the host before. Now, VG Manager creates a ConfigMap that is mounted to TopoLVM Node. This way, TopoLVM does not need the `file-checker` init-container anymore, hence it is deleted. 