### PR TITLE
OCPBUGS-29065: Reconcile topolvm node volumes

### DIFF
--- a/internal/controllers/lvmcluster/resource/topolvm_node.go
+++ b/internal/controllers/lvmcluster/resource/topolvm_node.go
@@ -87,6 +87,9 @@ func (n topolvmNode) EnsureCreated(r Reconciler, ctx context.Context, lvmCluster
 		// containers
 		ds.Spec.Template.Spec.Containers = dsTemplate.Spec.Template.Spec.Containers
 
+		// volumes
+		ds.Spec.Template.Spec.Volumes = dsTemplate.Spec.Template.Spec.Volumes
+
 		// tolerations
 		ds.Spec.Template.Spec.Tolerations = dsTemplate.Spec.Template.Spec.Tolerations
 


### PR DESCRIPTION
This PR fixes the 4.14 to 4.15 upgrade of TopoLVM Node. It currently fails as we introduced a new "metrics-cert" volume for TopoLVM Node in 4.15 and LVMS didn't reconcile the volumes. 