### PR TITLE
OCPBUGS-30266: fix: introduce minimum allocation sizes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
-	github.com/topolvm/topolvm v0.27.1-0.20240306010159-8c6c91dc8b7f
+	github.com/topolvm/topolvm v0.28.1-0.20240410004534-b0a2229dc10d
 	go.uber.org/zap v1.27.0
 	google.golang.org/grpc v1.62.1
 	gotest.tools/v3 v3.5.1
@@ -45,7 +45,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
-replace github.com/topolvm/topolvm => github.com/openshift/topolvm v0.15.3-0.20240321104545-ab31b05c1b85
+replace github.com/topolvm/topolvm => github.com/openshift/topolvm v0.15.3-0.20240410085813-a5c797a83619
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/openshift/client-go v0.0.0-20240312121557-60dd5f9fbf8d h1:vdrC3QYkFcs
 github.com/openshift/client-go v0.0.0-20240312121557-60dd5f9fbf8d/go.mod h1:Y5Hp789dTrF6Fq8cA5YQlpwffmlLy8mc2un/CY0cg7Q=
 github.com/openshift/library-go v0.0.0-20240312152318-4109a9e7a437 h1:xMflL80gT2cXxnmDkR8QLZCbfh/x38jV5XOfLiNlsLE=
 github.com/openshift/library-go v0.0.0-20240312152318-4109a9e7a437/go.mod h1:ePlaOqUiPplRc++6aYdMe+2FmXb2xTNS9Nz5laG2YmI=
-github.com/openshift/topolvm v0.15.3-0.20240321104545-ab31b05c1b85 h1:LdqfViDjjcIIgidKm+7lIRlpA49XZh9Qfjym4ab4CH8=
-github.com/openshift/topolvm v0.15.3-0.20240321104545-ab31b05c1b85/go.mod h1:sp/P6O6+7is1dnV6am+yk+djRxxfcOPyzW4Bi2CfEyU=
+github.com/openshift/topolvm v0.15.3-0.20240410085813-a5c797a83619 h1:hZodEfjqhRhC4iIdcfSYBjGU6X6jL6ibhAyI/iASpKU=
+github.com/openshift/topolvm v0.15.3-0.20240410085813-a5c797a83619/go.mod h1:2sDyRQ8hxqneC1d/usDasSZECKSCHP77zcIEK6422EM=
 github.com/operator-framework/api v0.22.0 h1:UZSn+iaQih4rCReezOnWTTJkMyawwV5iLnIItaOzytY=
 github.com/operator-framework/api v0.22.0/go.mod h1:p/7YDbr+n4fmESfZ47yLAV1SvkfE6NU2aX8KhcfI0GA=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=

--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -64,3 +64,18 @@ const (
 	PriorityClassNameUserCritical    = "openshift-user-critical"
 	PriorityClassNameClusterCritical = "system-cluster-critical"
 )
+
+// these constants are derived from the TopoLVM recommendations but maintained separately to allow easy override.
+// see https://github.com/topolvm/topolvm/blob/a967c95da14f80955332a00ebb258e319c6c39ac/cmd/topolvm-controller/app/root.go#L17-L28
+const (
+	// DefaultMinimumAllocationSizeBlock is the default minimum size for a block volume.
+	// Derived from the usual physical extent size of 4Mi * 2 (for accommodating metadata)
+	DefaultMinimumAllocationSizeBlock = "8Mi"
+	// DefaultMinimumAllocationSizeXFS is the default minimum size for a filesystem volume with XFS formatting.
+	// Derived from the hard XFS minimum size of 300Mi that is enforced by the XFS filesystem.
+	DefaultMinimumAllocationSizeXFS = "300Mi"
+	// DefaultMinimumAllocationSizeExt4 is the default minimum size for a filesystem volume with ext4 formatting.
+	// Derived from the usual 4096K blocks, 1024 inode default and journaling overhead,
+	// Allows for more than 80% free space after formatting, anything lower significantly reduces this percentage.
+	DefaultMinimumAllocationSizeExt4 = "32Mi"
+)

