### PR TITLE
OCPBUGS-33304: fix: Rework LVMVolumeGroupNodeStatus management

### DIFF
--- a/internal/controllers/lvmcluster/controller.go
+++ b/internal/controllers/lvmcluster/controller.go
@@ -181,8 +181,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 		logger.Info("processing LVMCluster deletion")
 		if err := r.processDelete(ctx, lvmCluster); err != nil {
-			// check every 10 seconds if there are still PVCs present or the LogicalVolumes are removed
-			return ctrl.Result{Requeue: true}, fmt.Errorf("failed to process LVMCluster deletion: %w", err)
+			// check in backing off intervals if there are still PVCs present or the LogicalVolumes are removed
+			return ctrl.Result{}, fmt.Errorf("failed to process LVMCluster deletion: %w", err)
 		}
 		return reconcile.Result{}, nil
 	}
@@ -207,6 +207,7 @@ func (r *Reconciler) reconcile(ctx context.Context, instance *lvmv1alpha1.LVMClu
 		resource.CSIDriver(),
 		resource.VGManager(),
 		resource.LVMVGs(),
+		resource.LVMVGNodeStatus(),
 		resource.TopoLVMStorageClass(),
 	}
 

--- a/internal/controllers/lvmcluster/resource/lvm_volumegroupnodestatus.go
+++ b/internal/controllers/lvmcluster/resource/lvm_volumegroupnodestatus.go
@@ -19,17 +19,20 @@ package resource
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
-
+	"github.com/openshift/lvm-operator/internal/controllers/lvmcluster/selector"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	cutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
-	lvmVGNodeStatusName = "lvmvgnodestatus"
+	lvmVGNodeStatusName       = "lvmvgnodestatus"
+	deleteProtectionFinalizer = "delete-protection.lvm.openshift.io"
 )
 
 func LVMVGNodeStatus() Manager {
@@ -38,67 +41,141 @@ func LVMVGNodeStatus() Manager {
 
 type lvmVGNodeStatus struct{}
 
-// lvmVGNodeStatus unit satisfies resourceManager interface
 var _ Manager = lvmVGNodeStatus{}
 
 func (l lvmVGNodeStatus) GetName() string {
 	return lvmVGNodeStatusName
 }
 
-// EnsureCreated is a noop. This will be created by vg-manager.
 func (l lvmVGNodeStatus) EnsureCreated(r Reconciler, ctx context.Context, cluster *lvmv1alpha1.LVMCluster) error {
+	logger := log.FromContext(ctx).WithValues("resourceManager", l.GetName())
+
+	nodes := v1.NodeList{}
+	if err := r.List(ctx, &nodes); err != nil {
+		return fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	validNodes, err := selector.ValidNodes(cluster, &nodes)
+	if err != nil {
+		return fmt.Errorf("failed to get valid nodes: %w", err)
+	}
+
+	logger.V(1).Info("nodes considered for LVMCluster",
+		"nodes", nodesToStringSummary(validNodes),
+		"total", nodesToStringSummary(nodes.Items),
+	)
+
+	for _, node := range validNodes {
+		lvmVGNodeStatus := &lvmv1alpha1.LVMVolumeGroupNodeStatus{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      node.Name,
+				Namespace: r.GetNamespace(),
+			},
+		}
+		result, err := cutil.CreateOrUpdate(ctx, r, lvmVGNodeStatus, func() error {
+			if err := ctrl.SetControllerReference(cluster, lvmVGNodeStatus, r.Scheme()); err != nil {
+				return fmt.Errorf("failed to set controller reference: %w", err)
+			}
+			if !hasDeleteProtectionFinalizer(lvmVGNodeStatus.Finalizers) {
+				lvmVGNodeStatus.SetFinalizers(append(lvmVGNodeStatus.Finalizers, deleteProtectionFinalizer))
+			}
+			return nil
+		})
+
+		if err != nil {
+			return fmt.Errorf("%s failed to reconcile: %w", l.GetName(), err)
+		}
+
+		if result != cutil.OperationResultNone {
+			logger.V(1).Info("LVMVolumeGroupNodeStatus applied to cluster", "operation", result, "name", lvmVGNodeStatus.Name)
+		}
+	}
+
 	return nil
 }
 
-func (l lvmVGNodeStatus) EnsureDeleted(r Reconciler, ctx context.Context, _ *lvmv1alpha1.LVMCluster) error {
-	logger := log.FromContext(ctx).WithValues("resourceManager", l.GetName())
-	vgNodeStatusList := &lvmv1alpha1.LVMVolumeGroupNodeStatusList{}
-	if err := r.List(ctx, vgNodeStatusList, client.InNamespace(r.GetNamespace())); err != nil {
+func (l lvmVGNodeStatus) EnsureDeleted(r Reconciler, ctx context.Context, cluster *lvmv1alpha1.LVMCluster) error {
+
+	nodeStatusList := &lvmv1alpha1.LVMVolumeGroupNodeStatusList{}
+	if err := r.List(ctx, nodeStatusList, client.InNamespace(r.GetNamespace())); err != nil {
 		return fmt.Errorf("failed to list LVMVolumeGroupNodeStatus: %w", err)
 	}
 
-	var volumeGroupNodeStatusesPendingDelete []string
-	for _, nodeItem := range vgNodeStatusList.Items {
-		var volumeGroupsPendingDelete []string
-		for _, item := range nodeItem.Spec.LVMVGStatus {
-			lvmVolumeGroup := &lvmv1alpha1.LVMVolumeGroup{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      item.Name,
-					Namespace: r.GetNamespace(),
-				},
-			}
+	nodeList := v1.NodeList{}
+	if err := r.List(ctx, &nodeList); err != nil {
+		return fmt.Errorf("failed to list nodes: %w", err)
+	}
 
-			if err := r.Get(ctx, client.ObjectKeyFromObject(lvmVolumeGroup), lvmVolumeGroup); err != nil {
-				if errors.IsNotFound(err) {
-					continue
-				}
+	validNodes, err := selector.ValidNodes(cluster, &nodeList)
+	if err != nil {
+		return fmt.Errorf("failed to get valid nodes: %w", err)
+	}
+
+	for _, status := range nodeStatusList.Items {
+		if isValidNode(status.Name, validNodes) {
+			if err := l.deleteNodeStatus(r, ctx, status); err != nil {
 				return err
 			}
-
-			logger.Info("waiting for LVMVolumeGroup to be deleted", "volumeGroup", client.ObjectKeyFromObject(lvmVolumeGroup),
-				"finalizers", lvmVolumeGroup.GetFinalizers(), "LVMVolumeGroupNodeStatusName", nodeItem.GetName())
-
-			volumeGroupsPendingDelete = append(volumeGroupsPendingDelete, lvmVolumeGroup.GetName())
 		}
-
-		if len(volumeGroupsPendingDelete) > 0 {
-			volumeGroupNodeStatusesPendingDelete = append(volumeGroupNodeStatusesPendingDelete, nodeItem.GetName())
-			continue
-		}
-
-		if !nodeItem.GetDeletionTimestamp().IsZero() {
-			return fmt.Errorf("the LVMVolumeGroupNodeStatus %s is still present, waiting for deletion", nodeItem.GetName())
-		}
-		if err := r.Delete(ctx, &nodeItem); err != nil {
-			return fmt.Errorf("failed to delete LVMVolumeGroupNodeStatus %s: %w", nodeItem.GetName(), err)
-		}
-
-		logger.Info("initiated LVMVolumeGroupNodeStatus deletion", "LVMVolumeGroupNodeStatusName", nodeItem.GetName())
 	}
-
-	if len(volumeGroupNodeStatusesPendingDelete) > 0 {
-		return fmt.Errorf("waiting for LVMVolumeGroups to be removed before removing LVMVolumeGroupNodeStatuses: %v", volumeGroupNodeStatusesPendingDelete)
-	}
-
 	return nil
+}
+
+// isValidNode checks if the node is in the list of valid nodes for the LVMVolumeGroupNodeStatus.
+func isValidNode(statusName string, validNodes []v1.Node) bool {
+	for _, node := range validNodes {
+		if statusName == node.Name {
+			return true
+		}
+	}
+	return false
+}
+
+// deleteNodeStatus deletes the LVMVolumeGroupNodeStatus if it is not marked for deletion and removes the finalizer.
+func (l lvmVGNodeStatus) deleteNodeStatus(r Reconciler, ctx context.Context, status lvmv1alpha1.LVMVolumeGroupNodeStatus) error {
+	logger := log.FromContext(ctx).WithValues("resourceManager", l.GetName())
+
+	if status.GetDeletionTimestamp().IsZero() {
+		if err := r.Delete(ctx, &status); err != nil {
+			return fmt.Errorf("failed to delete LVMVolumeGroupNodeStatus %s: %w", status.GetName(), err)
+		}
+		logger.Info("initiated LVMVolumeGroupNodeStatus deletion", "nodeStatus", client.ObjectKeyFromObject(&status))
+	}
+
+	if removeDeleteProtectionFinalizer(&status) {
+		if err := r.Update(ctx, &status); err != nil {
+			return fmt.Errorf("failed to remove finalizer from LVMVolumeGroupNodeStatus: %w", err)
+		}
+	}
+	return nil
+}
+
+func removeDeleteProtectionFinalizer(status *lvmv1alpha1.LVMVolumeGroupNodeStatus) bool {
+	finalizers := status.GetFinalizers()
+	for i, finalizer := range finalizers {
+		if finalizer == deleteProtectionFinalizer {
+			status.SetFinalizers(append(finalizers[:i], finalizers[i+1:]...))
+			return true
+		}
+	}
+	return false
+}
+
+func hasDeleteProtectionFinalizer(finalizers []string) bool {
+	for _, f := range finalizers {
+		if f == deleteProtectionFinalizer {
+			return true
+		}
+	}
+	return false
+}
+
+// nodesToStringSummary returns a string representation of the node names for logging,
+// as it is too long to log all nodes as objects.
+func nodesToStringSummary(nodes []v1.Node) string {
+	nodeNames := make([]string, len(nodes))
+	for i, node := range nodes {
+		nodeNames[i] = node.Name
+	}
+	return fmt.Sprintf("%v", nodeNames)
 }

--- a/internal/controllers/lvmcluster/selector/selector.go
+++ b/internal/controllers/lvmcluster/selector/selector.go
@@ -3,6 +3,7 @@ package selector
 import (
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	corev1helper "k8s.io/component-helpers/scheduling/corev1"
 )
 
 // ExtractNodeSelectorAndTolerations combines and extracts scheduling parameters from the multiple deviceClass entries in an lvmCluster
@@ -23,4 +24,41 @@ func ExtractNodeSelectorAndTolerations(lvmCluster *lvmv1alpha1.LVMCluster) (*cor
 		nodeSelector = &corev1.NodeSelector{NodeSelectorTerms: terms}
 	}
 	return nodeSelector, lvmCluster.Spec.Tolerations
+}
+
+func ValidNodes(lvmCluster *lvmv1alpha1.LVMCluster, nodes *corev1.NodeList) ([]corev1.Node, error) {
+	var validNodes []corev1.Node
+	nodeSelector, tolerations := ExtractNodeSelectorAndTolerations(lvmCluster)
+
+	for _, node := range nodes.Items {
+		// Check if node tolerates all taints
+		if !toleratesAllTaints(node.Spec.Taints, tolerations) {
+			continue
+		}
+
+		// If no node selector is specified, the node is valid
+		if nodeSelector == nil {
+			validNodes = append(validNodes, node)
+			continue
+		}
+
+		// Check if the node matches the node selector terms
+		if matches, err := corev1helper.MatchNodeSelectorTerms(&node, nodeSelector); err != nil {
+			return nil, err
+		} else if matches {
+			validNodes = append(validNodes, node)
+		}
+	}
+
+	return validNodes, nil
+}
+
+// tolerateAllTaints returns true if all taints are tolerated by the provided tolerations
+func toleratesAllTaints(taints []corev1.Taint, tolerations []corev1.Toleration) bool {
+	for _, taint := range taints {
+		if !corev1helper.TolerationsTolerateTaint(tolerations, &taint) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/controllers/lvmcluster/suite_test.go
+++ b/internal/controllers/lvmcluster/suite_test.go
@@ -50,7 +50,6 @@ import (
 var (
 	k8sClient client.Client
 	testEnv   *envtest.Environment
-	ctx       context.Context
 	cancel    context.CancelFunc
 )
 
@@ -72,6 +71,7 @@ var _ = BeforeSuite(func() {
 	logger := zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
 	logf.SetLogger(logger)
 
+	var ctx context.Context
 	ctx, cancel = context.WithCancel(context.Background())
 
 	By("bootstrapping test environment")

--- a/internal/controllers/vgmanager/controller.go
+++ b/internal/controllers/vgmanager/controller.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -125,13 +124,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	nodeStatus := r.getLVMVolumeGroupNodeStatus()
 	if err := r.Get(ctx, client.ObjectKeyFromObject(nodeStatus), nodeStatus); err != nil {
-		if k8serrors.IsNotFound(err) {
-			if err := r.Create(ctx, nodeStatus); err != nil {
-				return ctrl.Result{}, fmt.Errorf("could not create previously non-existing LVMVolumeGroupNodeStatus: %w", err)
-			}
-		} else {
-			return ctrl.Result{}, fmt.Errorf("could not determine if LVMVolumeGroupNodeStatus still needs to be created: %w", err)
-		}
+		return ctrl.Result{}, fmt.Errorf("could not get LVMVolumeGroupNodeStatus: %w", err)
 	}
 
 	return r.reconcile(ctx, volumeGroup, nodeStatus)


### PR DESCRIPTION
When LVMVolumeGroupNodeStatus was originally created it was thought of to be fully managed by the LVMVolumeGroups reconciler in vg-manager. However this is problematic because there must always be 1 owner for full blockOwnerDeletion and Deletion Propagation to work in kubernetes (Controller Reference must be set from the Owner to the owning object). This is not possible with that approach. If we reimagine the LVMCluster to create LVMVolumeGroupNodeStatus instead (by precalculating the Nodes for which we should create a node status) we can achieve the following:
1. Create NodeStatus as soon as LVMCluster exists
2. Have a Finalizer that protects from dropping a NodeStatus prematurely (this can still lead to issues where vg-manager can no longer remove its own volume group from the status due to a set finalizer, but its better than LVMCluster assuming that the vg was removed correctly and showing a wrong status)
3. Have a hook that allows to delete NodeStatus elements when the LVMCluster is removed.

This will allow external projects such as console to do clean operand deletion as we will now have a way to build a clean dependency chain from LVMCluster down to the owned CRs.