### PR TITLE
OCPEDGE-1085: Change the base image to fedora

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY internal/ internal/
 # Build
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -mod=vendor --ldflags "-s -w" -a -o lvms cmd/main.go
 
-FROM --platform=$TARGETPLATFORM registry.ci.openshift.org/ocp/4.16:base-rhel9
+FROM --platform=$TARGETPLATFORM fedora:latest
 
 RUN dnf update -y && \
     dnf install --nodocs --noplugins -y \


### PR DESCRIPTION
Because of a recent bug (https://issues.redhat.com/browse/OCPBUGS-33244), we had to switch to a rhel base image which requires registry authentication. This is not ideal for development and is not accessible to external contributors. That's why we want to switch to a Fedora base image.  