### PR TITLE
chore: remove topolvm-node from scrape

### DIFF
--- a/bundle/manifests/lvms-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/lvms-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -9,13 +9,6 @@ spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     path: /metrics
-    port: topolvm-metrics
-    scheme: https
-    tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: topolvm-node-metrics.openshift-storage.svc
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    path: /metrics
     port: https
     scheme: https
     tlsConfig:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -11,13 +11,6 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: topolvm-metrics
-      scheme: https
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tlsConfig:
-        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-        serverName: topolvm-node-metrics.openshift-storage.svc
-    - path: /metrics
       port: https
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
Removes the unnecessary scrape of topolvm-node since we no longer need to expose these separately from vgmanager