### PR TITLE
[release-4.15] OCPBUGS-28966: fix: more sophisticated tagging migration

### DIFF
--- a/catalog/lvms-operator/operator.yaml
+++ b/catalog/lvms-operator/operator.yaml
@@ -86,13 +86,25 @@ properties:
             }
           }
       operatorframework.io/suggested-namespace: openshift-storage
+      operatorframework.io/suggested-namespace-template: |-
+        {
+          "apiVersion": "v1",
+          "kind": "Namespace",
+          "metadata": {
+            "name": "openshift-storage",
+            "annotations": {
+              "workload.openshift.io/allowed": "management"
+            }
+          }
+        }
       operators.openshift.io/infrastructure-features: '["csi", "disconnected"]'
-      operators.operatorframework.io/builder: operator-sdk-v1.25.3
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.33.0
       operators.operatorframework.io/internal-objects: '["logicalvolumes.topolvm.io",
         "lvmvolumegroups.lvm.topolvm.io", "lvmvolumegroupnodestatuses.lvm.topolvm.io"]'
       operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
       repository: https://github.com/openshift/lvm-operator
-      target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     apiServiceDefinitions: {}
     crdDescriptions:
       owned:

--- a/internal/controllers/vgmanager/controller.go
+++ b/internal/controllers/vgmanager/controller.go
@@ -187,7 +187,7 @@ func (r *Reconciler) reconcile(
 
 	devices := r.filterDevices(ctx, newDevices, r.Filters(volumeGroup, r.LVM, r.LSBLK))
 
-	vgs, err := r.LVM.ListVGs()
+	vgs, err := r.LVM.ListVGs(true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to list volume groups: %w", err)
 	}

--- a/internal/controllers/vgmanager/lvm/lvm_test.go
+++ b/internal/controllers/vgmanager/lvm/lvm_test.go
@@ -260,7 +260,7 @@ func TestHostLVM_ListVGs(t *testing.T) {
 					return "", fmt.Errorf("invalid args %q", args[0])
 				},
 			}
-			vgs, err := NewHostLVM(executor).ListVGs()
+			vgs, err := NewHostLVM(executor).ListVGs(true)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -602,4 +602,16 @@ func TestHostLVM_execute(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_untaggedVGs(t *testing.T) {
+	vgs := []VolumeGroup{
+		{Name: "vg1", Tags: []string{"tag1"}},
+		{Name: "vg2", Tags: []string{lvmsTag}},
+	}
+
+	vgs = untaggedVGs(vgs)
+
+	assert.Len(t, vgs, 1)
+	assert.Equal(t, "vg1", vgs[0].Name)
 }

--- a/internal/controllers/vgmanager/lvm/mocks/mock_lvm.go
+++ b/internal/controllers/vgmanager/lvm/mocks/mock_lvm.go
@@ -640,25 +640,25 @@ func (_c *MockLVM_ListPVs_Call) RunAndReturn(run func(string) ([]lvm.PhysicalVol
 	return _c
 }
 
-// ListVGs provides a mock function with given fields:
-func (_m *MockLVM) ListVGs() ([]lvm.VolumeGroup, error) {
-	ret := _m.Called()
+// ListVGs provides a mock function with given fields: taggedByLVMS
+func (_m *MockLVM) ListVGs(taggedByLVMS bool) ([]lvm.VolumeGroup, error) {
+	ret := _m.Called(taggedByLVMS)
 
 	var r0 []lvm.VolumeGroup
 	var r1 error
-	if rf, ok := ret.Get(0).(func() ([]lvm.VolumeGroup, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(bool) ([]lvm.VolumeGroup, error)); ok {
+		return rf(taggedByLVMS)
 	}
-	if rf, ok := ret.Get(0).(func() []lvm.VolumeGroup); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(bool) []lvm.VolumeGroup); ok {
+		r0 = rf(taggedByLVMS)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]lvm.VolumeGroup)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(bool) error); ok {
+		r1 = rf(taggedByLVMS)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -672,13 +672,14 @@ type MockLVM_ListVGs_Call struct {
 }
 
 // ListVGs is a helper method to define mock.On call
-func (_e *MockLVM_Expecter) ListVGs() *MockLVM_ListVGs_Call {
-	return &MockLVM_ListVGs_Call{Call: _e.mock.On("ListVGs")}
+//   - taggedByLVMS bool
+func (_e *MockLVM_Expecter) ListVGs(taggedByLVMS interface{}) *MockLVM_ListVGs_Call {
+	return &MockLVM_ListVGs_Call{Call: _e.mock.On("ListVGs", taggedByLVMS)}
 }
 
-func (_c *MockLVM_ListVGs_Call) Run(run func()) *MockLVM_ListVGs_Call {
+func (_c *MockLVM_ListVGs_Call) Run(run func(taggedByLVMS bool)) *MockLVM_ListVGs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(bool))
 	})
 	return _c
 }
@@ -688,7 +689,7 @@ func (_c *MockLVM_ListVGs_Call) Return(_a0 []lvm.VolumeGroup, _a1 error) *MockLV
 	return _c
 }
 
