### PR TITLE
OCPBUGS-29188: fix: resolve PV name via Symlink before comparing to KName

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,16 +50,17 @@ repos:
         exclude: ^vendor/
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.55.2
+    rev: v1.56.0
     hooks:
       - id: golangci-lint
         entry: golangci-lint run --fix
         args:
           - "--modules-download-mode=vendor"
-          - "--timeout=10m"
+          - "--timeout=20m"
         types: [go]
         language: golang
         require_serial: true
+        pass_filenames: false
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/internal/controllers/vgmanager/devices.go
+++ b/internal/controllers/vgmanager/devices.go
@@ -206,7 +206,7 @@ func isDeviceAlreadyPartOfVG(nodeStatus *lvmv1alpha1.LVMVolumeGroupNodeStatus, d
 	for _, vgStatus := range nodeStatus.Spec.LVMVGStatus {
 		if vgStatus.Name == volumeGroup.Name {
 			for _, pv := range vgStatus.Devices {
-				if pv == diskName {
+				if resolvedPV, _ := evalSymlinks(pv); resolvedPV == diskName {
 					return true
 				}
 			}

--- a/internal/controllers/vgmanager/filter/filter_test.go
+++ b/internal/controllers/vgmanager/filter/filter_test.go
@@ -188,6 +188,9 @@ func TestOnlyValidFilesystemSignatures(t *testing.T) {
 			lvmExpect: []lvm.PhysicalVolume{{PvName: "dev1", VgName: "vg1"}},
 		},
 	}
+	evalSymlinks = func(path string) (string, error) {
+		return path, nil
+	}
 	for _, tc := range testcases {
 		t.Run(tc.label, func(t *testing.T) {
 			vg := &lvmv1alpha1.LVMVolumeGroup{}


### PR DESCRIPTION
This allows us to properly exclude and filter symlinked devices that would previously be compared via kname without being resolved. Now we compare them symlinked which results in proper filter results

Added precommit timeout and incremented golang ci lint version