### PR TITLE
OCPEDGE-1165: fix: Ensure no racy CSI plugin registration, better startup behavior for vgmanager, failing test summary artifact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,10 +292,21 @@ SUBSCRIPTION_CHANNEL ?= alpha
 # Handles only AWS as of now.
 DISK_INSTALL ?= false
 
+ifdef ARTIFACT_DIR
+SUMMARY_FILE = $(ARTIFACT_DIR)/lvms-e2e-summary.yaml
+endif
+
 .PHONY: e2e
 e2e: ginkgo ## Build and run e2e tests.
 	cd test/e2e && $(GINKGO) build
-	cd test/e2e && ./e2e.test --lvm-catalog-image=$(CATALOG_IMG) --lvm-subscription-channel=$(SUBSCRIPTION_CHANNEL) --lvm-operator-install=$(LVM_OPERATOR_INSTALL) --lvm-operator-uninstall=$(LVM_OPERATOR_UNINSTALL) --disk-install=$(DISK_INSTALL) -ginkgo.v
+	cd test/e2e && ./e2e.test \
+		--lvm-catalog-image=$(CATALOG_IMG) \
+		--lvm-subscription-channel=$(SUBSCRIPTION_CHANNEL) \
+		--lvm-operator-install=$(LVM_OPERATOR_INSTALL) \
+		--lvm-operator-uninstall=$(LVM_OPERATOR_UNINSTALL) \
+		--disk-install=$(DISK_INSTALL) \
+		--summary-file=$(SUMMARY_FILE) \
+		-ginkgo.v
 
 performance-stress-test: ## Build and run stress tests. Requires a fully setup LVMS installation. if you receive an error during running because of a missing token it might be because you have not logged in via token authentication but OIDC. you need a token login to run the performance test.
 	oc apply -f ./config/samples/lvm_v1alpha1_lvmcluster.yaml -n openshift-storage

--- a/api/v1alpha1/lvmcluster_test.go
+++ b/api/v1alpha1/lvmcluster_test.go
@@ -105,7 +105,12 @@ var _ = Describe("webhook acceptance tests", func() {
 		Expect(statusError.Status().Message).To(ContainSubstring(ErrDuplicateLVMCluster.Error()))
 
 		Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-	})
