### PR TITLE
[release-4.15] OCPBUGS-33842: Remove LVMVolumeGroupNodeStatus CRs as well when LVMCluster CR is removed

### DIFF
--- a/internal/controllers/lvmcluster/controller.go
+++ b/internal/controllers/lvmcluster/controller.go
@@ -149,6 +149,30 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, fmt.Errorf("failed to introspect running pod image: %w", err)
 	}
 
+	// The resource was deleted
+	if !lvmCluster.DeletionTimestamp.IsZero() {
+		// Check for existing LogicalVolumes
+		lvsExist, err := r.logicalVolumesExist(ctx)
+		if err != nil {
+			// check every 10 seconds if there are still PVCs present
+			return ctrl.Result{}, fmt.Errorf("failed to check if LogicalVolumes exist: %w", err)
+		}
+		if lvsExist {
+			waitForLVRemoval := time.Second * 10
+			err := fmt.Errorf("found PVCs provisioned by topolvm, waiting %s for their deletion", waitForLVRemoval)
+			r.WarningEvent(ctx, lvmCluster, EventReasonErrorDeletionPending, err)
+			// check every 10 seconds if there are still PVCs present
+			return ctrl.Result{RequeueAfter: waitForLVRemoval}, nil
+		}
+
+		logger.Info("processing LVMCluster deletion")
+		if err := r.processDelete(ctx, lvmCluster); err != nil {
+			// check every 10 seconds if there are still PVCs present or the LogicalVolumes are removed
+			return ctrl.Result{Requeue: true}, fmt.Errorf("failed to process LVMCluster deletion: %w", err)
+		}
+		return reconcile.Result{}, nil
+	}
+
 	result, reconcileError := r.reconcile(ctx, lvmCluster)
 
 	statusError := r.updateLVMClusterStatus(ctx, lvmCluster)
@@ -166,30 +190,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 // errors returned by this will be updated in the reconcileSucceeded condition of the LVMCluster
 func (r *Reconciler) reconcile(ctx context.Context, instance *lvmv1alpha1.LVMCluster) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
