### PR TITLE
NO-ISSUE: fix: use correct grace period setting for e2e test pods

### DIFF
--- a/test/e2e/lvm_pvc_test.go
+++ b/test/e2e/lvm_pvc_test.go
@@ -289,12 +289,12 @@ func generateContainer(mode k8sv1.PersistentVolumeMode) k8sv1.Container {
 func generatePodConsumingPVC(pvc *k8sv1.PersistentVolumeClaim) *k8sv1.Pod {
 	return &k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:                       fmt.Sprintf("%s-consumer", pvc.GetName()),
-			Namespace:                  testNamespace,
-			DeletionGracePeriodSeconds: ptr.To(int64(1)),
+			Name:      fmt.Sprintf("%s-consumer", pvc.GetName()),
+			Namespace: testNamespace,
 		},
 		Spec: k8sv1.PodSpec{
-			Containers: []k8sv1.Container{generateContainer(*pvc.Spec.VolumeMode)},
+			TerminationGracePeriodSeconds: ptr.To(int64(1)),
+			Containers:                    []k8sv1.Container{generateContainer(*pvc.Spec.VolumeMode)},
 			Volumes: []k8sv1.Volume{{
 				Name: VolumeNameForPVCTests,
 				VolumeSource: k8sv1.VolumeSource{
@@ -308,12 +308,12 @@ func generatePodConsumingPVC(pvc *k8sv1.PersistentVolumeClaim) *k8sv1.Pod {
 func generatePodWithEphemeralVolume(mode k8sv1.PersistentVolumeMode) *k8sv1.Pod {
 	return &k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:                       fmt.Sprintf("%s-ephemeral", strings.ToLower(string(mode))),
-			Namespace:                  testNamespace,
-			DeletionGracePeriodSeconds: ptr.To(int64(1)),
+			Name:      fmt.Sprintf("%s-ephemeral", strings.ToLower(string(mode))),
+			Namespace: testNamespace,
 		},
 		Spec: k8sv1.PodSpec{
-			Containers: []k8sv1.Container{generateContainer(mode)},
+			TerminationGracePeriodSeconds: ptr.To(int64(1)),
+			Containers:                    []k8sv1.Container{generateContainer(mode)},
 			Volumes: []k8sv1.Volume{{
 				Name: VolumeNameForPVCTests,
 				VolumeSource: k8sv1.VolumeSource{


### PR DESCRIPTION
adjusts the grace periods so the tests run within 2 mins instead of 5 due to waiting for 30s after each pod deletion instead of 1s