### PR TITLE
OCPEDGE-1005: must-gather: add support for --since and --since-time flags

### DIFF
--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -32,7 +32,7 @@ Developers must follow these steps to make a change:
    review process (effectively repeating steps 3-7 as needed).
 
 To test the changes in must-gather follow these steps:
-1. Run `make lvm-must-gather`
+1. Run `make lvms-must-gather`
 2. It will create an image named `quay.io/lvms_dev/lvm-must-gather:latest`
 3. Tag it and push it to your image repository to use it with the `oc adm` command
 

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -5,20 +5,17 @@ mkdir -p ${BASE_COLLECTION_PATH}
 # Store PIDs of all the subprocesses
 pids=()
 
-# Command line argument
-SINCE_TIME=$1
-
 # timestamp for starting of the script
 START_TIME=$(date +%r)
 start=$(date +%s)
 printf "collection started at: %s \n" "${START_TIME}" >>${BASE_COLLECTION_PATH}/gather-debug.log 2>&1
 
 # Call other gather scripts
-gather_node_info ${BASE_COLLECTION_PATH} "${SINCE_TIME}" &
+gather_node_info ${BASE_COLLECTION_PATH} &
 pids+=($!)
-gather_namespaced_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}" &
+gather_namespaced_resources ${BASE_COLLECTION_PATH} &
 pids+=($!)
-gather_clusterscoped_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}" &
+gather_clusterscoped_resources ${BASE_COLLECTION_PATH} &
 pids+=($!)
 
 # Check if PID array has any values, if so, wait for them to finish

--- a/must-gather/collection-scripts/gather_clusterscoped_resources
+++ b/must-gather/collection-scripts/gather_clusterscoped_resources
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+source gather_common
+get_log_collection_args
+
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1
 
@@ -6,9 +10,6 @@ BASE_COLLECTION_PATH=$1
 if [ "${BASE_COLLECTION_PATH}" = "" ]; then
     BASE_COLLECTION_PATH=$(pwd)
 fi
-
-# Expect time option as an argument
-SINCE_TIME=$2
 
 # Command List
 commands_get=()
@@ -67,7 +68,7 @@ done
 
 # Run the Collection of Resources oc yaml to list
 for oc_yaml in "${oc_yamls[@]}"; do
-    { oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect "${oc_yaml}" --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+    { oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect "${oc_yaml}" ${log_collection_args}; } >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 done
 
 # Run the Collection of Resources oc describe to list

--- a/must-gather/collection-scripts/gather_common
+++ b/must-gather/collection-scripts/gather_common
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+get_log_collection_args() {
+    # validation of MUST_GATHER_SINCE and MUST_GATHER_SINCE_TIME is done by the
+    # caller (oc adm must-gather) so it's safe to use the values as they are.
+    log_collection_args=""
+
+    if [ -n "${MUST_GATHER_SINCE:-}" ]; then
+        log_collection_args=--since="${MUST_GATHER_SINCE}"
+    fi
+    if [ -n "${MUST_GATHER_SINCE_TIME:-}" ]; then
+        log_collection_args=--since-time="${MUST_GATHER_SINCE_TIME}"
+    fi
+}

--- a/must-gather/collection-scripts/gather_namespaced_resources
+++ b/must-gather/collection-scripts/gather_namespaced_resources
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+source gather_common
+get_log_collection_args
+
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1
 
@@ -6,9 +10,6 @@ BASE_COLLECTION_PATH=$1
 if [ "${BASE_COLLECTION_PATH}" = "" ]; then
     BASE_COLLECTION_PATH=$(pwd)
 fi
-
-# Expect time option as an argument
-SINCE_TIME=$2
 
 # Use a global variable for namespace
 INSTALL_NAMESPACE=openshift-storage
@@ -54,11 +55,11 @@ oc_yamls+=("csv")
 oc_yamls+=("installplan")
 
 echo "collecting dump of namespace" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
-oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect ns/"${INSTALL_NAMESPACE}" --"${SINCE_TIME}" >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect ns/"${INSTALL_NAMESPACE}" ${log_collection_args} >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 echo "collecting dump of clusterresourceversion" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
 for oc_yaml in "${oc_yamls[@]}"; do
     # shellcheck disable=SC2129
-    oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect "${oc_yaml}" -n "${INSTALL_NAMESPACE}" --"${SINCE_TIME}" >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+    oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect "${oc_yaml}" -n "${INSTALL_NAMESPACE}" ${log_collection_args} >>"${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 done
 
 # Create the dir for oc_output
@@ -88,16 +89,16 @@ mkdir -p "${BASE_COLLECTION_PATH}/namespaces/all/"
 # Run the Collection of Resources using must-gather
 for resource in "${resources[@]}"; do
     echo "collecting dump of ${resource}" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
-    { oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect "${resource}" --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+    { oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect "${resource}" --all-namespaces ${log_collection_args}; } >>"${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
 done
 
 # For pvc of all namespaces
 echo "collecting dump of oc get pvc all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
 { oc get pvc --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/pvc_all_namespaces"
-{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect pvc --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect pvc --all-namespaces ${log_collection_args}; } >>"${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
 
 # For snapshot of all namespaces
 echo "collecting dump of snapshot information for all namespaces" | tee -a "${BASE_COLLECTION_PATH}/gather-debug.log"
 { oc get volumesnapshot --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/get_volumesnapshot_all_namespaces"
 { oc describe volumesnapshot --all-namespaces; } >>"${BASE_COLLECTION_PATH}/namespaces/all/desc_volumesnapshot_all_namespaces"
-{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect volumesnapshot --all-namespaces --"${SINCE_TIME}"; } >>"${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect volumesnapshot --all-namespaces ${log_collection_args}; } >>"${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1


### PR DESCRIPTION
`oc adm must-gather` has new flags `--since` and `--since-time`, which set `MUST_GATHER_SINCE` and `MUST_GATHER_SINCE_TIME` environment vars to limit log collection based on a specified time. This PR adds support for these flags to LVMS must-gather. 