--- a/vendor/github.com/topolvm/topolvm/Makefile
+++ b/vendor/github.com/topolvm/topolvm/Makefile
@@ -269,8 +269,7 @@ install-helm-docs: | $(BINDIR)
 tools: install-kind install-container-structure-test install-helm install-helm-docs | $(BINDIR) ## Install development tools.
 	GOBIN=$(BINDIR) go install honnef.co/go/tools/cmd/staticcheck@latest
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) $(GOLANGCI_LINT_VERSION)
-	# Follow the official documentation to install the `latest` version, because explicitly specifying the version will get an error.
-	GOBIN=$(BINDIR) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(BINDIR) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 	GOBIN=$(BINDIR) go install sigs.k8s.io/controller-tools/cmd/controller-gen@v$(CONTROLLER_TOOLS_VERSION)
 
 	$(CURL) -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOC_VERSION)/protoc-$(PROTOC_VERSION)-linux-x86_64.zip

--- a/vendor/github.com/topolvm/topolvm/internal/driver/allocation_settings.go
+++ b/vendor/github.com/topolvm/topolvm/internal/driver/allocation_settings.go
@@ -1,0 +1,107 @@
+package driver
+
+import (
+	"reflect"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// MinimumAllocationSettings contains the minimum allocation settings for the controller.
+// It contains the default settings.
+type MinimumAllocationSettings struct {
+	Filesystem map[string]Quantity `json:"filesystem" ,yaml:"filesystem"`
+	Block      Quantity            `json:"block" ,yaml:"block"`
+}
+
+type Quantity resource.Quantity
+
+var _ pflag.Value = &Quantity{}
+
+func newQuantityValue(val resource.Quantity, p *Quantity) *Quantity {
+	*p = Quantity(val)
+	return p
+}
+
+func NewQuantityFlagVar(fs *pflag.FlagSet, name string, value resource.Quantity, usage string) Quantity {
+	p := new(Quantity)
+	fs.Var(newQuantityValue(value, p), name, usage)
+	return *p
+}
+
+func QuantityVar(fs *pflag.FlagSet, p *Quantity, name string, value resource.Quantity, usage string) {
+	fs.Var(newQuantityValue(value, p), name, usage)
+}
+
+func (q *Quantity) String() string {
+	rq := resource.Quantity(*q)
+	return rq.String()
+}
+
+func (q *Quantity) Set(s2 string) error {
+	rq, err := resource.ParseQuantity(s2)
+	if err != nil {
+		return err
+	}
+	*q = Quantity(rq)
+	return nil
+}
+
+func (q *Quantity) Type() string {
+	rq := resource.Quantity(*q)
+	return reflect.TypeOf(rq).String()
+}
+
+// MinMaxAllocationsFromSettings returns the minimum and maximum allocations based on the settings.
+// It uses the required and limit bytes from the CSI Call and the device class and capabilities from the StorageClass.
+// It then returns the minimum and maximum allocations in bytes that can be used for that context.
+func (settings MinimumAllocationSettings) MinMaxAllocationsFromSettings(
+	required, limit int64,
+	capabilities []*csi.VolumeCapability,
+) (int64, int64) {
+	minimumSize := settings.GetMinimumAllocationSize(capabilities)
+
+	if minimumSize.CmpInt64(required) > 0 {
+		ctrlLogger.Info("required size is less than minimum size, "+
+			"using minimum size as required size", "required", required, "minimum", minimumSize.Value())
+		required = minimumSize.Value()
+	}
+
+	return required, limit
+}
+
+// GetMinimumAllocationSize returns the minimum size to be allocated from the parameters derived from the StorageClass.
+// it uses either the filesystem or block key to get the minimum allocated size.
+// it determines which key to use based on the capabilities.
+// If no key is found or neither capability exists, it returns 0.
+// If the value is not a valid Quantity, it returns an error.
+func (settings MinimumAllocationSettings) GetMinimumAllocationSize(
+	capabilities []*csi.VolumeCapability,
+) resource.Quantity {
+	var quantity resource.Quantity
+
+	for _, capability := range capabilities {
+		if capability.GetBlock() != nil {
+			quantity = resource.Quantity(settings.Block)
+			break
+		}
+
+		if capability.GetMount() != nil {
+			rawQuantity, ok := settings.Filesystem[capability.GetMount().FsType]
+			if !ok {
+				break
+			}
+
+			quantity = resource.Quantity(rawQuantity)
+
+			break
+		}
+	}
+
+	if quantity.Sign() < 0 {
+		return resource.MustParse("0")
+	}
+
+	return quantity
+}

--- a/vendor/github.com/topolvm/topolvm/internal/lvmd/device_class_manager.go
+++ b/vendor/github.com/topolvm/topolvm/internal/lvmd/device_class_manager.go
@@ -9,8 +9,8 @@ import (
 	lvmdTypes "github.com/topolvm/topolvm/pkg/lvmd/types"
 )
 
-// ErrNotFound is returned when a VG or LV is not found.
-var ErrNotFound = errors.New("device-class not found")
+// ErrDeviceClassNotFound is returned when a VG or LV is not found.
+var ErrDeviceClassNotFound = errors.New("device-class not found")
 
 const (
 	defaultSpareGB = 10
@@ -148,7 +148,7 @@ func (m DeviceClassManager) DeviceClass(dcName string) (*lvmdTypes.DeviceClass, 
 	if v, ok := m.deviceClassByName[dcName]; ok {
 		return v, nil
 	}
-	return nil, ErrNotFound
+	return nil, ErrDeviceClassNotFound
 }
 
 // FindDeviceClassByVGName returns the device-class with the volume group name
@@ -156,7 +156,7 @@ func (m DeviceClassManager) FindDeviceClassByVGName(vgName string) (*lvmdTypes.D
 	if v, ok := m.deviceClassByVGName[vgName]; ok {
 		return v, nil
 	}
-	return nil, ErrNotFound
+	return nil, ErrDeviceClassNotFound
 }
 
 // FindDeviceClassByThinPoolName returns the device-class with volume group and pool combination
@@ -165,5 +165,5 @@ func (m DeviceClassManager) FindDeviceClassByThinPoolName(vgName string, poolNam
 	if v, ok := m.deviceClassByThinPoolName[name]; ok {
 		return v, nil
 	}
-	return nil, ErrNotFound
+	return nil, ErrDeviceClassNotFound
 }

--- a/vendor/github.com/topolvm/topolvm/internal/lvmd/lvservice.go
+++ b/vendor/github.com/topolvm/topolvm/internal/lvmd/lvservice.go
@@ -159,14 +159,14 @@ func (s *lvService) RemoveLV(ctx context.Context, req *proto.RemoveLVRequest) (*
 	}
 
 	vg, err := command.FindVolumeGroup(ctx, dc.VolumeGroup)
-	if errors.Is(err, ErrNotFound) {
+	if errors.Is(err, command.ErrNotFound) {
 		return nil, status.Errorf(codes.NotFound, "%s: %s", err.Error(), req.DeviceClass)
 	} else if err != nil {
 		logger.Error(err, "failed to get volume group", "name", dc.VolumeGroup)
 		return nil, err
 	}
 
-	if err := vg.RemoveVolume(ctx, req.GetName()); errors.Is(err, ErrNotFound) {
+	if err := vg.RemoveVolume(ctx, req.GetName()); errors.Is(err, command.ErrNotFound) {
 		return nil, status.Errorf(codes.NotFound, "%s: %s", err.Error(), req.DeviceClass)
 	} else if err != nil {
 		logger.Error(err, "failed to remove volume", "name", req.GetName())

--- a/vendor/github.com/topolvm/topolvm/internal/lvmd/vgservice.go
+++ b/vendor/github.com/topolvm/topolvm/internal/lvmd/vgservice.go
@@ -163,8 +163,8 @@ func (s *vgService) send(server proto.VGService_WatchServer) error {
 
 		for _, pool := range pools {
 			dc, err := s.dcManager.FindDeviceClassByThinPoolName(vg.Name(), pool.Name())
-			// we either get nil or ErrNotFound
-			if errors.Is(err, ErrNotFound) {
+			// we either get nil or ErrDeviceClassNotFound
+			if errors.Is(err, ErrDeviceClassNotFound) {
 				continue
 			}
 
@@ -203,7 +203,7 @@ func (s *vgService) send(server proto.VGService_WatchServer) error {
 		}
 
 		dc, err := s.dcManager.FindDeviceClassByVGName(vg.Name())
-		if errors.Is(err, ErrNotFound) {
+		if errors.Is(err, ErrDeviceClassNotFound) {
 			continue
 		}
 

--- a/vendor/github.com/topolvm/topolvm/pkg/driver/controller.go
+++ b/vendor/github.com/topolvm/topolvm/pkg/driver/controller.go
@@ -4,4 +4,26 @@ import (
 	internalDriver "github.com/topolvm/topolvm/internal/driver"
 )
 
+// NewControllerServer is an externally consumable wrapper.
+// It allows starting a new controller server even without access to the package internals.
 var NewControllerServer = internalDriver.NewControllerServer
+
+// ControllerServerSettings is an externally consumable wrapper.
+// It is used to configure the controller server.
+type ControllerServerSettings = internalDriver.ControllerServerSettings
+
+// MinimumAllocationSettings is an externally consumable wrapper.
+// It contains the minimum allocation settings for the controller inside controller server settings.
+type MinimumAllocationSettings = internalDriver.MinimumAllocationSettings
+
+// Quantity is an externally consumable wrapper.
+// It is used to represent a quantity of a resource.
+type Quantity = internalDriver.Quantity
+
+// NewQuantityFlagVar is an externally consumable wrapper.
+// It is used to create a new quantity flag variable.
+var NewQuantityFlagVar = internalDriver.NewQuantityFlagVar
+
+// QuantityVar is an externally consumable wrapper.
+// It is used to create a new quantity variable.
+var QuantityVar = internalDriver.QuantityVar

--- a/vendor/github.com/topolvm/topolvm/versions.mk
+++ b/vendor/github.com/topolvm/topolvm/versions.mk
@@ -29,6 +29,9 @@ MINIKUBE_VERSION := v1.32.0
 # https://github.com/protocolbuffers/protobuf/releases
 PROTOC_VERSION :=  25.2
 
+# https://github.com/kubernetes-sigs/controller-runtime/tree/main/tools/setup-envtest
+# Usually on latest, but might need to be pinned from time to time
+ENVTEST_VERSION := bf15e44028f908c790721fc8fe67c7bf2d06a611
 ENVTEST_KUBERNETES_VERSION := $(shell echo $(KUBERNETES_VERSION) | cut -d "." -f 1-2)
 
 # Tools versions which are defined in go.mod

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -374,7 +374,7 @@ github.com/stretchr/objx
 ## explicit; go 1.17
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
-# github.com/topolvm/topolvm v0.27.1-0.20240306010159-8c6c91dc8b7f => github.com/openshift/topolvm v0.15.3-0.20240321104545-ab31b05c1b85
+# github.com/topolvm/topolvm v0.28.1-0.20240410004534-b0a2229dc10d => github.com/openshift/topolvm v0.15.3-0.20240410085813-a5c797a83619
 ## explicit; go 1.20
 github.com/topolvm/topolvm
 github.com/topolvm/topolvm/api/legacy/v1
@@ -1287,4 +1287,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
-# github.com/topolvm/topolvm => github.com/openshift/topolvm v0.15.3-0.20240321104545-ab31b05c1b85
+# github.com/topolvm/topolvm => github.com/openshift/topolvm v0.15.3-0.20240410085813-a5c797a83619


### PR DESCRIPTION
This introduces minimum allocation sizing on the topolvm controller server equivalent to our upstream. The difference here is that we set our own limits so that we can later transition to a more dynamic configuration if required. For now the minimum limits should suffice.