### PR TITLE
NO-JIRA: fix: do not set resource version in lvmcluster test

### DIFF
--- a/api/v1alpha1/lvmcluster_test.go
+++ b/api/v1alpha1/lvmcluster_test.go
@@ -80,6 +80,7 @@ var _ = Describe("webhook acceptance tests", func() {
 
 		duplicate := resource.DeepCopy()
 		duplicate.SetName(fmt.Sprintf("%s-dupe", duplicate.GetName()))
+		duplicate.SetResourceVersion("")
 
 		err := k8sClient.Create(ctx, duplicate)
 		Expect(err).To(HaveOccurred())


### PR DESCRIPTION
Addresses the failure in the recent main run that was coming up during test execution

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-openshift-lvm-operator-main-post-unit-test/1749362544251768832#1:build-log.txt%3A133
