### PR TITLE
OCPEDGE-1126: feat: make lvms microshift aware during vgmanager mounting

### DIFF
--- a/internal/controllers/vgmanager/lvmd/lvmd.go
+++ b/internal/controllers/vgmanager/lvmd/lvmd.go
@@ -25,7 +25,7 @@ var (
 
 const (
 	DefaultFileConfigDir     = "/etc/topolvm"
-	MicroShiftFileConfigDir  = "/etc/microshift"
+	MicroShiftFileConfigDir  = "/var/lib/microshift/lvms"
 	DefaultFileConfigPath    = DefaultFileConfigDir + "/lvmd.yaml"
 	MicroShiftFileConfigPath = MicroShiftFileConfigDir + "/lvmd.yaml"
 	maxReadLength            = 2 * 1 << 20 // 2MB


### PR DESCRIPTION
readjusts the mount directory to /var/lib to not induce conflicts with ostree state management. paths are still synchronized from /etc/topolvm via a watch from /etc to /var/lib in microshift

See https://github.com/openshift/microshift/pull/3535#discussion_r1653042872 for the reasoning background and https://github.com/openshift/microshift/pull/3535/commits/a66137a80fc6952ebc959f7f661df4dc734886cf for adjustment on the implementation on microshift