+	},
+		// It can happen that the creation of the LVMCluster is not yet visible to the webhook, so we retry a few times.
+		// This is a workaround for the fact that the informer cache is not yet updated when the webhook is called.
+		// This is faster / more efficient than waiting for the informer cache to be updated with a set interval.
+		FlakeAttempts(3),
+	)
 
 	It("namespace cannot be looked up via ENV", func(ctx SpecContext) {
 		generatedName := generateUniqueNameForTestCase(ctx)

--- a/cmd/vgmanager/vgmanager.go
+++ b/cmd/vgmanager/vgmanager.go
@@ -182,7 +182,7 @@ func run(cmd *cobra.Command, _ []string, opts *Options) error {
 		registrationServer := internalCSI.NewRegistrationServer(
 			constants.TopolvmCSIDriverName, registrationPath(), []string{"1.0.0"})
 		registerapi.RegisterRegistrationServer(grpcServer, registrationServer)
-		if err = mgr.Add(runners.NewGRPCRunner(grpcServer, pluginRegistrationSocketPath(), false)); err != nil {
+		if err = mgr.Add(internalCSI.NewGRPCRunner(grpcServer, pluginRegistrationSocketPath(), false)); err != nil {
 			return fmt.Errorf("could not add grpc runner for registration server: %w", err)
 		}
 
@@ -191,7 +191,7 @@ func run(cmd *cobra.Command, _ []string, opts *Options) error {
 			return fmt.Errorf("could not setup topolvm node server: %w", err)
 		}
 		csi.RegisterNodeServer(grpcServer, nodeServer)
-		err = mgr.Add(runners.NewGRPCRunner(grpcServer, constants.DefaultCSISocket, false))
+		err = mgr.Add(internalCSI.NewGRPCRunner(grpcServer, constants.DefaultCSISocket, false))
 		if err != nil {
 			return fmt.Errorf("could not add grpc runner for node server: %w", err)
 		}

--- a/cmd/vgmanager/vgmanager.go
+++ b/cmd/vgmanager/vgmanager.go
@@ -213,7 +213,7 @@ func run(cmd *cobra.Command, _ []string, opts *Options) error {
 		return fmt.Errorf("unable to create controller VGManager: %w", err)
 	}
 
-	if err := mgr.AddReadyzCheck("readyz", readyCheck(mgr, lvmdConfig)); err != nil {
+	if err := mgr.AddReadyzCheck("readyz", readyCheck(mgr)); err != nil {
 		return fmt.Errorf("unable to set up ready check: %w", err)
 	}
 
@@ -334,7 +334,7 @@ func pluginRegistrationSocketPath() string {
 }
 
 // readyCheck returns a healthz.Checker that verifies the operator is ready
-func readyCheck(mgr manager.Manager, config *lvmd.Config) healthz.Checker {
+func readyCheck(mgr manager.Manager) healthz.Checker {
 	return func(req *http.Request) error {
 		// Perform various checks here to determine if the operator is ready
 		if !mgr.GetCache().WaitForCacheSync(req.Context()) {

--- a/cmd/vgmanager/vgmanager.go
+++ b/cmd/vgmanager/vgmanager.go
@@ -172,8 +172,8 @@ func run(cmd *cobra.Command, _ []string, opts *Options) error {
 		}
 		grpcServer := grpc.NewServer(grpc.UnaryInterceptor(ErrorLoggingInterceptor),
 			grpc.SharedWriteBuffer(true),
-			grpc.MaxConcurrentStreams(1),
-			grpc.NumStreamWorkers(1))
+			grpc.MaxConcurrentStreams(2),
+			grpc.NumStreamWorkers(2))
 		identityServer := driver.NewIdentityServer(func() (bool, error) {
 			return true, nil
 		})

--- a/internal/controllers/lvmcluster/resource/vgmanager.go
+++ b/internal/controllers/lvmcluster/resource/vgmanager.go
@@ -23,6 +23,7 @@ import (
 	lvmv1alpha1 "github.com/openshift/lvm-operator/api/v1alpha1"
 	"github.com/openshift/lvm-operator/internal/cluster"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -156,13 +157,25 @@ func (v vgManager) EnsureDeleted(r Reconciler, ctx context.Context, lvmCluster *
 
 	logger.Info("initiated DaemonSet deletion", "DaemonSet", ds.Name)
 
-	if err := r.Get(ctx, client.ObjectKeyFromObject(&ds), &ds); errors.IsNotFound(err) {
-		return nil
-	} else if err != nil {
-		return fmt.Errorf("failed to verify deletion of %s daemonset %q: %w", v.GetName(), ds.Name, err)
-	} else {
+	if err := r.Get(ctx, client.ObjectKeyFromObject(&ds), &ds); err == nil {
 		return fmt.Errorf("%s daemonset %q still has to be removed", v.GetName(), ds.Name)
+	} else if !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to verify deletion of %s daemonset %q: %w", v.GetName(), ds.Name, err)
 	}
+
+	// because we have background deletion, we also have to check the pods
+	// if there are still pods, we have to wait for them to be removed
+	// if there are no pods, we can consider the daemonset deleted
+	podList := &v1.PodList{}
+	if err := r.List(ctx, podList, client.InNamespace(r.GetNamespace()),
+		client.MatchingLabels(ds.Spec.Selector.MatchLabels),
+	); err != nil {
+		return fmt.Errorf("failed to list pods for DaemonSet %q: %w", ds.Name, err)
+	} else if len(podList.Items) > 0 {
+		return fmt.Errorf("DaemonSet %q still has %d pods running", ds.Name, len(podList.Items))
+	}
+
+	return nil
 }
 
 func initMapIfNil(m *map[string]string) {

--- a/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
+++ b/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
@@ -205,8 +205,8 @@ var (
 	}
 )
 
-// newVGManagerDaemonset returns the desired vgmanager daemonset for a given LVMCluster
-func newVGManagerDaemonset(
+// templateVGManagerDaemonset returns the desired vgmanager daemonset for a given LVMCluster
+func templateVGManagerDaemonset(
 	lvmCluster *lvmv1alpha1.LVMCluster,
 	clusterType cluster.Type,
 	namespace, vgImage string,

--- a/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
+++ b/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
@@ -268,6 +268,14 @@ func newVGManagerDaemonset(
 					ContainerPort: 8081,
 					Protocol:      corev1.ProtocolTCP},
 			},
+			StartupProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{Path: "/healthz",
+						Port: intstr.FromString(constants.TopolvmNodeContainerHealthzName)}},
+				FailureThreshold:    10,
+				InitialDelaySeconds: 0,
+				TimeoutSeconds:      2,
+				PeriodSeconds:       2},
 			LivenessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{Path: "/healthz",

--- a/internal/csi/registrar.go
+++ b/internal/csi/registrar.go
@@ -2,11 +2,13 @@ package csi
 
 import (
 	"context"
+	"fmt"
 	_ "net/http/pprof"
-	"os"
+	"sync"
 
 	"k8s.io/klog/v2"
 	registerapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // registrationServer is a sample plugin to work with plugin watcher
@@ -14,13 +16,26 @@ type registrationServer struct {
 	driverName string
 	endpoint   string
 	version    []string
+
+	registered    bool
+	registeredMut sync.RWMutex
+
+	onFail context.CancelCauseFunc
 }
 
-var _ registerapi.RegistrationServer = registrationServer{}
+var _ registerapi.RegistrationServer = &registrationServer{}
+
+var ErrPluginRegistrationFailed = fmt.Errorf("plugin registration failed")
+
+type CheckableRegistrationServer interface {
+	registerapi.RegistrationServer
+	Registered() bool
+}
 
 // NewRegistrationServer returns an initialized registrationServer instance
-func NewRegistrationServer(driverName string, endpoint string, versions []string) registerapi.RegistrationServer {
+func NewRegistrationServer(onFail context.CancelCauseFunc, driverName string, endpoint string, versions []string) CheckableRegistrationServer {
 	return &registrationServer{
+		onFail:     onFail,
 		driverName: driverName,
 		endpoint:   endpoint,
 		version:    versions,
@@ -28,8 +43,8 @@ func NewRegistrationServer(driverName string, endpoint string, versions []string
 }
 
 // GetInfo is the RPC invoked by plugin watcher
-func (e registrationServer) GetInfo(ctx context.Context, req *registerapi.InfoRequest) (*registerapi.PluginInfo, error) {
-	klog.V(2).Infof("Received GetInfo call: %+v", req)
+func (e *registrationServer) GetInfo(ctx context.Context, req *registerapi.InfoRequest) (*registerapi.PluginInfo, error) {
+	klog.V(2).Infof("Received GetInfo call (signalling the beginning of registration): %+v", req)
 
 	return &registerapi.PluginInfo{
 		Type:              registerapi.CSIPlugin,
@@ -39,12 +54,24 @@ func (e registrationServer) GetInfo(ctx context.Context, req *registerapi.InfoRe
 	}, nil
 }
 
-func (e registrationServer) NotifyRegistrationStatus(ctx context.Context, status *registerapi.RegistrationStatus) (*registerapi.RegistrationStatusResponse, error) {
-	klog.V(2).Infof("Received NotifyRegistrationStatus call: %+v", status)
+func (e *registrationServer) NotifyRegistrationStatus(ctx context.Context, status *registerapi.RegistrationStatus) (*registerapi.RegistrationStatusResponse, error) {
+	log.FromContext(ctx).Info("CSI Plugin got a registration update", "status", status)
 	if !status.PluginRegistered {
-		klog.Errorf("Registration process failed with error: %+v, restarting registration container.", status.Error)
-		os.Exit(1)
+		err := fmt.Errorf("%w: %s", ErrPluginRegistrationFailed, status.Error)
+		log.FromContext(ctx).Error(err, "Registration process failed, restarting registration container.")
+		defer e.onFail(err)
+		return &registerapi.RegistrationStatusResponse{}, nil
 	}
 
+	e.registeredMut.Lock()
+	e.registered = status.PluginRegistered
+	e.registeredMut.Unlock()
+
 	return &registerapi.RegistrationStatusResponse{}, nil
+}
+
+func (e *registrationServer) Registered() bool {
+	e.registeredMut.RLock()
+	defer e.registeredMut.RUnlock()
+	return e.registered
 }

--- a/test/e2e/config_test.go
+++ b/test/e2e/config_test.go
@@ -24,6 +24,7 @@ import (
 	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	configv1 "github.com/openshift/api/config/v1"
 	secv1 "github.com/openshift/api/security/v1"
+	topolvmv1 "github.com/topolvm/topolvm/api/v1"
 
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -72,6 +73,7 @@ func init() {
 
 	utilruntime.Must(k8sscheme.AddToScheme(scheme))
 	utilruntime.Must(lvmv1.AddToScheme(scheme))
+	utilruntime.Must(topolvmv1.AddToScheme(scheme))
 	utilruntime.Must(operatorv1.AddToScheme(scheme))
 	utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(snapapi.AddToScheme(scheme))

--- a/test/e2e/helper_test.go
+++ b/test/e2e/helper_test.go
@@ -57,6 +57,7 @@ func VerifyLVMSSetup(ctx context.Context, cluster *v1alpha1.LVMCluster) {
 	GinkgoHelper()
 	validateLVMCluster(ctx, cluster)
 	validateCSIDriver(ctx)
+	validateCSINodeInfo(ctx, cluster, true)
 	validateVGManager(ctx)
 	validateLVMVolumeGroup(ctx)
 	validateStorageClass(ctx)

--- a/test/e2e/lvm_cluster_test.go
+++ b/test/e2e/lvm_cluster_test.go
@@ -40,6 +40,7 @@ func lvmClusterTest() {
 			return
 		}
 		DeleteResource(ctx, cluster)
+		validateCSINodeInfo(ctx, cluster, false)
 	})
 
 	Describe("Filesystem Type", Serial, func() {

--- a/test/e2e/lvm_pvc_test.go
+++ b/test/e2e/lvm_pvc_test.go
@@ -77,6 +77,7 @@ func pvcTestThinProvisioning() {
 				return
 			}
 			DeleteResource(ctx, cluster)
+			validateCSINodeInfo(ctx, cluster, false)
 		})
 	})
 
@@ -125,6 +126,7 @@ func pvcTestThickProvisioning() {
 				return
 			}
 			DeleteResource(ctx, cluster)
+			validateCSINodeInfo(ctx, cluster, false)
 		})
 	})
 

--- a/test/e2e/lvm_suite_test.go
+++ b/test/e2e/lvm_suite_test.go
@@ -66,6 +66,9 @@ var _ = AfterSuite(func(ctx context.Context) {
 })
 
 var _ = Describe("LVM Operator e2e tests", func() {
+	JustAfterEach(func(ctx SpecContext) {
+		SummaryOnFailure(ctx)
+	})
 	Describe("LVM Cluster Configuration", Serial, lvmClusterTest)
 	Describe("PVC", Serial, Ordered, func() {
 		Describe("Thin", Serial, Ordered, pvcTestThinProvisioning)

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/lvm-operator/api/v1alpha1"
+	"github.com/openshift/lvm-operator/internal/controllers/lvmcluster/resource"
 	topolvmv1 "github.com/topolvm/topolvm/api/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	k8sv1 "k8s.io/api/core/v1"
@@ -119,11 +120,8 @@ func validateDaemonSet(ctx context.Context, name types.NamespacedName) bool {
 		if err := crClient.Get(ctx, name, ds); err != nil {
 			return err
 		}
-		isReady := ds.Status.DesiredNumberScheduled == ds.Status.NumberReady
-		if !isReady {
-			return fmt.Errorf("the DaemonSet %s is not considered ready", name)
-		}
-		return nil
+
+		return resource.VerifyDaemonSetReadiness(ds)
 	}, timeout, interval).WithContext(ctx).Should(Succeed())
 }
 

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -178,7 +178,8 @@ func validatePodData(ctx context.Context, pod *k8sv1.Pod, expectedData string, c
 
 func validateCSINodeInfo(ctx context.Context, lvmCluster *v1alpha1.LVMCluster, shouldBePresent bool) bool {
 	GinkgoHelper()
-	By("validating the CSINode(s) for the Cluster to have the driver registered")
+	By(fmt.Sprintf("validating the CSINode(s) for the Cluster to  %s have the driver registered",
+		map[bool]string{true: "", false: "NOT "}[shouldBePresent]))
 	return Eventually(func(ctx context.Context) error {
 		var nodes []k8sv1.Node
 
@@ -214,7 +215,7 @@ func validateCSINodeInfo(ctx context.Context, lvmCluster *v1alpha1.LVMCluster, s
 			if exists != shouldBePresent {
 				return fmt.Errorf("CSINode %q should %scontain the driver %q",
 					node.Name,
-					map[bool]string{true: "", false: "not "}[shouldBePresent],
+					map[bool]string{true: "", false: "NOT "}[shouldBePresent],
 					csiDriverName,
 				)
 			}


### PR DESCRIPTION
This stops vgmanager from going healthy too early as we need to signal healthiness only when the driver has been started. Fixes the racy registration server that now properly starts and shuts down and is part of the healthiness check we use in vgmanager. That will ensure that no vgmanager gets ready that isnt registered in the kubelet. Ensures that vgmanager pods are gone before LVMCluster is freed.

Adds an artifact into the e2e step on failure that can be used to see the immediate LVMS cluster state when a failure occurs in case of a cleanup in the post failure steps.

Validates in tests that all CSINodes have proper registrations for vgmanager so we dont have weird flakes in the future.