-func (_c *MockLVM_ListVGs_Call) RunAndReturn(run func() ([]lvm.VolumeGroup, error)) *MockLVM_ListVGs_Call {
+func (_c *MockLVM_ListVGs_Call) RunAndReturn(run func(bool) ([]lvm.VolumeGroup, error)) *MockLVM_ListVGs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/controllers/vgmanager/status.go
+++ b/internal/controllers/vgmanager/status.go
@@ -164,7 +164,7 @@ func (r *Reconciler) removeVolumeGroupStatus(ctx context.Context, vg *lvmv1alpha
 }
 
 func (r *Reconciler) setDevices(status *lvmv1alpha1.VGStatus, devices *FilteredBlockDevices) (bool, error) {
-	vgs, err := r.LVM.ListVGs()
+	vgs, err := r.LVM.ListVGs(true)
 	if err != nil {
 		return false, fmt.Errorf("failed to list volume groups. %v", err)
 	}

--- a/internal/tagging/tagging.go
+++ b/internal/tagging/tagging.go
@@ -2,6 +2,7 @@ package tagging
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	lvmv1 "github.com/openshift/lvm-operator/api/v1alpha1"
@@ -17,49 +18,88 @@ import (
 func AddTagToVGs(ctx context.Context, c client.Client, lvm lvm.LVM, nodeName string, namespace string) error {
 	logger := log.FromContext(ctx)
 
-	vgs, err := lvm.ListVGs()
+	// now we get all untagged vgs on the node
+	vgs, err := lvm.ListVGs(false)
 	if err != nil {
-		return fmt.Errorf("failed to list volume groups: %w", err)
+		return fmt.Errorf("failed to list volume groups on node "+
+			"to determine if tag migration is necessary: %w", err)
+	} else if len(vgs) == 0 {
+		logger.Info("no untagged volume groups found on the node, skipping migration")
+		return nil
 	}
+	logger.Info("found untagged volume groups on the node", "vgs", vgs)
 
-	lvmVolumeGroupList := &lvmv1.LVMVolumeGroupList{}
-	err = c.List(ctx, lvmVolumeGroupList, &client.ListOptions{Namespace: namespace})
+	potentialVGsInNode, err := vgCandidatesForTagMigration(ctx, c, nodeName, namespace)
 	if err != nil {
-		return fmt.Errorf("failed to list LVMVolumeGroups: %w", err)
+		return fmt.Errorf("failed to get potential volume groups for node during tag migration: %w", err)
+	} else if len(potentialVGsInNode) == 0 {
+		logger.Info("no potential volume groups found for the node, skipping migration")
+		return nil
 	}
+	logger.Info("found existing LVMVolumeGroups candidates for the node", "vgs", potentialVGsInNode)
 
-	// If there is a matching LVMVolumeGroup CR, tag the existing volume group
-	for _, vg := range vgs {
-		tagged := false
-		for _, lvmVolumeGroup := range lvmVolumeGroupList.Items {
-			if vg.Name != lvmVolumeGroup.Name {
+	var tagged []string
+	var taggingErr error
+
+	for _, potentialVG := range potentialVGsInNode {
+		// If there is an existing Volume Group managed by LVMS (through LVMVolumeGroup) that is also present on the node
+		// but is not tagged, we should tag it now.
+		for _, vg := range vgs {
+			if vg.Name != potentialVG {
 				continue
 			}
-			if lvmVolumeGroup.Spec.NodeSelector != nil {
-				node := &corev1.Node{}
-				err = c.Get(ctx, types.NamespacedName{Name: nodeName}, node)
-				if err != nil {
-					return fmt.Errorf("failed to get node %s: %w", nodeName, err)
-				}
-
-				matches, err := corev1helper.MatchNodeSelectorTerms(node, lvmVolumeGroup.Spec.NodeSelector)
-				if err != nil {
-					return fmt.Errorf("failed to match nodeSelector to node labels: %w", err)
-				}
-				if !matches {
-					continue
-				}
-			}
-
+			logger.Info("tagging volume group managed by LVMS", "vg", vg.Name)
 			if err := lvm.AddTagToVG(vg.Name); err != nil {
-				return err
+				taggingErr = errors.Join(taggingErr, fmt.Errorf("failed to tag volume group %s: %w", vg.Name, err))
+				continue
 			}
-			tagged = true
+			tagged = append(tagged, vg.Name)
 		}
-		if !tagged {
-			logger.Info("skipping tagging volume group %s as there is no corresponding LVMVolumeGroup CR", vg.Name)
-		}
+	}
+
+	if len(tagged) > 0 {
+		logger.Info("tagged volume groups", "count", len(tagged), "vgs", tagged)
+	} else {
+		logger.Info("no volume groups were tagged")
+	}
+
+	if taggingErr != nil {
+		return fmt.Errorf("failed to tag at least one volume group: %w", taggingErr)
 	}
 
 	return nil
+}
+
+func vgCandidatesForTagMigration(ctx context.Context, c client.Client, nodeName, namespace string) ([]string, error) {
+	node := &corev1.Node{}
+	if err := c.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
+		return nil, fmt.Errorf("failed to get node %s: %w", nodeName, err)
+	}
+
+	lvmVolumeGroupList := &lvmv1.LVMVolumeGroupList{}
+	if err := c.List(ctx, lvmVolumeGroupList, &client.ListOptions{Namespace: namespace}); err != nil {
+		return nil, fmt.Errorf("failed to list LVMVolumeGroups from cluster: %w", err)
+	}
+
+	// to tag only the volume groups that are not tagged yet and managed by the operator
+	// we need to find the volume groups that should be on the node already (based on the LVMVolumeGroup CRs)
+	// and then reapply the tag to them if they are not tagged yet.
+	// however, even though the CR exists it might not be on the node yet, so its only a candidate for tagging
+	var potentialVGsInNode []string
+	for _, lvmVolumeGroup := range lvmVolumeGroupList.Items {
+		// If the LVMVolumeGroup CR does not have a nodeSelector, the vg is a potential match by default
+		if lvmVolumeGroup.Spec.NodeSelector == nil {
+			potentialVGsInNode = append(potentialVGsInNode, lvmVolumeGroup.GetName())
+			continue
+		}
+		// If the LVMVolumeGroup CR has a nodeSelector, the vg is a potential match if the node labels match the nodeSelector
+		matches, err := corev1helper.MatchNodeSelectorTerms(node, lvmVolumeGroup.Spec.NodeSelector)
+		if err != nil {
+			return nil, fmt.Errorf("failed to match nodeSelector to node labels: %w", err)
+		}
+		if matches {
+			potentialVGsInNode = append(potentialVGsInNode, lvmVolumeGroup.GetName())
+		}
+	}
+	return potentialVGsInNode, nil
 }


### PR DESCRIPTION
This PR solves 2 main issues:

1. The tagging migration used lvs that were already prefiltered by the tag
2. The tagging migration was using inefficient querying and always ran for all lvs, that now changed.

The test cases didnt reach all the paths so we didnt catch that.