### PR TITLE
OCPBUGS-27330: fix: avoid topolvm-controller annotation generation increment

### DIFF
--- a/internal/controllers/lvmcluster/resource/topolvm_controller.go
+++ b/internal/controllers/lvmcluster/resource/topolvm_controller.go
@@ -93,11 +93,6 @@ func (c topolvmController) EnsureCreated(r Reconciler, ctx context.Context, lvmC
 
 		existingDeployment.Spec.Template.Spec.PriorityClassName = desiredDeployment.Spec.Template.Spec.PriorityClassName
 
-		initMapIfNil(&existingDeployment.ObjectMeta.Annotations)
-		for key, value := range desiredDeployment.Annotations {
-			existingDeployment.ObjectMeta.Annotations[key] = value
-		}
-
 		initMapIfNil(&existingDeployment.Spec.Template.Annotations)
 		for key, value := range desiredDeployment.Spec.Template.Annotations {
 			existingDeployment.Spec.Template.Annotations[key] = value


### PR DESCRIPTION
Removes the unnecessary annotation patch that also overrode the deployment.kubernetes.io/revision annotation generated by the k8s controller causing additional spec generations