### PR TITLE
OCPBUGS-23375: Add priority class name to lvms resources

### DIFF
--- a/bundle/manifests/lvms-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvms-operator.clusterserviceversion.yaml
@@ -672,6 +672,7 @@ spec:
                 - mountPath: /tmp/k8s-metrics-server/serving-certs
                   name: metrics-cert
                   readOnly: true
+              priorityClassName: openshift-user-critical
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: lvms-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -37,6 +37,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+      priorityClassName: openshift-user-critical
       containers:
       - command:
         - /lvms

--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -106,4 +106,7 @@ const (
 	StorageClassPrefix        = "lvms-"
 	VolumeSnapshotClassPrefix = "lvms-"
 	SCCPrefix                 = "lvms-"
+
+	PriorityClassNameUserCritical    = "openshift-user-critical"
+	PriorityClassNameClusterCritical = "system-cluster-critical"
 )

--- a/internal/controllers/lvmcluster/resource/topolvm_controller.go
+++ b/internal/controllers/lvmcluster/resource/topolvm_controller.go
@@ -91,6 +91,8 @@ func (c topolvmController) EnsureCreated(r Reconciler, ctx context.Context, lvmC
 		// labels, volumes, service account etc can remain unchanged
 		existingDeployment.Spec.Template.Spec.Containers = desiredDeployment.Spec.Template.Spec.Containers
 
+		existingDeployment.Spec.Template.Spec.PriorityClassName = desiredDeployment.Spec.Template.Spec.PriorityClassName
+
 		initMapIfNil(&existingDeployment.ObjectMeta.Annotations)
 		for key, value := range desiredDeployment.Annotations {
 			existingDeployment.ObjectMeta.Annotations[key] = value
@@ -161,6 +163,7 @@ func getControllerDeployment(namespace string, enableSnapshots bool, topoLVMLead
 				Spec: corev1.PodSpec{
 					Containers:         containers,
 					ServiceAccountName: constants.TopolvmControllerServiceAccount,
+					PriorityClassName:  constants.PriorityClassNameClusterCritical,
 					Volumes:            volumes,
 				},
 			},

--- a/internal/controllers/lvmcluster/resource/topolvm_node.go
+++ b/internal/controllers/lvmcluster/resource/topolvm_node.go
@@ -89,6 +89,8 @@ func (n topolvmNode) EnsureCreated(r Reconciler, ctx context.Context, lvmCluster
 		// tolerations
 		ds.Spec.Template.Spec.Tolerations = dsTemplate.Spec.Template.Spec.Tolerations
 
+		ds.Spec.Template.Spec.PriorityClassName = dsTemplate.Spec.Template.Spec.PriorityClassName
+
 		// nodeSelector if non-nil
 		if dsTemplate.Spec.Template.Spec.Affinity != nil {
 			setDaemonsetNodeSelector(dsTemplate.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution, ds)
@@ -206,6 +208,7 @@ func getNodeDaemonSet(lvmCluster *lvmv1alpha1.LVMCluster, namespace string, args
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: constants.TopolvmNodeServiceAccount,
+					PriorityClassName:  constants.PriorityClassNameClusterCritical,
 					Containers:         containers,
 					Volumes:            volumes,
 					HostPID:            true,

--- a/internal/controllers/lvmcluster/resource/vgmanager.go
+++ b/internal/controllers/lvmcluster/resource/vgmanager.go
@@ -90,6 +90,7 @@ func (v vgManager) EnsureCreated(r Reconciler, ctx context.Context, lvmCluster *
 		ds.Spec.Template.Spec.Containers = dsTemplate.Spec.Template.Spec.Containers
 		ds.Spec.Template.Spec.Volumes = dsTemplate.Spec.Template.Spec.Volumes
 		ds.Spec.Template.Spec.ServiceAccountName = dsTemplate.Spec.Template.Spec.ServiceAccountName
+		ds.Spec.Template.Spec.PriorityClassName = dsTemplate.Spec.Template.Spec.PriorityClassName
 		ds.Spec.Template.Spec.Tolerations = dsTemplate.Spec.Template.Spec.Tolerations
 
 		if dsTemplate.Spec.Template.Spec.Affinity != nil {

--- a/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
+++ b/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
@@ -218,8 +218,9 @@ func newVGManagerDaemonset(lvmCluster *lvmv1alpha1.LVMCluster, namespace, vgImag
 				},
 
 				Spec: corev1.PodSpec{
-					Volumes:    volumes,
-					Containers: containers,
+					PriorityClassName: constants.PriorityClassNameUserCritical,
+					Volumes:           volumes,
+					Containers:        containers,
 					// to read /proc/1/mountinfo
 					HostPID:            true,
 					Tolerations:        tolerations,


### PR DESCRIPTION
This PR adds priority class names to LVMS resources as per the OpenShift [conventions](https://github.com/openshift/enhancements/blob/6264168ccf099b74cc6258569e3c5e9be481ecd1/CONVENTIONS.md?plain=1#L222-L224).