-
-	// The resource was deleted
-	if !instance.DeletionTimestamp.IsZero() {
-		// Check for existing LogicalVolumes
-		lvsExist, err := r.logicalVolumesExist(ctx)
-		if err != nil {
-			// check every 10 seconds if there are still PVCs present
-			return ctrl.Result{}, fmt.Errorf("failed to check if LogicalVolumes exist: %w", err)
-		}
-		if lvsExist {
-			waitForLVRemoval := time.Second * 10
-			err := fmt.Errorf("found PVCs provisioned by topolvm, waiting %s for their deletion", waitForLVRemoval)
-			r.WarningEvent(ctx, instance, EventReasonErrorDeletionPending, err)
-			// check every 10 seconds if there are still PVCs present
-			return ctrl.Result{RequeueAfter: waitForLVRemoval}, nil
-		}
-
-		logger.Info("processing LVMCluster deletion")
-		if err := r.processDelete(ctx, instance); err != nil {
-			// check every 10 seconds if there are still PVCs present or the LogicalVolumes are removed
-			return ctrl.Result{Requeue: true}, fmt.Errorf("failed to process LVMCluster deletion: %w", err)
-		}
-		return reconcile.Result{}, nil
-	}
 
 	if updated := controllerutil.AddFinalizer(instance, lvmClusterFinalizer); updated {
 		if err := r.Client.Update(ctx, instance); err != nil {
@@ -404,6 +404,7 @@ func (r *Reconciler) processDelete(ctx context.Context, instance *lvmv1alpha1.LV
 		resourceDeletionList := []resource.Manager{
 			resource.TopoLVMStorageClass(),
 			resource.LVMVGs(),
+			resource.LVMVGNodeStatus(),
 			resource.TopoLVMController(),
 			resource.CSIDriver(),
 			resource.TopoLVMNode(),

--- a/internal/controllers/lvmcluster/resource/lvm_volumegroupnodestatus.go
+++ b/internal/controllers/lvmcluster/resource/lvm_volumegroupnodestatus.go
@@ -1,0 +1,104 @@
+/*
+Copyright © 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"context"
+	"fmt"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	lvmVGNodeStatusName = "lvmvgnodestatus"
+)
+
+func LVMVGNodeStatus() Manager {
+	return lvmVGNodeStatus{}
+}
+
+type lvmVGNodeStatus struct{}
+
+// lvmVGNodeStatus unit satisfies resourceManager interface
+var _ Manager = lvmVGNodeStatus{}
+
+func (l lvmVGNodeStatus) GetName() string {
+	return lvmVGNodeStatusName
+}
+
+// EnsureCreated is a noop. This will be created by vg-manager.
+func (l lvmVGNodeStatus) EnsureCreated(r Reconciler, ctx context.Context, cluster *lvmv1alpha1.LVMCluster) error {
+	return nil
+}
+
+func (l lvmVGNodeStatus) EnsureDeleted(r Reconciler, ctx context.Context, _ *lvmv1alpha1.LVMCluster) error {
+	logger := log.FromContext(ctx).WithValues("resourceManager", l.GetName())
+	vgNodeStatusList := &lvmv1alpha1.LVMVolumeGroupNodeStatusList{}
+	if err := r.List(ctx, vgNodeStatusList, client.InNamespace(r.GetNamespace())); err != nil {
+		return fmt.Errorf("failed to list LVMVolumeGroupNodeStatus: %w", err)
+	}
+
+	var volumeGroupNodeStatusesPendingDelete []string
+	for _, nodeItem := range vgNodeStatusList.Items {
+		var volumeGroupsPendingDelete []string
+		for _, item := range nodeItem.Spec.LVMVGStatus {
+			lvmVolumeGroup := &lvmv1alpha1.LVMVolumeGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      item.Name,
+					Namespace: r.GetNamespace(),
+				},
+			}
+
+			if err := r.Get(ctx, client.ObjectKeyFromObject(lvmVolumeGroup), lvmVolumeGroup); err != nil {
+				if errors.IsNotFound(err) {
+					continue
+				}
+				return err
+			}
+
+			logger.Info("waiting for LVMVolumeGroup to be deleted", "volumeGroup", client.ObjectKeyFromObject(lvmVolumeGroup),
+				"finalizers", lvmVolumeGroup.GetFinalizers(), "LVMVolumeGroupNodeStatusName", nodeItem.GetName())
+
+			volumeGroupsPendingDelete = append(volumeGroupsPendingDelete, lvmVolumeGroup.GetName())
+		}
+
+		if len(volumeGroupsPendingDelete) > 0 {
+			volumeGroupNodeStatusesPendingDelete = append(volumeGroupNodeStatusesPendingDelete, nodeItem.GetName())
+			continue
+		}
+
+		if !nodeItem.GetDeletionTimestamp().IsZero() {
+			return fmt.Errorf("the LVMVolumeGroupNodeStatus %s is still present, waiting for deletion", nodeItem.GetName())
+		}
+		if err := r.Delete(ctx, &nodeItem); err != nil {
+			return fmt.Errorf("failed to delete LVMVolumeGroupNodeStatus %s: %w", nodeItem.GetName(), err)
+		}
+
+		logger.Info("initiated LVMVolumeGroupNodeStatus deletion", "LVMVolumeGroupNodeStatusName", nodeItem.GetName())
+	}
+
+	if len(volumeGroupNodeStatusesPendingDelete) > 0 {
+		return fmt.Errorf("waiting for LVMVolumeGroups to be removed before removing LVMVolumeGroupNodeStatuses: %v", volumeGroupNodeStatusesPendingDelete)
+	}
+
+	return nil
+}


### PR DESCRIPTION
cherry-picks 0045d704522c706b34c778a714f41ed346d1c1b1