### PR TITLE
[WIP] OCPEDGE-927: Introduce Static discovery of devices that allows immutable storage configurations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ kustomize: ## Download kustomize locally if necessary.
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@bf15e44028f908c790721fc8fe67c7bf2d06a611)
 
 JSONNET = $(shell pwd)/bin/jsonnet
 jsonnet: ## Download jsonnet locally if necessary.

--- a/api/v1alpha1/lvmcluster_types.go
+++ b/api/v1alpha1/lvmcluster_types.go
@@ -79,7 +79,7 @@ type DeviceClass struct {
 
 	// DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
 	// at install time or at runtime (static or dynamic configuration of devices)
-	// If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+	// If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at LVMCluster creation time.
 	// If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
 	// By default, the value is set to RuntimeDynamic.
 	// This field cannot be updated once the LVMCluster is created.

--- a/api/v1alpha1/lvmcluster_types.go
+++ b/api/v1alpha1/lvmcluster_types.go
@@ -61,6 +61,13 @@ const (
 	FilesystemTypeXFS  DeviceFilesystemType = "xfs"
 )
 
+type DeviceDiscoveryPolicy string
+
+const (
+	DeviceDiscoveryPolicyInstallStatic  DeviceDiscoveryPolicy = "InstallStatic"
+	DeviceDiscoveryPolicyRuntimeDynamic DeviceDiscoveryPolicy = "RuntimeDynamic"
+)
+
 type DeviceClass struct {
 	// Name of the class, the VG and possibly the storageclass.
 	// Validations to confirm that this field can be used as metadata.name field in storageclass
@@ -69,6 +76,17 @@ type DeviceClass struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
 	Name string `json:"name,omitempty"`
+
+	// DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
+	// at install time or at runtime (static or dynamic configuration of devices)
+	// If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+	// If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
+	// By default, the value is set to RuntimeDynamic.
+	// This field cannot be updated once the LVMCluster is created.
+	// +kubebuilder:validation:Enum=InstallStatic;RuntimeDynamic
+	// +kubebuilder:default=RuntimeDynamic
+	// +kubebuilder:validation:Required
+	DeviceDiscoveryPolicy DeviceDiscoveryPolicy `json:"deviceDiscoveryPolicy,omitempty"`
 
 	// DeviceSelector is a set of rules that should match for a device to be included in the LVMCluster
 	// +optional

--- a/api/v1alpha1/lvmvolumegroup_types.go
+++ b/api/v1alpha1/lvmvolumegroup_types.go
@@ -27,7 +27,7 @@ import (
 type LVMVolumeGroupSpec struct {
 	// DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
 	// at install time or at runtime (static or dynamic configuration of devices)
-	// If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+	// If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at LVMCluster creation time.
 	// If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
 	// By default, the value is set to RuntimeDynamic.
 	// This field cannot be updated once the LVMCluster is created.

--- a/api/v1alpha1/lvmvolumegroup_types.go
+++ b/api/v1alpha1/lvmvolumegroup_types.go
@@ -25,6 +25,17 @@ import (
 
 // LVMVolumeGroupSpec defines the desired state of LVMVolumeGroup
 type LVMVolumeGroupSpec struct {
+	// DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
+	// at install time or at runtime (static or dynamic configuration of devices)
+	// If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+	// If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
+	// By default, the value is set to RuntimeDynamic.
+	// This field cannot be updated once the LVMCluster is created.
+	// +kubebuilder:validation:Enum=InstallStatic;RuntimeDynamic
+	// +kubebuilder:default=RuntimeDynamic
+	// +kubebuilder:validation:Required
+	DeviceDiscoveryPolicy DeviceDiscoveryPolicy `json:"deviceDiscoveryPolicy,omitempty"`
+
 	// DeviceSelector is a set of rules that should match for a device to be included in this TopoLVMCluster
 	// +optional
 	DeviceSelector *DeviceSelector `json:"deviceSelector,omitempty"`

--- a/api/v1alpha1/lvmvolumegroupnodestatus_types.go
+++ b/api/v1alpha1/lvmvolumegroupnodestatus_types.go
@@ -56,7 +56,7 @@ type VGStatus struct {
 
 	// DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
 	// at install time or at runtime (static or dynamic configuration of devices)
-	// If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+	// If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at LVMCluster creation time.
 	// If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
 	// By default, the value is set to RuntimeDynamic.
 	// This field cannot be updated once the LVMCluster is created.

--- a/api/v1alpha1/lvmvolumegroupnodestatus_types.go
+++ b/api/v1alpha1/lvmvolumegroupnodestatus_types.go
@@ -53,6 +53,17 @@ type VGStatus struct {
 	// Excluded contains the per node status of applied device exclusions that were picked up via selector,
 	// but were not used for other reasons.
 	Excluded []ExcludedDevice `json:"excluded,omitempty"`
+
+	// DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
+	// at install time or at runtime (static or dynamic configuration of devices)
+	// If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+	// If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
+	// By default, the value is set to RuntimeDynamic.
+	// This field cannot be updated once the LVMCluster is created.
+	// +kubebuilder:validation:Enum=InstallStatic;RuntimeDynamic
+	// +kubebuilder:default=RuntimeDynamic
+	// +kubebuilder:validation:Required
+	DeviceDiscoveryPolicy DeviceDiscoveryPolicy `json:"deviceDiscoveryPolicy,omitempty"`
 }
 
 type ExcludedDevice struct {

--- a/bundle/manifests/lvm.topolvm.io_lvmclusters.yaml
+++ b/bundle/manifests/lvm.topolvm.io_lvmclusters.yaml
@@ -57,6 +57,19 @@ spec:
                           description: Default is a flag to indicate whether the device-class
                             is the default
                           type: boolean
+                        deviceDiscoveryPolicy:
+                          default: RuntimeDynamic
+                          description: |-
+                            DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
+                            at install time or at runtime (static or dynamic configuration of devices)
+                            If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+                            If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
+                            By default, the value is set to RuntimeDynamic.
+                            This field cannot be updated once the LVMCluster is created.
+                          enum:
+                          - InstallStatic
+                          - RuntimeDynamic
+                          type: string
                         deviceSelector:
                           description: DeviceSelector is a set of rules that should
                             match for a device to be included in the LVMCluster
@@ -303,6 +316,19 @@ spec:
                         description: NodeStatus defines the observed state of the
                           deviceclass on the node
                         properties:
+                          deviceDiscoveryPolicy:
+                            default: RuntimeDynamic
+                            description: |-
+                              DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
+                              at install time or at runtime (static or dynamic configuration of devices)
+                              If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+                              If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
+                              By default, the value is set to RuntimeDynamic.
+                              This field cannot be updated once the LVMCluster is created.
+                            enum:
+                            - InstallStatic
+                            - RuntimeDynamic
+                            type: string
                           devices:
                             description: Devices is the list of devices used by the
                               volume group

--- a/bundle/manifests/lvm.topolvm.io_lvmclusters.yaml
+++ b/bundle/manifests/lvm.topolvm.io_lvmclusters.yaml
@@ -62,7 +62,7 @@ spec:
                           description: |-
                             DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
                             at install time or at runtime (static or dynamic configuration of devices)
-                            If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+                            If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at LVMCluster creation time.
                             If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
                             By default, the value is set to RuntimeDynamic.
                             This field cannot be updated once the LVMCluster is created.
@@ -321,7 +321,7 @@ spec:
                             description: |-
                               DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
                               at install time or at runtime (static or dynamic configuration of devices)
-                              If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+                              If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at LVMCluster creation time.
                               If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
                               By default, the value is set to RuntimeDynamic.
                               This field cannot be updated once the LVMCluster is created.

--- a/bundle/manifests/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
+++ b/bundle/manifests/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
@@ -50,7 +50,7 @@ spec:
                       description: |-
                         DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
                         at install time or at runtime (static or dynamic configuration of devices)
-                        If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+                        If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at LVMCluster creation time.
                         If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
                         By default, the value is set to RuntimeDynamic.
                         This field cannot be updated once the LVMCluster is created.

--- a/bundle/manifests/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
+++ b/bundle/manifests/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
@@ -45,6 +45,19 @@ spec:
                 description: NodeStatus contains the per node status of the VG
                 items:
                   properties:
+                    deviceDiscoveryPolicy:
+                      default: RuntimeDynamic
+                      description: |-
+                        DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
+                        at install time or at runtime (static or dynamic configuration of devices)
+                        If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+                        If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
+                        By default, the value is set to RuntimeDynamic.
+                        This field cannot be updated once the LVMCluster is created.
+                      enum:
+                      - InstallStatic
+                      - RuntimeDynamic
+                      type: string
                     devices:
                       description: Devices is the list of devices used by the volume
                         group

--- a/bundle/manifests/lvm.topolvm.io_lvmvolumegroups.yaml
+++ b/bundle/manifests/lvm.topolvm.io_lvmvolumegroups.yaml
@@ -48,7 +48,7 @@ spec:
                 description: |-
                   DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
                   at install time or at runtime (static or dynamic configuration of devices)
-                  If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+                  If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at LVMCluster creation time.
                   If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
                   By default, the value is set to RuntimeDynamic.
                   This field cannot be updated once the LVMCluster is created.

--- a/bundle/manifests/lvm.topolvm.io_lvmvolumegroups.yaml
+++ b/bundle/manifests/lvm.topolvm.io_lvmvolumegroups.yaml
@@ -43,6 +43,19 @@ spec:
                 description: Default is a flag to indicate whether the device-class
                   is the default
                 type: boolean
+              deviceDiscoveryPolicy:
+                default: RuntimeDynamic
+                description: |-
+                  DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
+                  at install time or at runtime (static or dynamic configuration of devices)
+                  If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+                  If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
+                  By default, the value is set to RuntimeDynamic.
+                  This field cannot be updated once the LVMCluster is created.
+                enum:
+                - InstallStatic
+                - RuntimeDynamic
+                type: string
               deviceSelector:
                 description: DeviceSelector is a set of rules that should match for
                   a device to be included in this TopoLVMCluster

--- a/bundle/manifests/lvms-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvms-operator.clusterserviceversion.yaml
@@ -15,6 +15,7 @@ metadata:
               "deviceClasses": [
                 {
                   "default": true,
+                  "deviceDiscoveryPolicy": "InstallStatic",
                   "fstype": "xfs",
                   "name": "vg1",
                   "thinPoolConfig": {

--- a/config/crd/bases/lvm.topolvm.io_lvmclusters.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmclusters.yaml
@@ -53,6 +53,19 @@ spec:
                           description: Default is a flag to indicate whether the device-class
                             is the default
                           type: boolean
+                        deviceDiscoveryPolicy:
+                          default: RuntimeDynamic
+                          description: |-
+                            DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
+                            at install time or at runtime (static or dynamic configuration of devices)
+                            If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+                            If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
+                            By default, the value is set to RuntimeDynamic.
+                            This field cannot be updated once the LVMCluster is created.
+                          enum:
+                          - InstallStatic
+                          - RuntimeDynamic
+                          type: string
                         deviceSelector:
                           description: DeviceSelector is a set of rules that should
                             match for a device to be included in the LVMCluster
@@ -299,6 +312,19 @@ spec:
                         description: NodeStatus defines the observed state of the
                           deviceclass on the node
                         properties:
+                          deviceDiscoveryPolicy:
+                            default: RuntimeDynamic
+                            description: |-
+                              DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
+                              at install time or at runtime (static or dynamic configuration of devices)
+                              If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+                              If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
+                              By default, the value is set to RuntimeDynamic.
+                              This field cannot be updated once the LVMCluster is created.
+                            enum:
+                            - InstallStatic
+                            - RuntimeDynamic
+                            type: string
                           devices:
                             description: Devices is the list of devices used by the
                               volume group

--- a/config/crd/bases/lvm.topolvm.io_lvmclusters.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmclusters.yaml
@@ -58,7 +58,7 @@ spec:
                           description: |-
                             DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
                             at install time or at runtime (static or dynamic configuration of devices)
-                            If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+                            If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at LVMCluster creation time.
                             If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
                             By default, the value is set to RuntimeDynamic.
                             This field cannot be updated once the LVMCluster is created.
@@ -317,7 +317,7 @@ spec:
                             description: |-
                               DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
                               at install time or at runtime (static or dynamic configuration of devices)
-                              If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+                              If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at LVMCluster creation time.
                               If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
                               By default, the value is set to RuntimeDynamic.
                               This field cannot be updated once the LVMCluster is created.

--- a/config/crd/bases/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
@@ -50,7 +50,7 @@ spec:
                       description: |-
                         DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
                         at install time or at runtime (static or dynamic configuration of devices)
-                        If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+                        If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at LVMCluster creation time.
                         If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
                         By default, the value is set to RuntimeDynamic.
                         This field cannot be updated once the LVMCluster is created.

--- a/config/crd/bases/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
@@ -45,6 +45,19 @@ spec:
                 description: NodeStatus contains the per node status of the VG
                 items:
                   properties:
+                    deviceDiscoveryPolicy:
+                      default: RuntimeDynamic
+                      description: |-
+                        DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
+                        at install time or at runtime (static or dynamic configuration of devices)
+                        If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+                        If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
+                        By default, the value is set to RuntimeDynamic.
+                        This field cannot be updated once the LVMCluster is created.
+                      enum:
+                      - InstallStatic
+                      - RuntimeDynamic
+                      type: string
                     devices:
                       description: Devices is the list of devices used by the volume
                         group

--- a/config/crd/bases/lvm.topolvm.io_lvmvolumegroups.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmvolumegroups.yaml
@@ -48,7 +48,7 @@ spec:
                 description: |-
                   DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
                   at install time or at runtime (static or dynamic configuration of devices)
-                  If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+                  If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at LVMCluster creation time.
                   If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
                   By default, the value is set to RuntimeDynamic.
                   This field cannot be updated once the LVMCluster is created.

--- a/config/crd/bases/lvm.topolvm.io_lvmvolumegroups.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmvolumegroups.yaml
@@ -43,6 +43,19 @@ spec:
                 description: Default is a flag to indicate whether the device-class
                   is the default
                 type: boolean
+              deviceDiscoveryPolicy:
+                default: RuntimeDynamic
+                description: |-
+                  DeviceDiscoveryPolicy is a flag to indicate whether the device should be discovered
+                  at install time or at runtime (static or dynamic configuration of devices)
+                  If set to DeviceDiscoveryPolicyInstallStatic, the devices will not be added to the VG if they are not present at setup time.
+                  If set to DeviceDiscoveryPolicyRuntimeDynamic, the devices will be added to the VG if they are present at runtime.
+                  By default, the value is set to RuntimeDynamic.
+                  This field cannot be updated once the LVMCluster is created.
+                enum:
+                - InstallStatic
+                - RuntimeDynamic
+                type: string
               deviceSelector:
                 description: DeviceSelector is a set of rules that should match for
                   a device to be included in this TopoLVMCluster

--- a/internal/controllers/lvmcluster/resource/lvm_volumegroup.go
+++ b/internal/controllers/lvmcluster/resource/lvm_volumegroup.go
@@ -138,10 +138,11 @@ func lvmVolumeGroups(namespace string, deviceClasses []lvmv1alpha1.DeviceClass) 
 				Namespace: namespace,
 			},
 			Spec: lvmv1alpha1.LVMVolumeGroupSpec{
-				NodeSelector:   deviceClass.NodeSelector,
-				DeviceSelector: deviceClass.DeviceSelector,
-				ThinPoolConfig: deviceClass.ThinPoolConfig,
-				Default:        len(deviceClasses) == 1 || deviceClass.Default, // True if there is only one device class or default is explicitly set.
+				NodeSelector:          deviceClass.NodeSelector,
+				DeviceSelector:        deviceClass.DeviceSelector,
+				ThinPoolConfig:        deviceClass.ThinPoolConfig,
+				Default:               len(deviceClasses) == 1 || deviceClass.Default, // True if there is only one device class or default is explicitly set.
+				DeviceDiscoveryPolicy: deviceClass.DeviceDiscoveryPolicy,
 			},
 		}
 		lvmVolumeGroups = append(lvmVolumeGroups, lvmVolumeGroup)

--- a/internal/controllers/vgmanager/controller.go
+++ b/internal/controllers/vgmanager/controller.go
@@ -94,7 +94,7 @@ type Reconciler struct {
 	dmsetup.Dmsetup
 	NodeName  string
 	Namespace string
-	Filters   func(*lvmv1alpha1.LVMVolumeGroup) filter.Filters
+	Filters   func(*lvmv1alpha1.LVMVolumeGroup, *lvmv1alpha1.LVMVolumeGroupNodeStatus) filter.Filters
 	Shutdown  context.CancelFunc
 }
 
@@ -198,7 +198,7 @@ func (r *Reconciler) reconcile(
 
 	logger.V(1).Info("block device infos", "bdi", bdi)
 
-	devices := r.filterDevices(ctx, newDevices, pvs, bdi, r.Filters(volumeGroup))
+	devices := r.filterDevices(ctx, newDevices, pvs, bdi, r.Filters(volumeGroup, nodeStatus))
 
 	vgs, err := r.LVM.ListVGs(ctx, true)
 	if err != nil {

--- a/internal/controllers/vgmanager/devices_test.go
+++ b/internal/controllers/vgmanager/devices_test.go
@@ -33,9 +33,7 @@ func Test_getNewDevicesToBeAdded(t *testing.T) {
 
 	r := &Reconciler{}
 
-	filters := filter.DefaultFilters(nil)
-	// remove noBindMounts filter as it reads `proc/1/mountinfo` file.
-	delete(filters, "noBindMounts")
+	filters := filter.DefaultFilters(nil, nil)
 
 	testCases := []struct {
 		description           string

--- a/internal/controllers/vgmanager/devices_test.go
+++ b/internal/controllers/vgmanager/devices_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-logr/logr/testr"
@@ -30,6 +31,13 @@ func Test_getNewDevicesToBeAdded(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+
+	evalSymlinks = func(path string) (string, error) {
+		return path, nil
+	}
+	defer func() {
+		evalSymlinks = filepath.EvalSymlinks
+	}()
 
 	r := &Reconciler{}
 

--- a/internal/controllers/vgmanager/status.go
+++ b/internal/controllers/vgmanager/status.go
@@ -34,8 +34,9 @@ import (
 
 func (r *Reconciler) setVolumeGroupProgressingStatus(ctx context.Context, vg *lvmv1alpha1.LVMVolumeGroup, vgs []lvm.VolumeGroup, devices FilteredBlockDevices) (bool, error) {
 	status := &lvmv1alpha1.VGStatus{
-		Name:   vg.GetName(),
-		Status: lvmv1alpha1.VGStatusProgressing,
+		Name:                  vg.GetName(),
+		Status:                lvmv1alpha1.VGStatusProgressing,
+		DeviceDiscoveryPolicy: vg.Spec.DeviceDiscoveryPolicy,
 	}
 
 	// Set devices for the VGStatus.
@@ -48,8 +49,9 @@ func (r *Reconciler) setVolumeGroupProgressingStatus(ctx context.Context, vg *lv
 
 func (r *Reconciler) setVolumeGroupReadyStatus(ctx context.Context, vg *lvmv1alpha1.LVMVolumeGroup, vgs []lvm.VolumeGroup, devices FilteredBlockDevices) (bool, error) {
 	status := &lvmv1alpha1.VGStatus{
-		Name:   vg.GetName(),
-		Status: lvmv1alpha1.VGStatusReady,
+		Name:                  vg.GetName(),
+		Status:                lvmv1alpha1.VGStatusReady,
+		DeviceDiscoveryPolicy: vg.Spec.DeviceDiscoveryPolicy,
 	}
 
 	// Set devices for the VGStatus.
@@ -62,9 +64,10 @@ func (r *Reconciler) setVolumeGroupReadyStatus(ctx context.Context, vg *lvmv1alp
 
 func (r *Reconciler) setVolumeGroupFailedStatus(ctx context.Context, vg *lvmv1alpha1.LVMVolumeGroup, vgs []lvm.VolumeGroup, devices FilteredBlockDevices, err error) (bool, error) {
 	status := &lvmv1alpha1.VGStatus{
-		Name:   vg.GetName(),
-		Status: lvmv1alpha1.VGStatusFailed,
-		Reason: err.Error(),
+		Name:                  vg.GetName(),
+		Status:                lvmv1alpha1.VGStatusFailed,
+		Reason:                err.Error(),
+		DeviceDiscoveryPolicy: vg.Spec.DeviceDiscoveryPolicy,
 	}
 
 	// Set devices for the VGStatus.


### PR DESCRIPTION
`DeviceDiscoveryPolicy` is a flag to indicate whether the device should be discovered at install time or at runtime (static or dynamic configuration of devices):
- If set to `DeviceDiscoveryPolicyInstallStatic`, the devices will not be added to the VG if they are not present at setup time. 
- If set to `DeviceDiscoveryPolicyRuntimeDynamic`, the devices will be added to the VG if they are present at runtime. By default, the value is set to `RuntimeDynamic`. 
- This field cannot be updated once the LVMCluster is created.

All existing LVMClusters will work in Dynamic Mode and will not be able to be reconfigured to Static Mode. Any new LVMClusters will be able to be changed to Static Mode.

A new LVMCluster with 2 devices (/dev/loop0 available when LVMCluster was created and /dev/loop1 added afterwards) would look like this:

```yaml
apiVersion: lvm.topolvm.io/v1alpha1
kind: LVMCluster
metadata:
  finalizers:
  - lvmcluster.topolvm.io
  generation: 1
  name: my-lvmcluster
  namespace: openshift-storage
spec:
  storage:
    deviceClasses:
    - default: true
      deviceDiscoveryPolicy: InstallStatic
      fstype: xfs
      name: vg1
      thinPoolConfig:
        name: thin-pool-1
        overprovisionRatio: 10
        sizePercent: 90
status:
  deviceClassStatuses:
  - name: vg1
    nodeStatus:
    - deviceDiscoveryPolicy: InstallStatic
      devices:
      - /dev/loop0
      excluded:
      - name: /dev/loop1
        reasons:
        - /dev/loop1 was not part of vg1 at creation (static device discovery enabled)
      - name: /dev/vda
        reasons:
        - /dev/vda has children block devices and could not be considered
        - /dev/vda was not part of vg1 at creation (static device discovery enabled)
      - name: /dev/vda1
        reasons:
        - /dev/vda1 has an invalid partition label "BIOS-BOOT"
        - /dev/vda1 was not part of vg1 at creation (static device discovery enabled)
      - name: /dev/vda2
        reasons:
        - /dev/vda2 has an invalid filesystem signature (vfat) and cannot be used
        - /dev/vda2 was not part of vg1 at creation (static device discovery enabled)
      - name: /dev/vda3
        reasons:
        - /dev/vda3 has an invalid filesystem signature (ext4) and cannot be used
        - /dev/vda3 has an invalid partition label "boot"
        - /dev/vda3 was not part of vg1 at creation (static device discovery enabled)
        reasons:
        - /dev/vda4 has an invalid filesystem signature (xfs) and cannot be used
        - /dev/vda4 was not part of vg1 at creation (static device discovery enabled)
      name: vg1
      node: crc-vlf7c-master-0
      status: Ready
  ready: true
  state: Ready

```



We can later on think about introudcing switching between RuntimeDynamic and InstallStatic (in case we want people to be able to switch between dynamic allocation and "pinning" their configuration) but this has been out of scope for this PR.