### PR TITLE
OCPBUGS-34227: fix: move checks into readiness and introduce grpc health

### DIFF
--- a/internal/controllers/lvmcluster/controller.go
+++ b/internal/controllers/lvmcluster/controller.go
@@ -210,6 +210,7 @@ func (r *Reconciler) reconcile(ctx context.Context, instance *lvmv1alpha1.LVMClu
 		resource.LVMVGs(),
 		resource.LVMVGNodeStatus(),
 		resource.TopoLVMStorageClass(),
+		resource.CSINode(),
 	}
 
 	if r.ClusterType == cluster.TypeOCP {
@@ -339,6 +340,7 @@ func (r *Reconciler) processDelete(ctx context.Context, instance *lvmv1alpha1.LV
 			resource.LVMVGNodeStatus(),
 			resource.CSIDriver(),
 			resource.VGManager(r.ClusterType),
+			resource.CSINode(),
 		}
 
 		if r.ClusterType == cluster.TypeOCP {

--- a/internal/controllers/lvmcluster/resource/csi_node.go
+++ b/internal/controllers/lvmcluster/resource/csi_node.go
@@ -1,0 +1,112 @@
+package resource
+
+import (
+	"context"
+	"fmt"
+
+	lvmv1alpha1 "github.com/openshift/lvm-operator/v4/api/v1alpha1"
+	"github.com/openshift/lvm-operator/v4/internal/controllers/constants"
+	"github.com/openshift/lvm-operator/v4/internal/controllers/lvmcluster/selector"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	resourceName = "topolvm-csi-node-registrations"
+)
+
+func CSINode() Manager {
+	return csiNode{}
+}
+
+type csiNode struct {
+}
+
+func (c csiNode) GetName() string {
+	return resourceName
+}
+
+func (c csiNode) EnsureCreated(r Reconciler, ctx context.Context, cluster *lvmv1alpha1.LVMCluster) error {
+	logger := log.FromContext(ctx).WithValues("resourceManager", c.GetName())
+
+	csiNodes, err := c.GetAllCSINodeCandidates(ctx, r, cluster)
+	if err != nil {
+		return err
+	}
+
+	for _, csiNode := range csiNodes {
+		found := false
+		for _, driver := range csiNode.Spec.Drivers {
+			if driver.Name == constants.TopolvmCSIDriverName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("csi node %s does not have driver %s", csiNode.Name, constants.TopolvmCSIDriverName)
+		}
+	}
+
+	logger.V(2).Info("All CSINode driver registrations have been created by the kubelet")
+
+	return nil
+}
+
+func (c csiNode) EnsureDeleted(r Reconciler, ctx context.Context, cluster *lvmv1alpha1.LVMCluster) error {
+	logger := log.FromContext(ctx).WithValues("resourceManager", c.GetName())
+
+	csiNodes, err := c.GetAllCSINodeCandidates(ctx, r, cluster)
+	if err != nil {
+		return err
+	}
+
+	for _, csiNode := range csiNodes {
+		found := false
+		for _, driver := range csiNode.Spec.Drivers {
+			if driver.Name == constants.TopolvmCSIDriverName {
+				found = true
+				break
+			}
+		}
+		if found {
+			return fmt.Errorf("csi node %s does not have driver %s", csiNode.Name, constants.TopolvmCSIDriverName)
+		}
+	}
+
+	logger.V(2).Info("All CSINode driver registrations have been deleted by the kubelet")
+
+	return nil
+}
+
+func (c csiNode) GetAllCSINodeCandidates(ctx context.Context, clnt client.Client, cluster *lvmv1alpha1.LVMCluster) ([]*storagev1.CSINode, error) {
+	nodeList := &v1.NodeList{}
+	if err := clnt.List(ctx, nodeList); err != nil {
+		return nil, err
+	}
+
+	valid, err := selector.ValidNodes(cluster, nodeList)
+	if err != nil {
+		return nil, err
+	}
+
+	csiNodes := make([]*storagev1.CSINode, 0, len(valid))
+	for _, node := range valid {
+		csiNode := &storagev1.CSINode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: node.Name,
+			},
+		}
+		if err := clnt.Get(ctx, client.ObjectKeyFromObject(csiNode), csiNode); err != nil {
+			return nil, err
+		}
+		csiNodes = append(csiNodes, csiNode)
+
+	}
+
+	return csiNodes, nil
+}
+
+var _ Manager = csiNode{}

--- a/internal/csi/grpc_runner.go
+++ b/internal/csi/grpc_runner.go
@@ -39,6 +39,13 @@ func (r gRPCServerRunner) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to listen on %s: %w", r.sockFile, err)
 	}
+	defer func(ctx context.Context) {
+		logger := log.FromContext(ctx)
+		if err := os.Remove(r.sockFile); err != nil && !os.IsNotExist(err) {
+			logger.Error(fmt.Errorf("failed to remove socket file after shutdown: %w", err), "failed socket file removal")
+		}
+		logger.Info("removed socket file", "sockFile", r.sockFile)
+	}(ctx)
 
 	go func() {
 		if err := r.srv.Serve(lis); err != nil {
@@ -60,9 +67,6 @@ func (r gRPCServerRunner) Start(ctx context.Context) error {
 	case <-time.After(10 * time.Second):
 		r.srv.Stop()
 		logger.Info("Stopped gRPC server forcibly", "duration", time.Since(start))
-	}
-	if err := os.Remove(r.sockFile); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove socket file after shutdown: %w", err)
 	}
 	return nil
 }

--- a/internal/csi/health.go
+++ b/internal/csi/health.go
@@ -1,0 +1,32 @@
+package csi
+
+import (
+	"context"
+
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+type HealthCheck func(ctx context.Context) error
+
+var AlwaysHealthy HealthCheck = func(ctx context.Context) error {
+	return nil
+}
+
+type healthServer struct {
+	grpc_health_v1.UnimplementedHealthServer
+	checker HealthCheck
+}
+
+func NewHealthServer(c HealthCheck) grpc_health_v1.HealthServer {
+	return &healthServer{
+		checker: c,
+	}
+}
+
+func (srv *healthServer) Check(ctx context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	if err := srv.checker(ctx); err != nil {
+		return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING}, nil
+	}
+
+	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
+}


### PR DESCRIPTION
This avoids the pod shutdown in case of healthiness errors, e.g. when the device class setup takes extremely long. This has the side effect of vgmanager possibly hanging up if there is a hangup in one of its servers, but it will show a not Ready State if that happens. Also now the node server only reports healthiness once this has been successfully completed.

This concretely fixes a situation in which the lvmd setup takes extremely long due to thinpool provisioning (e.g. 5 mins for zeroing a huge array of disks) and the kubelet would kill the pod due to the failing healthiness.