### PR TITLE
[release-4.15] OCPBUGS-29351: fix: resolve PV name before comparing to KName

### DIFF
--- a/internal/controllers/vgmanager/devices.go
+++ b/internal/controllers/vgmanager/devices.go
@@ -207,7 +207,7 @@ func isDeviceAlreadyPartOfVG(nodeStatus *lvmv1alpha1.LVMVolumeGroupNodeStatus, d
 	for _, vgStatus := range nodeStatus.Spec.LVMVGStatus {
 		if vgStatus.Name == volumeGroup.Name {
 			for _, pv := range vgStatus.Devices {
-				if pv == diskName {
+				if resolvedPV, _ := evalSymlinks(pv); resolvedPV == diskName {
 					return true
 				}
 			}

--- a/internal/controllers/vgmanager/filter/filter.go
+++ b/internal/controllers/vgmanager/filter/filter.go
@@ -19,6 +19,7 @@ package filter
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
@@ -63,6 +64,9 @@ var (
 		"bios", "boot", "reserved",
 	}
 )
+
+// evalSymlinks redefined to be able to override in tests
+var evalSymlinks = filepath.EvalSymlinks
 
 type Filter func(lsblk.BlockDevice) error
 
@@ -116,7 +120,11 @@ func DefaultFilters(vg *lvmv1alpha1.LVMVolumeGroup, lvmInstance lvm.LVM, lsblkIn
 
 				var foundPV *lvm.PhysicalVolume
 				for _, pv := range pvs {
-					if pv.PvName == dev.KName {
+					resolvedPVPath, err := evalSymlinks(pv.PvName)
+					if err != nil {
+						return fmt.Errorf("the pv %s could not be resolved via symlink: %w", pv, err)
+					}
+					if resolvedPVPath == dev.KName {
 						foundPV = &pv
 						break
 					}

--- a/internal/controllers/vgmanager/filter/filter_test.go
+++ b/internal/controllers/vgmanager/filter/filter_test.go
@@ -212,6 +212,9 @@ func TestOnlyValidFilesystemSignatures(t *testing.T) {
 			},
 		},
 	}
+	evalSymlinks = func(path string) (string, error) {
+		return path, nil
+	}
 	for _, tc := range testcases {
 		t.Run(tc.label, func(t *testing.T) {
 			mockLVM := lvmmocks.NewMockLVM(t)


### PR DESCRIPTION
(cherry picked from commit f20496562d2af700b141f1aca86e9efcc47959dd)