### PR TITLE
feat: introduce KubeSAN codepath for shared volume groups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -425,4 +425,4 @@ vuln-scan-container:
 
 kubesan-node-layering-image:
 	@echo "Building the kubesan-node-layering image"
-	$(IMAGE_BUILD_CMD) build -f hack/kubesan-node-adjustment.Containerfile -t "quay.io/jmoller/node-base-kubesan-patched:v4.16.0" hack/
+	$(IMAGE_BUILD_CMD) build -f hack/kubesan-node-adjustment.Containerfile -t "quay.io/jmoller/node-base-kubesan-patched:v4.16.0-00" hack/

--- a/Makefile
+++ b/Makefile
@@ -422,3 +422,7 @@ vuln-scan-deps:
 .PHONY: vuln-scan-container
 vuln-scan-container:
 	snyk container test $(IMAGE_REPO)/$(IMAGE_TAG) --severity-threshold=$(SEVERITY_THRESHOLD) --org=$(SNYK_ORG)
+
+kubesan-node-layering-image:
+	@echo "Building the kubesan-node-layering image"
+	$(IMAGE_BUILD_CMD) build -f hack/kubesan-node-adjustment.Containerfile -t "quay.io/jmoller/node-base-kubesan-patched:v4.16.0" hack/

--- a/README.md
+++ b/README.md
@@ -234,16 +234,15 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: lvms-test
-  labels:
-    type: local
+  namespace: openshift-storage
 spec:
   storageClassName: lvms-vg1
   resources:
     requests:
-      storage: 5Gi
+      storage: 1Gi
   accessModes:
-    - ReadWriteOnce
-  volumeMode: Filesystem
+    - ReadWriteMany
+  volumeMode: Block
 EOF
 ```
 
@@ -266,6 +265,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: lvms-test
+  namespace: openshift-storage
 spec:
   volumes:
     - name: storage
@@ -277,9 +277,34 @@ spec:
       ports:
         - containerPort: 80
           name: "http-server"
-      volumeMounts:
-        - mountPath: "/usr/share/nginx/html"
-          name: storage
+      volumeDevices:
+        - name: storage
+          devicePath: /dev/xvda
+EOF
+```
+
+```bash
+$ cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lvms-test-remote
+  namespace: openshift-storage
+spec:
+  nodeName: ip-10-0-35-126.eu-central-1.compute.internal
+  volumes:
+    - name: storage
+      persistentVolumeClaim:
+        claimName: lvms-test
+  containers:
+    - name: container
+      image: public.ecr.aws/docker/library/nginx:latest
+      ports:
+        - containerPort: 80
+          name: "http-server"
+      volumeDevices:
+        - name: storage
+          devicePath: /dev/xvda
 EOF
 ```
 

--- a/api/v1alpha1/lvmcluster_types.go
+++ b/api/v1alpha1/lvmcluster_types.go
@@ -92,6 +92,14 @@ const (
 	FilesystemTypeXFS  DeviceFilesystemType = "xfs"
 )
 
+// The DeviceAccessPolicy type defines the accessibility of the lvm2 volume group backing the deviceClass.
+type DeviceAccessPolicy string
+
+const (
+	DeviceAccessPolicyShared    DeviceAccessPolicy = "shared"
+	DeviceAccessPolicyNodeLocal DeviceAccessPolicy = "nodeLocal"
+)
+
 type DeviceClass struct {
 	// Name specifies a name for the device class
 	// +kubebuilder:validation:MaxLength=245
@@ -120,6 +128,13 @@ type DeviceClass struct {
 	// +kubebuilder:default=xfs
 	// +optional
 	FilesystemType DeviceFilesystemType `json:"fstype,omitempty"`
+
+	// Policy defines the policy for the deviceClass.
+	// DEV PREVIEW: shared will allow accessing the deviceClass from multiple nodes.
+	// The deviceClass will then be configured via shared volume group.
+	// +optional
+	// +kubebuilder:validation:Enum=shared;local
+	DeviceAccessPolicy DeviceAccessPolicy `json:"deviceAccessPolicy,omitempty"`
 }
 
 // DeviceSelector specifies the list of criteria that have to match before a device is assigned

--- a/api/v1alpha1/lvmcluster_webhook.go
+++ b/api/v1alpha1/lvmcluster_webhook.go
@@ -304,6 +304,9 @@ func (v *lvmClusterValidator) verifyDeviceClass(l *LVMCluster) (admission.Warnin
 		if deviceClass.Default {
 			countDefault++
 		}
+		if deviceClass.ThinPoolConfig != nil && deviceClass.DeviceAccessPolicy == DeviceAccessPolicyShared {
+			return nil, fmt.Errorf("ThinPoolConfig can not be set when deviceAccessPolicy is set to Shared")
+		}
 	}
 	if countDefault > 1 {
 		return nil, fmt.Errorf("%w. Currently, there are %d default deviceClasses", ErrOnlyOneDefaultDeviceClassAllowed, countDefault)

--- a/api/v1alpha1/lvmvolumegroup_types.go
+++ b/api/v1alpha1/lvmvolumegroup_types.go
@@ -40,6 +40,10 @@ type LVMVolumeGroupSpec struct {
 	// Default is a flag to indicate whether the device-class is the default
 	// +optional
 	Default bool `json:"default,omitempty"`
+
+	// DeviceAccessPolicy defines the policy for accessing the devices
+	// +optional
+	DeviceAccessPolicy DeviceAccessPolicy `json:"deviceAccessPolicy,omitempty"`
 }
 
 // LVMVolumeGroupStatus defines the observed state of LVMVolumeGroup

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,6 +79,7 @@ func NewCmd(setupLog logr.Logger) *cobra.Command {
 		vgmanager.NewCmd(&vgmanager.Options{
 			Scheme:   scheme,
 			SetupLog: setupLog,
+			Metrics:  InitializeMetricsManager(),
 		}),
 	)
 

--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -279,15 +279,16 @@ func run(cmd *cobra.Command, _ []string, opts *Options) error {
 	}
 	csi.RegisterControllerServer(grpcServer, controllerSever)
 
-	if err = mgr.Add(internalCSI.NewGRPCRunner(grpcServer, constants.DefaultCSISocket, false)); err != nil {
+	if err = mgr.Add(internalCSI.NewGRPCRunner(grpcServer, constants.ControllerCSILocalPath, false)); err != nil {
 		return err
 	}
 
 	if err := mgr.Add(internalCSI.NewProvisioner(mgr, internalCSI.ProvisionerOptions{
-		DriverName:          constants.TopolvmCSIDriverName,
-		CSIEndpoint:         constants.DefaultCSISocket,
-		CSIOperationTimeout: 10 * time.Second,
-		Metrics:             opts.Metrics,
+		DriverName:             constants.TopolvmCSIDriverName,
+		CSIEndpoint:            constants.ControllerCSILocalPath,
+		CSIOperationTimeout:    10 * time.Second,
+		Metrics:                opts.Metrics,
+		EnableCapacityTracking: true,
 	})); err != nil {
 		return fmt.Errorf("unable to create CSI Provisioner: %w", err)
 	}
@@ -295,7 +296,7 @@ func run(cmd *cobra.Command, _ []string, opts *Options) error {
 	if enableSnapshotting {
 		if err := mgr.Add(internalCSI.NewSnapshotter(mgr, internalCSI.SnapshotterOptions{
 			DriverName:          constants.TopolvmCSIDriverName,
-			CSIEndpoint:         constants.DefaultCSISocket,
+			CSIEndpoint:         constants.ControllerCSILocalPath,
 			CSIOperationTimeout: 10 * time.Second,
 		})); err != nil {
 			return fmt.Errorf("unable to create CSI Snapshotter: %w", err)
@@ -304,7 +305,7 @@ func run(cmd *cobra.Command, _ []string, opts *Options) error {
 
 	if err := mgr.Add(internalCSI.NewResizer(mgr, internalCSI.ProvisionerOptions{
 		DriverName:          constants.TopolvmCSIDriverName,
-		CSIEndpoint:         constants.DefaultCSISocket,
+		CSIEndpoint:         constants.ControllerCSILocalPath,
 		CSIOperationTimeout: 10 * time.Second,
 	})); err != nil {
 		return err

--- a/cmd/vgmanager/vgmanager.go
+++ b/cmd/vgmanager/vgmanager.go
@@ -29,6 +29,8 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/fsnotify/fsnotify"
 	"github.com/go-logr/logr"
+	"github.com/kubernetes-csi/csi-lib-utils/connection"
+	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"github.com/openshift/lvm-operator/v4/internal/cluster"
 	"github.com/openshift/lvm-operator/v4/internal/controllers/constants"
 	"github.com/openshift/lvm-operator/v4/internal/controllers/lvmcluster/resource"
@@ -48,8 +50,10 @@ import (
 	topoLVMD "github.com/topolvm/topolvm/pkg/lvmd"
 	"github.com/topolvm/topolvm/pkg/runners"
 	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/api/meta"
 	registerapi "k8s.io/kubelet/pkg/apis/pluginregistration/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -83,6 +87,7 @@ type Options struct {
 	healthProbeAddr string
 
 	enableSharedVolumes bool
+	Metrics             *connection.ExtendedCSIMetricsManager
 }
 
 // NewCmd creates a new CLI command
@@ -174,6 +179,42 @@ func run(cmd *cobra.Command, _ []string, opts *Options) error {
 		registerapi.RegisterRegistrationServer(registrationGrpcServer, registration)
 		if err = mgr.Add(internalCSI.NewGRPCRunner(registrationGrpcServer, registration.registrationPath, false)); err != nil {
 			return fmt.Errorf("could not add grpc runner for registration server: %w", err)
+		}
+
+		if err := mgr.Add(internalCSI.NewProvisioner(mgr, internalCSI.ProvisionerOptions{
+			DriverName:          constants.KubeSANCSIDriverName,
+			CSIEndpoint:         constants.ControllerCSILocalPath,
+			CSIOperationTimeout: 10 * time.Second,
+			NodeDeployment: &internalCSI.NodeDeployment{
+				NodeName:        nodeName,
+				NodeCSIEndpoint: kubeSANRegistrationPath(),
+			},
+			ExtraCreateMetadata: true,
+			Metrics:             opts.Metrics,
+		})); err != nil {
+			return fmt.Errorf("unable to create CSI Provisioner: %w", err)
+		}
+
+		enableSnapshotting := true
+		vsc := &snapapi.VolumeSnapshotClassList{}
+		if err := mgr.GetClient().List(ctx, vsc, &client.ListOptions{Limit: 1}); err != nil {
+			// this is necessary in case the VolumeSnapshotClass CRDs are not registered in the Distro, e.g. for OpenShift Local
+			if meta.IsNoMatchError(err) {
+				opts.SetupLog.Info("VolumeSnapshotClasses do not exist on the cluster, ignoring")
+				enableSnapshotting = false
+			}
+		}
+
+		if enableSnapshotting {
+			if err := mgr.Add(internalCSI.NewSnapshotter(mgr, internalCSI.SnapshotterOptions{
+				DriverName:          constants.KubeSANCSIDriverName,
+				CSIEndpoint:         constants.ControllerCSILocalPath,
+				CSIOperationTimeout: 10 * time.Second,
+				LeaderElection:      true,
+				ExtraCreateMetadata: true,
+			})); err != nil {
+				return fmt.Errorf("unable to create CSI Snapshotter: %w", err)
+			}
 		}
 	} else {
 		volumeGroupLock = runner.NewNoneVolumeGroupLock()

--- a/config/crd/bases/kubesan.gitlab.io_blobpools.yaml
+++ b/config/crd/bases/kubesan.gitlab.io_blobpools.yaml
@@ -1,0 +1,46 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: blobpools.kubesan.gitlab.io
+spec:
+  group: kubesan.gitlab.io
+  names:
+    kind: BlobPool
+    plural: blobpools
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - jsonPath: .spec.activeOnNode
+          name: Active On
+          type: string
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [blobs, activeOnNode, holders]
+              properties:
+                blobs:
+                  type: array
+                  items:
+                    type: string
+                activeOnNode:
+                  type: string
+                  nullable: true
+                holders:
+                  type: array
+                  items:
+                    type: object
+                    required: [blob, node, cookie]
+                    properties:
+                      blob:
+                        type: string
+                      node:
+                        type: string
+                      cookie:
+                        type: string

--- a/config/crd/bases/kubesan.gitlab.io_blobpools.yaml
+++ b/config/crd/bases/kubesan.gitlab.io_blobpools.yaml
@@ -1,46 +1,68 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: blobpools.kubesan.gitlab.io
 spec:
   group: kubesan.gitlab.io
   names:
     kind: BlobPool
+    listKind: BlobPoolList
     plural: blobpools
+    singular: blobpool
   scope: Cluster
   versions:
     - name: v1alpha1
-      served: true
-      storage: true
-      additionalPrinterColumns:
-        - jsonPath: .spec.activeOnNode
-          name: Active On
-          type: string
       schema:
         openAPIV3Schema:
-          type: object
-          required: [spec]
           properties:
-            spec:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
               type: object
-              required: [blobs, activeOnNode, holders]
+            spec:
               properties:
+                activeOnNode:
+                  description: The node on which the LVM thin *pool* LV backing this
+                    blob pool is active, if any.
+                  type: string
                 blobs:
-                  type: array
                   items:
                     type: string
-                activeOnNode:
-                  type: string
-                  nullable: true
-                holders:
                   type: array
+                holders:
                   items:
-                    type: object
-                    required: [blob, node, cookie]
                     properties:
                       blob:
                         type: string
-                      node:
-                        type: string
                       cookie:
                         type: string
+                      node:
+                        type: string
+                    required:
+                      - blob
+                      - cookie
+                      - node
+                    type: object
+                  type: array
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true

--- a/config/crd/bases/lvm.topolvm.io_lvmclusters.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmclusters.yaml
@@ -54,6 +54,15 @@ spec:
                             class is the default. You can configure only a single
                             default device class.
                           type: boolean
+                        deviceAccessPolicy:
+                          description: |-
+                            Policy defines the policy for the deviceClass.
+                            DEV PREVIEW: shared will allow accessing the deviceClass from multiple nodes.
+                            The deviceClass will then be configured via shared volume group.
+                          enum:
+                          - shared
+                          - local
+                          type: string
                         deviceSelector:
                           description: DeviceSelector contains the configuration to
                             specify paths to the devices that you want to add to the

--- a/config/crd/bases/lvm.topolvm.io_lvmvolumegroups.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmvolumegroups.yaml
@@ -43,6 +43,10 @@ spec:
                 description: Default is a flag to indicate whether the device-class
                   is the default
                 type: boolean
+              deviceAccessPolicy:
+                description: DeviceAccessPolicy defines the policy for accessing the
+                  devices
+                type: string
               deviceSelector:
                 description: DeviceSelector is a set of rules that should match for
                   a device to be included in this TopoLVMCluster

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - bases/topolvm.io_logicalvolumes.yaml
 - bases/lvm.topolvm.io_lvmvolumegroups.yaml
 - bases/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
+- bases/kubesan.gitlab.io_blobpools.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patches:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,6 +7,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/lvms_dev/lvms-operator
+  newName: quay.io/jmoller/lvms-operator
   newTag: latest
 namePrefix: lvms-

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -86,7 +86,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         volumeMounts:
-          - mountPath: /run/topolvm
+          - mountPath: /run/csi
             name: "socket-dir"
       volumes:
         - name: socket-dir

--- a/config/rbac/kubesan_blobs_clusterrole.yaml
+++ b/config/rbac/kubesan_blobs_clusterrole.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: kubesan-blobs
+  name: blobs
 rules:
   - apiGroups: [""]
     resources: [persistentvolumes]

--- a/config/rbac/kubesan_blobs_clusterrole.yaml
+++ b/config/rbac/kubesan_blobs_clusterrole.yaml
@@ -1,0 +1,23 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubesan-blobs
+rules:
+  - apiGroups: [""]
+    resources: [persistentvolumes]
+    verbs: [get, update]
+  - apiGroups: [""]
+    resources: [services]
+    verbs: [create, delete]
+  - apiGroups: [apps]
+    resources: [replicasets]
+    verbs: [create, delete, get]
+  - apiGroups: [batch]
+    resources: [jobs]
+    verbs: [create, delete, get]
+  - apiGroups: [storage.k8s.io]
+    resources: [storageclasses]
+    verbs: [get, update]
+  - apiGroups: [kubesan.gitlab.io]
+    resources: [blobpools]
+    verbs: [create, delete, get, update]

--- a/config/rbac/kubesan_blobs_clusterrole_binding.yaml
+++ b/config/rbac/kubesan_blobs_clusterrole_binding.yaml
@@ -1,0 +1,18 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubesan-blobs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubesan-blobs
+subjects:
+  - kind: ServiceAccount
+    name: kubesan-csi-controller-plugin
+    namespace: system
+  - kind: ServiceAccount
+    name: kubesan-csi-node-plugin
+    namespace: system
+  - kind: ServiceAccount
+    name: vg-manager
+    namespace: system

--- a/config/rbac/kubesan_blobs_clusterrole_binding.yaml
+++ b/config/rbac/kubesan_blobs_clusterrole_binding.yaml
@@ -1,17 +1,17 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: kubesan-blobs
+  name: blobs
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kubesan-blobs
+  name: blobs
 subjects:
   - kind: ServiceAccount
-    name: kubesan-csi-controller-plugin
+    name: csi-controller-plugin
     namespace: system
   - kind: ServiceAccount
-    name: kubesan-csi-node-plugin
+    name: csi-node-plugin
     namespace: system
   - kind: ServiceAccount
     name: vg-manager

--- a/config/rbac/kubesan_blobs_service_account.yaml
+++ b/config/rbac/kubesan_blobs_service_account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kubesan-blobs
+  name: blobs
   namespace: system

--- a/config/rbac/kubesan_blobs_service_account.yaml
+++ b/config/rbac/kubesan_blobs_service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubesan-blobs
+  namespace: system

--- a/config/rbac/kubesan_controller_service_account.yaml
+++ b/config/rbac/kubesan_controller_service_account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kubesan-csi-controller-plugin
+  name: csi-controller-plugin
   namespace: system

--- a/config/rbac/kubesan_controller_service_account.yaml
+++ b/config/rbac/kubesan_controller_service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubesan-csi-controller-plugin
+  namespace: system

--- a/config/rbac/kubesan_csi_controller_clusterrole.yaml
+++ b/config/rbac/kubesan_csi_controller_clusterrole.yaml
@@ -1,0 +1,11 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubesan-csi-controller
+rules:
+  - apiGroups: [""]
+    resources: [persistentvolumeclaims]
+    verbs: [get]
+  - apiGroups: [batch]
+    resources: [jobs]
+    verbs: [create, delete, get]

--- a/config/rbac/kubesan_csi_controller_clusterrole_binding.yaml
+++ b/config/rbac/kubesan_csi_controller_clusterrole_binding.yaml
@@ -10,3 +10,6 @@ subjects:
   - kind: ServiceAccount
     name: kubesan-csi-controller-plugin
     namespace: system
+  - kind: ServiceAccount
+    name: vg-manager
+    namespace: system

--- a/config/rbac/kubesan_csi_controller_clusterrole_binding.yaml
+++ b/config/rbac/kubesan_csi_controller_clusterrole_binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubesan-csi-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubesan-csi-controller
+subjects:
+  - kind: ServiceAccount
+    name: kubesan-csi-controller-plugin
+    namespace: system

--- a/config/rbac/kubesan_csi_controller_clusterrole_binding.yaml
+++ b/config/rbac/kubesan_csi_controller_clusterrole_binding.yaml
@@ -8,7 +8,7 @@ roleRef:
   name: kubesan-csi-controller
 subjects:
   - kind: ServiceAccount
-    name: kubesan-csi-controller-plugin
+    name: csi-controller-plugin
     namespace: system
   - kind: ServiceAccount
     name: vg-manager

--- a/config/rbac/kubesan_csi_provisioner_clusterrole.yaml
+++ b/config/rbac/kubesan_csi_provisioner_clusterrole.yaml
@@ -1,0 +1,29 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubesan-csi-provisioner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]

--- a/config/rbac/kubesan_csi_provisioner_clusterrole_binding.yaml
+++ b/config/rbac/kubesan_csi_provisioner_clusterrole_binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubesan-csi-provisioner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubesan-csi-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: kubesan-csi-controller-plugin
+    namespace: kubesan

--- a/config/rbac/kubesan_csi_provisioner_clusterrole_binding.yaml
+++ b/config/rbac/kubesan_csi_provisioner_clusterrole_binding.yaml
@@ -10,3 +10,6 @@ subjects:
   - kind: ServiceAccount
     name: kubesan-csi-controller-plugin
     namespace: kubesan
+  - kind: ServiceAccount
+    name: vg-manager
+    namespace: system

--- a/config/rbac/kubesan_csi_provisioner_clusterrole_binding.yaml
+++ b/config/rbac/kubesan_csi_provisioner_clusterrole_binding.yaml
@@ -8,7 +8,7 @@ roleRef:
   name: kubesan-csi-provisioner
 subjects:
   - kind: ServiceAccount
-    name: kubesan-csi-controller-plugin
+    name: csi-controller-plugin
     namespace: kubesan
   - kind: ServiceAccount
     name: vg-manager

--- a/config/rbac/kubesan_csi_snapshotter_clusterrole.yaml
+++ b/config/rbac/kubesan_csi_snapshotter_clusterrole.yaml
@@ -1,0 +1,17 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubesan-csi-snapshotter
+rules:
+  - apiGroups: [""]
+    resources: [events]
+    verbs: [list, watch, create, update, patch]
+  - apiGroups: [snapshot.storage.k8s.io]
+    resources: [volumesnapshotclasses]
+    verbs: [get, list, watch]
+  - apiGroups: [snapshot.storage.k8s.io]
+    resources: [volumesnapshotcontents]
+    verbs: [get, list, watch, update, patch]
+  - apiGroups: [snapshot.storage.k8s.io]
+    resources: [volumesnapshotcontents/status]
+    verbs: [update, patch]

--- a/config/rbac/kubesan_csi_snapshotter_clusterrole_binding.yaml
+++ b/config/rbac/kubesan_csi_snapshotter_clusterrole_binding.yaml
@@ -10,3 +10,6 @@ subjects:
   - kind: ServiceAccount
     name: csi-controller-plugin
     namespace: kubesan
+  - kind: ServiceAccount
+    name: vg-manager
+    namespace: system

--- a/config/rbac/kubesan_csi_snapshotter_clusterrole_binding.yaml
+++ b/config/rbac/kubesan_csi_snapshotter_clusterrole_binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubesan-csi-snapshotter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubesan-csi-snapshotter
+subjects:
+  - kind: ServiceAccount
+    name: csi-controller-plugin
+    namespace: kubesan

--- a/config/rbac/kubesan_nbd_client_service_account.yaml
+++ b/config/rbac/kubesan_nbd_client_service_account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kubesan-nbd-client
+  name: nbd-client
   namespace: system

--- a/config/rbac/kubesan_nbd_client_service_account.yaml
+++ b/config/rbac/kubesan_nbd_client_service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubesan-nbd-client
+  namespace: system

--- a/config/rbac/kubesan_nbd_server_service_account.yaml
+++ b/config/rbac/kubesan_nbd_server_service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubesan-nbd-server
+  namespace: system

--- a/config/rbac/kubesan_nbd_server_service_account.yaml
+++ b/config/rbac/kubesan_nbd_server_service_account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kubesan-nbd-server
+  name: nbd-server
   namespace: system

--- a/config/rbac/kubesan_node_service_account.yaml
+++ b/config/rbac/kubesan_node_service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubesan-csi-node-plugin
+  namespace: system

--- a/config/rbac/kubesan_node_service_account.yaml
+++ b/config/rbac/kubesan_node_service_account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kubesan-csi-node-plugin
+  name: csi-node-plugin
   namespace: system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -22,3 +22,17 @@ resources:
 - vg_manager_clusterrole.yaml
 - vg_manager_clusterrole_binding.yaml
 - vg_manager_service_account.yaml
+
+- kubesan_blobs_clusterrole.yaml
+- kubesan_blobs_clusterrole_binding.yaml
+- kubesan_blobs_service_account.yaml
+- kubesan_controller_service_account.yaml
+- kubesan_csi_controller_clusterrole.yaml
+- kubesan_csi_controller_clusterrole_binding.yaml
+- kubesan_csi_provisioner_clusterrole.yaml
+- kubesan_csi_provisioner_clusterrole_binding.yaml
+- kubesan_csi_snapshotter_clusterrole.yaml
+- kubesan_csi_snapshotter_clusterrole_binding.yaml
+- kubesan_nbd_client_service_account.yaml
+- kubesan_nbd_server_service_account.yaml
+- kubesan_node_service_account.yaml

--- a/config/rbac/vg_manager_clusterrole.yaml
+++ b/config/rbac/vg_manager_clusterrole.yaml
@@ -31,6 +31,7 @@ rules:
     - storage.k8s.io
   resources:
     - csidrivers
+    - volumeattachments
   verbs:
     - get
     - list

--- a/config/rbac/vg_manager_role.yaml
+++ b/config/rbac/vg_manager_role.yaml
@@ -66,3 +66,15 @@ rules:
     - create
     - patch
     - update
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch

--- a/config/rbac/vg_manager_role.yaml
+++ b/config/rbac/vg_manager_role.yaml
@@ -19,6 +19,26 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csistoragecapacities
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - lvm.topolvm.io
   resources:
   - lvmvolumegroups/finalizers

--- a/config/samples/lvm_v1alpha1_lvmcluster.yaml
+++ b/config/samples/lvm_v1alpha1_lvmcluster.yaml
@@ -8,8 +8,7 @@ spec:
     - name: vg1
       default: true
       deviceAccessPolicy: shared
-      thinPoolConfig:
-        name: thin-pool-1
-        sizePercent: 90
-        overprovisionRatio: 10
       fstype: xfs
+      deviceSelector:
+        paths:
+        - /dev/nvme1n1

--- a/config/samples/lvm_v1alpha1_lvmcluster.yaml
+++ b/config/samples/lvm_v1alpha1_lvmcluster.yaml
@@ -7,6 +7,7 @@ spec:
     deviceClasses:
     - name: vg1
       default: true
+      deviceAccessPolicy: shared
       thinPoolConfig:
         name: thin-pool-1
         sizePercent: 90

--- a/hack/appstream.repo
+++ b/hack/appstream.repo
@@ -1,0 +1,7 @@
+[localdev-rhel-9-appstream-rpms]
+name = localdev-rhel-9-appstream-rpms
+id = localdev-rhel-9-appstream-rpms
+baseurl = https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/appstream/os/
+enabled = 1
+gpgcheck = 0
+sslverify=0

--- a/hack/baseos.repo
+++ b/hack/baseos.repo
@@ -1,0 +1,7 @@
+[localdev-rhel-9-baseos-rpms]
+name = localdev-rhel-9-baseos-rpms
+id = localdev-rhel-9-baseos-rpms
+baseurl = https://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.4/x86_64/baseos/os/
+enabled = 1
+gpgcheck = 0
+sslverify=0

--- a/hack/generate-lvmlockd-config.service
+++ b/hack/generate-lvmlockd-config.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Generate lvmlockd config based on IP address
+After=network.target
+Before=lvmlockd.service sanlock.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/lvmlockd_generate.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/hack/generate-lvmlockd-config.service
+++ b/hack/generate-lvmlockd-config.service
@@ -1,10 +1,11 @@
 [Unit]
 Description=Generate lvmlockd config based on IP address
-After=network.target
+After=network-online.target
 Before=lvmlockd.service sanlock.service
 
 [Service]
 Type=oneshot
+ExecStartPre=/bin/sh -c 'until ping -c1 google.com; do sleep 1; done;'
 ExecStart=/usr/bin/lvmlockd_generate.sh
 RemainAfterExit=yes
 

--- a/hack/kubesan-node-adjustment.Containerfile
+++ b/hack/kubesan-node-adjustment.Containerfile
@@ -1,0 +1,17 @@
+# oc adm release info --image-for rhel-coreos on a 4.16 cluster
+FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:eaa7835f2ec7d2513a76e30a41c21ce62ec11313fab2f8f3f46dd4999957a883
+
+ADD ./appstream.repo /etc/yum.repos.d/
+ADD ./baseos.repo /etc/yum.repos.d/
+
+ADD ./lvmlockd_generate.sh /usr/bin/
+RUN chmod +x /usr/bin/lvmlockd_generate.sh
+ADD ./generate-lvmlockd-config.service /etc/systemd/system/
+
+RUN rpm-ostree cliwrap install-to-root / && \
+    rpm-ostree install lvm2-lockd sanlock && \
+    rpm-ostree cleanup -m && \
+    mkdir -p /etc/modules-load.d && echo -e "nbd\ndm-thin-pool" | sudo tee /etc/modules-load.d/kubesan.conf && \
+    mkdir -p /etc/sanlock && echo -e "use_watchdog = 0" | sudo tee /etc/sanlock/sanlock.conf && \
+    systemctl enable generate-lvmlockd-config.service sanlock lvmlockd && \
+    ostree container commit

--- a/hack/kubesan-node-adjustment.Containerfile
+++ b/hack/kubesan-node-adjustment.Containerfile
@@ -13,5 +13,9 @@ RUN rpm-ostree cliwrap install-to-root / && \
     rpm-ostree cleanup -m && \
     mkdir -p /etc/modules-load.d && echo -e "nbd\ndm-thin-pool" | sudo tee /etc/modules-load.d/kubesan.conf && \
     mkdir -p /etc/sanlock && echo -e "use_watchdog = 0" | sudo tee /etc/sanlock/sanlock.conf && \
+    sed -i 's/^[[:space:]]*# use_lvmlockd = 0[[:space:]]*$/use_lvmlockd = 1/' /etc/lvm/lvm.conf && \
     systemctl enable generate-lvmlockd-config.service sanlock lvmlockd && \
     ostree container commit
+
+RUN mkdir -p /etc/systemd/system/sanlock.service.d
+ADD ./sanlock-root-workaround.conf /etc/systemd/system/sanlock.service.d/override.conf

--- a/hack/kubesan.machineconfig.yaml
+++ b/hack/kubesan.machineconfig.yaml
@@ -1,0 +1,8 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: kubesan-enablement-layer
+spec:
+  osImageURL: quay.io/jmoller/node-base-kubesan-patched:v4.16.0

--- a/hack/kubesan.machineconfig.yaml
+++ b/hack/kubesan.machineconfig.yaml
@@ -5,4 +5,4 @@ metadata:
     machineconfiguration.openshift.io/role: worker
   name: kubesan-enablement-layer
 spec:
-  osImageURL: quay.io/jmoller/node-base-kubesan-patched:v4.16.0
+  osImageURL: quay.io/jmoller/node-base-kubesan-patched:v4.16.0-00

--- a/hack/lvmlockd_generate.sh
+++ b/hack/lvmlockd_generate.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Extract the last octet of the IP address
+# Function to convert IP address to a single integer
+ip_to_int() {
+    local IFS=.
+    read -r i1 i2 i3 i4 <<< "$1"
+    echo $(( (i1 << 24) + (i2 << 16) + (i3 << 8) + i4 ))
+}
+
+# Get the IP address
+IP_ADDRESS=$(hostname -I | awk '{print $1}')
+
+# Convert the IP address to an integer
+HOST_ID=$(ip_to_int "$IP_ADDRESS")
+
+# Ensure the host_id is within the range 1-2000
+HOST_ID=$((HOST_ID % 2000 + 1))
+
+# Write the config file
+CONFIG_FILE="/etc/lvm/lvmlocal.conf"
+echo "using host id $HOST_ID based on $IP_ADDRESS"
+echo "local {" > $CONFIG_FILE
+echo "    # The lvmlockd sanlock host_id." >> $CONFIG_FILE
+echo "    # This must be unique among all hosts, and must be between 1 and 2000." >> $CONFIG_FILE
+echo "    host_id = $HOST_ID" >> $CONFIG_FILE
+echo "}" >> $CONFIG_FILE

--- a/hack/multi-attach/multi-attach.go
+++ b/hack/multi-attach/multi-attach.go
@@ -1,0 +1,407 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+const (
+	WorkerNodeRole       = "node-role.kubernetes.io/worker"
+	DefaultAWSPurposeTag = "rh-lvms-testing"
+	DefaultVolumeType    = "io2"
+	DefaultVolumeSizeGB  = 100
+	DefaultVolumeIOPS    = 3000
+	DefaultVolumeName    = "lvms-multiattach-test"
+)
+
+var scheme = runtime.NewScheme()
+
+// This small tool is written to automatically detect all worker nodes
+// in an AWS cluster, then create a volume in EBS based on
+// DefaultVolumeType, DefaultVolumeSizeGB, DefaultVolumeIOPS and DefaultVolumeName
+// and attach it to all worker nodes via multi-attach, simulating a SAN on an AWS node.
+func main() {
+	utilruntime.Must(k8sscheme.AddToScheme(scheme))
+
+	ctrl.SetLogger(zap.New(zap.WriteTo(os.Stdout), zap.UseDevMode(true)))
+
+	ctx := ctrllog.IntoContext(context.Background(), ctrl.Log)
+	logger := ctrllog.FromContext(ctx)
+
+	err := run(ctx)
+
+	if err != nil {
+		logger.Error(err, "Error running multi-attach")
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context) error {
+	// Load Kubernetes configuration
+	config, err := getKubeconfig(os.Getenv("KUBECONFIG"))
+	if err != nil {
+		return fmt.Errorf("could not get kubeconfig: %w", err)
+	}
+
+	// Create Kubernetes clnt
+	clnt, err := client.New(config, client.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("could not create Kubernetes client: %w", err)
+	}
+
+	// List worker nodes
+	nodes := &corev1.NodeList{}
+	if err = clnt.List(ctx, nodes, client.MatchingLabels{WorkerNodeRole: ""}); err != nil {
+		return fmt.Errorf("could not list worker nodes: %w", err)
+	} else if len(nodes.Items) == 0 {
+		return fmt.Errorf("no worker nodes found")
+	}
+
+	awsNodeInfo, err := getAWSNodeInfo(nodes.Items[0])
+	if err != nil {
+		return fmt.Errorf("could not get AWS node info: %w", err)
+	}
+
+	volume, err := getMultiAttachDiskSetupFromNodeList(nodes.Items)
+	if err != nil {
+		return fmt.Errorf("could not get node environment: %w", err)
+	}
+
+	ctrllog.FromContext(ctx).Info("preparing volume", "Node", volume)
+
+	// Load AWS configuration
+	ec2Client, err := getEC2Client(ctx, clnt, awsNodeInfo.Region)
+	if err != nil {
+		return fmt.Errorf("could not get EC2 client: %w", err)
+	}
+
+	diskMan := NewAWSDiskManager(ec2Client)
+
+	if err = diskMan.cleanupAWSDisks(ctx, nodes.Items); err != nil {
+		return fmt.Errorf("could not cleanup AWS disks: %w", err)
+	}
+
+	if err = diskMan.CreateAndAttachAWSVolumes(ctx, []Volume{volume}); err != nil {
+		return fmt.Errorf("could not create and attach AWS volumes: %w", err)
+	}
+
+	return nil
+}
+
+func getEC2Client(ctx context.Context, client client.Client, region string) (*ec2.EC2, error) {
+	logger := ctrllog.FromContext(ctx)
+	// get AWS credentials
+	awsCreds := &corev1.Secret{}
+	secretName := types.NamespacedName{Name: "aws-creds", Namespace: "kube-system"}
+	err := client.Get(ctx, secretName, awsCreds)
+	if err != nil {
+		return nil, fmt.Errorf("could not get aws credentials for EC2 Client: %w", err)
+	}
+	// detect region
+	// base64 decode
+	id, found := awsCreds.Data["aws_access_key_id"]
+	if !found {
+		return nil, fmt.Errorf("cloud credential id not found")
+	}
+	key, found := awsCreds.Data["aws_secret_access_key"]
+	if !found {
+		return nil, fmt.Errorf("cloud credential key not found")
+	}
+	sess, err := session.NewSession(&aws.Config{
+		Region:      aws.String(region),
+		Credentials: credentials.NewStaticCredentials(string(id), string(key), ""),
+		Logger: aws.LoggerFunc(func(args ...interface{}) {
+			logger.Info(fmt.Sprint(args), "source", "aws")
+		}),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not create session for ec2: %w", err)
+	}
+
+	// initialize client
+	return ec2.New(sess), nil
+}
+
+func getKubeconfig(kubeconfig string) (*rest.Config, error) {
+	var config *rest.Config
+	var err error
+	if kubeconfig != "" {
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	} else if config, err = clientcmd.BuildConfigFromKubeconfigGetter("", func() (*api.Config, error) {
+		return clientcmd.NewDefaultClientConfigLoadingRules().Load()
+	}); err != nil {
+		config, err = rest.InClusterConfig()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return config, err
+}
+
+type AWSNodeInfo struct {
+	Name       string
+	InstanceID string
+	Region     string
+	Zone       string
+}
+
+// getAWSNodeInfo returns instanceID, region, zone, error
+func getAWSNodeInfo(node corev1.Node) (AWSNodeInfo, error) {
+	// providerID looks like: aws:///us-east-2a/i-02d314dea14ed4efb
+	if !strings.HasPrefix(node.Spec.ProviderID, "aws://") {
+		return AWSNodeInfo{}, fmt.Errorf("%s is not an aws based Node: %s",
+			node.GetName(), node.Spec.ProviderID)
+	}
+	split := strings.Split(node.Spec.ProviderID, "/")
+	instanceID := split[len(split)-1]
+	zone := split[len(split)-2]
+	region := zone[:len(zone)-1]
+	return AWSNodeInfo{
+		Name:       node.GetName(),
+		InstanceID: instanceID,
+		Region:     region,
+		Zone:       zone,
+	}, nil
+}
+
+type Volume struct {
+	Size  int
+	Nodes []AWSNodeInfo
+}
+
+func getMultiAttachDiskSetupFromNodeList(nodes []corev1.Node) (Volume, error) {
+	vol := Volume{
+		Size: DefaultVolumeSizeGB,
+	}
+
+	for _, node := range nodes {
+		nodeInfo, err := getAWSNodeInfo(node)
+		if err != nil {
+			return Volume{}, fmt.Errorf("could not get node environment: %w", err)
+		}
+		vol.Nodes = append(vol.Nodes, nodeInfo)
+	}
+
+	return vol, nil
+}
+
+type AWSDiskManager struct {
+	ec2                    *ec2.EC2
+	createTimeout          time.Duration
+	createPollingInterval  time.Duration
+	cleanupTimeout         time.Duration
+	cleanupPollingInterval time.Duration
+}
+
+func NewAWSDiskManager(ec2 *ec2.EC2) *AWSDiskManager {
+	return &AWSDiskManager{
+		ec2:                    ec2,
+		createTimeout:          4 * time.Minute,
+		createPollingInterval:  5 * time.Second,
+		cleanupTimeout:         5 * time.Minute,
+		cleanupPollingInterval: 2 * time.Second,
+	}
+}
+
+// CreateAndAttachAWSVolumes assumes that the device spaces /dev/sd[h-z] are available on the node
+// do not provide more than 20 disksize
+// do not use more than once per Node
+// this function is async
+func (m *AWSDiskManager) CreateAndAttachAWSVolumes(ctx context.Context, volumes []Volume) error {
+	for _, disk := range volumes {
+		err := m.createAndAttachAWSVolumesForNodes(ctx, disk)
+		if err != nil {
+			return fmt.Errorf("could not create and attach AWS volume for node: %w", err)
+		}
+	}
+	return nil
+}
+
+func (m *AWSDiskManager) createAndAttachAWSVolumesForNodes(ctx context.Context, volume Volume) error {
+	log := ctrllog.FromContext(ctx).WithValues("nodes", volume.Nodes)
+
+	// create ec2 volumes
+	createInput := &ec2.CreateVolumeInput{
+		AvailabilityZone:   aws.String(volume.Nodes[0].Zone),
+		Size:               aws.Int64(int64(volume.Size)),
+		VolumeType:         aws.String(DefaultVolumeType),
+		Iops:               aws.Int64(DefaultVolumeIOPS),
+		MultiAttachEnabled: aws.Bool(true),
+		TagSpecifications: []*ec2.TagSpecification{
+			{
+				ResourceType: aws.String("volume"),
+				Tags: []*ec2.Tag{
+					{
+						Key:   aws.String("Name"),
+						Value: aws.String(fmt.Sprintf(DefaultVolumeName)),
+					},
+					{
+						Key:   aws.String("purpose"),
+						Value: aws.String(DefaultAWSPurposeTag),
+					},
+				},
+			},
+		},
+	}
+	vol, err := m.ec2.CreateVolumeWithContext(ctx, createInput)
+	if err != nil {
+		return fmt.Errorf("failed to create aws Disks for Nodes %s with %v: %w", volume.Nodes, createInput, err)
+	}
+	log.Info("created volume", "size", volume.Size, "id", vol.VolumeId)
+	// attach and poll for attachment to complete
+	attachments := make([]*ec2.VolumeAttachment, 0, len(volume.Nodes))
+
+	err = wait.PollUntilContextTimeout(ctx, m.createPollingInterval, m.createTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			describeVolumeInput := &ec2.DescribeVolumesInput{
+				VolumeIds: []*string{vol.VolumeId},
+			}
+			vols, err := m.ec2.DescribeVolumesWithContext(ctx, describeVolumeInput)
+			if err != nil {
+				return false, fmt.Errorf("failed to describe volumes to determine attachment completion: %w", err)
+			}
+			if len(vols.Volumes) == 0 {
+				return false, fmt.Errorf("volume not found")
+			}
+
+			for _, node := range volume.Nodes {
+				for _, attachment := range attachments {
+					if *attachment.InstanceId == node.InstanceID {
+						ctrllog.FromContext(ctx).Info("volume already attached to node", "node", node.InstanceID)
+						continue
+					}
+				}
+
+				log := log.WithValues("size", vol.Size, "id", vol.VolumeId)
+				log.Info("volume attachment starting")
+				attachInput := &ec2.AttachVolumeInput{
+					VolumeId:   vol.VolumeId,
+					InstanceId: aws.String(node.InstanceID),
+					Device:     aws.String(fmt.Sprintf("/dev/sdg")),
+				}
+				attachment, err := m.ec2.AttachVolumeWithContext(ctx, attachInput)
+				if err != nil {
+					ctrllog.FromContext(ctx).Info("failed to attach volume, retrying...", "node", node.InstanceID)
+					continue
+				}
+				attachments = append(attachments, attachment)
+			}
+			return len(attachments) == len(volume.Nodes), nil
+		})
+	if err != nil {
+		return fmt.Errorf("failed to wait for volume attachment to complete for nodes %s: %w", volume.Nodes, err)
+	}
+	return nil
+}
+
+func (m *AWSDiskManager) cleanupAWSDisks(ctx context.Context, nodes []corev1.Node) error {
+	logger := ctrllog.FromContext(ctx)
+
+	var awsNodes []AWSNodeInfo
+	for _, node := range nodes {
+		nodeInfo, err := getAWSNodeInfo(node)
+		if err != nil {
+			return fmt.Errorf("could not get node environment: %w", err)
+		}
+		awsNodes = append(awsNodes, nodeInfo)
+	}
+	removed := make([]int, 0, len(awsNodes))
+
+	err := wait.PollUntilContextTimeout(ctx, m.cleanupPollingInterval, m.cleanupTimeout, true, func(ctx context.Context) (bool, error) {
+		volumes, err := m.getAWSTestVolumes(ctx)
+		if err != nil {
+			return false, fmt.Errorf("failed to list AWS volumes for cleanup (deletion): %+v", err)
+		}
+		for _, volume := range volumes {
+			if volume.State == nil {
+				logger.Info("volume did not have a state", "id", volume.VolumeId)
+				return false, nil
+			}
+
+			for i, node := range awsNodes {
+				removedBefore := false
+				for _, removed := range removed {
+					if i == removed {
+						removedBefore = true
+						break
+					}
+				}
+				if removedBefore {
+					continue
+				}
+				if attachment, err := m.ec2.DetachVolumeWithContext(ctx, &ec2.DetachVolumeInput{
+					VolumeId:   volume.VolumeId,
+					InstanceId: aws.String(node.InstanceID),
+				}); err != nil {
+					logger.Error(err, "could not detach volume", "volume_attachment", attachment)
+				}
+				removed = append(removed, i)
+			}
+
+			if len(removed) != len(awsNodes) {
+				logger.Info("not all instances have been detached yet", "remaining", awsNodes)
+				return false, nil
+			}
+
+			if *volume.State != ec2.VolumeStateAvailable {
+				logger.Info("waiting for volume to become available after detach", "desiredState", ec2.VolumeStateAvailable, "currentState", volume.State, "id", volume.VolumeId)
+				return false, nil
+			}
+
+			logger.Info("deleting AWS Volume", "size", volume.Size, "id", volume.VolumeId)
+			if deleteOut, err := m.ec2.DeleteVolumeWithContext(ctx, &ec2.DeleteVolumeInput{VolumeId: volume.VolumeId}); err != nil {
+				logger.Error(err, "could not delete volume", "delete_out", deleteOut)
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed AWS Volume cleanup: %w", err)
+	}
+	return nil
+}
+
+func (m *AWSDiskManager) getAWSTestVolumes(ctx context.Context) ([]*ec2.Volume, error) {
+	output, err := m.ec2.DescribeVolumesWithContext(ctx, &ec2.DescribeVolumesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("tag:purpose"),
+				Values: []*string{aws.String(DefaultAWSPurposeTag)},
+			},
+		},
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to list AWS volumes: %w", err)
+	}
+
+	return output.Volumes, err
+
+}

--- a/hack/sanlock-root-workaround.conf
+++ b/hack/sanlock-root-workaround.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/sanlock daemon -U 0 -G 0

--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -25,11 +25,11 @@ const (
 	KubeSANDomainName    = "gitlab.io"
 	KubeSANCSIDriverName = KubeSANIdentifier + "." + KubeSANDomainName
 
-	KubeSANCSIControllerPluginServiceAccount = "kubesan-csi-controller-plugin"
-	KubeSANCSINodePluginServiceAccount       = "kubesan-csi-node-plugin"
+	KubeSANCSIControllerPluginServiceAccount = "csi-controller-plugin"
+	KubeSANCSINodePluginServiceAccount       = "csi-node-plugin"
 	KubeSANNBDClientServiceAccount           = "nbd-client"
 	KubeSANNBDServerServiceAccount           = "nbd-server"
-	KubeSANBlobsServiceAccount               = "kubesan-blobs"
+	KubeSANBlobsServiceAccount               = "blobs"
 	KubeSANRunDir                            = "/run/kubesan"
 	KubeSANNBDDir                            = KubeSANRunDir + "/nbd"
 	KubeSANImage                             = "quay.io/kubesan/kubesan:latest"

--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -19,6 +19,8 @@ package constants
 const (
 	TopolvmCSIDriverName = "topolvm.io"
 
+	ControllerCSILocalPath = "/run/csi/socket"
+
 	KubeSANIdentifier    = "kubesan"
 	KubeSANDomainName    = "gitlab.io"
 	KubeSANCSIDriverName = KubeSANIdentifier + "." + KubeSANDomainName
@@ -30,7 +32,7 @@ const (
 	KubeSANBlobsServiceAccount               = "kubesan-blobs"
 	KubeSANRunDir                            = "/run/kubesan"
 	KubeSANNBDDir                            = KubeSANRunDir + "/nbd"
-	KubeSANCSILocalPath                      = "/run/csi"
+	KubeSANImage                             = "quay.io/kubesan/kubesan:latest"
 
 	VGManagerServiceAccount = "vg-manager"
 

--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -19,10 +19,25 @@ package constants
 const (
 	TopolvmCSIDriverName = "topolvm.io"
 
+	KubeSANIdentifier    = "kubesan"
+	KubeSANDomainName    = "gitlab.io"
+	KubeSANCSIDriverName = KubeSANIdentifier + "." + KubeSANDomainName
+
+	KubeSANCSIControllerPluginServiceAccount = "kubesan-csi-controller-plugin"
+	KubeSANCSINodePluginServiceAccount       = "kubesan-csi-node-plugin"
+	KubeSANNBDClientServiceAccount           = "kubesan-nbd-client"
+	KubeSANNBDServerServiceAccount           = "kubesan-nbd-server"
+	KubeSANBlobsServiceAccount               = "kubesan-blobs"
+	KubeSANRunDir                            = "/run/kubesan"
+	KubeSANNBDDir                            = KubeSANRunDir + "/nbd"
+	KubeSANCSILocalPath                      = "/run/csi"
+
 	VGManagerServiceAccount = "vg-manager"
 
 	VgManagerMemRequest = "45Mi"
 	VgManagerCPURequest = "5m"
+
+	KubeSANBackingVolumeGroupKey = "backingVolumeGroup"
 
 	// topoLVM Node
 	CSIKubeletRootDir               = "/var/lib/kubelet/"

--- a/internal/controllers/constants/constants.go
+++ b/internal/controllers/constants/constants.go
@@ -27,8 +27,8 @@ const (
 
 	KubeSANCSIControllerPluginServiceAccount = "kubesan-csi-controller-plugin"
 	KubeSANCSINodePluginServiceAccount       = "kubesan-csi-node-plugin"
-	KubeSANNBDClientServiceAccount           = "kubesan-nbd-client"
-	KubeSANNBDServerServiceAccount           = "kubesan-nbd-server"
+	KubeSANNBDClientServiceAccount           = "nbd-client"
+	KubeSANNBDServerServiceAccount           = "nbd-server"
 	KubeSANBlobsServiceAccount               = "kubesan-blobs"
 	KubeSANRunDir                            = "/run/kubesan"
 	KubeSANNBDDir                            = KubeSANRunDir + "/nbd"

--- a/internal/controllers/lvmcluster/controller.go
+++ b/internal/controllers/lvmcluster/controller.go
@@ -204,16 +204,12 @@ func (r *Reconciler) reconcile(ctx context.Context, instance *lvmv1alpha1.LVMClu
 		logger.Info("successfully added finalizer")
 	}
 
-	_, standard := resource.RequiresSharedVolumeGroupSetup(instance.Spec.Storage.DeviceClasses)
-
 	resources := []resource.Manager{
 		resource.CSIDriver(),
 		resource.VGManager(r.ClusterType),
 		resource.StorageClass(),
-	}
-
-	if standard {
-		resources = append(resources, resource.LVMVGs(), resource.LVMVGNodeStatus())
+		resource.LVMVGs(),
+		resource.LVMVGNodeStatus(),
 	}
 
 	if r.ClusterType == cluster.TypeOCP {

--- a/internal/controllers/lvmcluster/controller.go
+++ b/internal/controllers/lvmcluster/controller.go
@@ -204,12 +204,16 @@ func (r *Reconciler) reconcile(ctx context.Context, instance *lvmv1alpha1.LVMClu
 		logger.Info("successfully added finalizer")
 	}
 
+	_, standard := resource.RequiresSharedVolumeGroupSetup(instance.Spec.Storage.DeviceClasses)
+
 	resources := []resource.Manager{
 		resource.CSIDriver(),
 		resource.VGManager(r.ClusterType),
-		resource.LVMVGs(),
-		resource.LVMVGNodeStatus(),
-		resource.TopoLVMStorageClass(),
+		resource.StorageClass(),
+	}
+
+	if standard {
+		resources = append(resources, resource.LVMVGs(), resource.LVMVGNodeStatus())
 	}
 
 	if r.ClusterType == cluster.TypeOCP {
@@ -334,7 +338,7 @@ func (r *Reconciler) logicalVolumesExist(ctx context.Context) (bool, error) {
 func (r *Reconciler) processDelete(ctx context.Context, instance *lvmv1alpha1.LVMCluster) error {
 	if controllerutil.ContainsFinalizer(instance, lvmClusterFinalizer) {
 		resourceDeletionList := []resource.Manager{
-			resource.TopoLVMStorageClass(),
+			resource.StorageClass(),
 			resource.LVMVGs(),
 			resource.LVMVGNodeStatus(),
 			resource.CSIDriver(),

--- a/internal/controllers/lvmcluster/resource/device_policy_util.go
+++ b/internal/controllers/lvmcluster/resource/device_policy_util.go
@@ -1,0 +1,20 @@
+package resource
+
+import (
+	lvmv1alpha1 "github.com/openshift/lvm-operator/v4/api/v1alpha1"
+)
+
+func RequiresSharedVolumeGroupSetup(dcs []lvmv1alpha1.DeviceClass) (
+	shared bool,
+	standard bool,
+) {
+	for _, dc := range dcs {
+		if dc.DeviceAccessPolicy == lvmv1alpha1.DeviceAccessPolicyShared {
+			shared = true
+		}
+		if dc.DeviceAccessPolicy == lvmv1alpha1.DeviceAccessPolicyNodeLocal {
+			standard = true
+		}
+	}
+	return
+}

--- a/internal/controllers/lvmcluster/resource/lvm_volumegroup.go
+++ b/internal/controllers/lvmcluster/resource/lvm_volumegroup.go
@@ -138,10 +138,11 @@ func lvmVolumeGroups(namespace string, deviceClasses []lvmv1alpha1.DeviceClass) 
 				Namespace: namespace,
 			},
 			Spec: lvmv1alpha1.LVMVolumeGroupSpec{
-				NodeSelector:   deviceClass.NodeSelector,
-				DeviceSelector: deviceClass.DeviceSelector,
-				ThinPoolConfig: deviceClass.ThinPoolConfig,
-				Default:        len(deviceClasses) == 1 || deviceClass.Default, // True if there is only one device class or default is explicitly set.
+				NodeSelector:       deviceClass.NodeSelector,
+				DeviceSelector:     deviceClass.DeviceSelector,
+				ThinPoolConfig:     deviceClass.ThinPoolConfig,
+				Default:            len(deviceClasses) == 1 || deviceClass.Default, // True if there is only one device class or default is explicitly set.
+				DeviceAccessPolicy: deviceClass.DeviceAccessPolicy,
 			},
 		}
 		lvmVolumeGroups = append(lvmVolumeGroups, lvmVolumeGroup)

--- a/internal/controllers/lvmcluster/resource/scc.go
+++ b/internal/controllers/lvmcluster/resource/scc.go
@@ -301,7 +301,7 @@ func newKubeSANBlobsScc(namespace string) *secv1.SecurityContextConstraints {
 		},
 	}
 
-	scc.Name = constants.SCCPrefix + "kubesan-blobs"
+	scc.Name = constants.SCCPrefix + "blobs"
 	scc.AllowPrivilegedContainer = true
 	scc.AllowHostNetwork = false
 	scc.AllowHostDirVolumePlugin = true

--- a/internal/controllers/lvmcluster/resource/scc.go
+++ b/internal/controllers/lvmcluster/resource/scc.go
@@ -245,6 +245,7 @@ func newNBDClientScc(namespace string) *secv1.SecurityContextConstraints {
 	}
 	scc.Users = []string{
 		fmt.Sprintf("system:serviceaccount:%s:%s", namespace, constants.KubeSANNBDClientServiceAccount),
+		fmt.Sprintf("system:serviceaccount:%s:%s", namespace, constants.VGManagerServiceAccount),
 	}
 
 	return scc
@@ -285,7 +286,8 @@ func newNBDServerScc(namespace string) *secv1.SecurityContextConstraints {
 		secv1.FSTypeSecret,
 	}
 	scc.Users = []string{
-		fmt.Sprintf("system:serviceaccount:%s:%s", namespace, constants.KubeSANNBDClientServiceAccount),
+		fmt.Sprintf("system:serviceaccount:%s:%s", namespace, constants.KubeSANNBDServerServiceAccount),
+		fmt.Sprintf("system:serviceaccount:%s:%s", namespace, constants.VGManagerServiceAccount),
 	}
 
 	return scc
@@ -327,6 +329,7 @@ func newKubeSANBlobsScc(namespace string) *secv1.SecurityContextConstraints {
 	}
 	scc.Users = []string{
 		fmt.Sprintf("system:serviceaccount:%s:%s", namespace, constants.KubeSANBlobsServiceAccount),
+		fmt.Sprintf("system:serviceaccount:%s:%s", namespace, constants.VGManagerServiceAccount),
 	}
 
 	return scc

--- a/internal/controllers/lvmcluster/resource/topolvm_csi_driver.go
+++ b/internal/controllers/lvmcluster/resource/topolvm_csi_driver.go
@@ -126,7 +126,7 @@ func getCSIDriverResources(cluster *lvmv1alpha1.LVMCluster) []*storagev1.CSIDriv
 			Spec: storagev1.CSIDriverSpec{
 				AttachRequired:       &attachRequired,
 				PodInfoOnMount:       &podInfoOnMount,
-				StorageCapacity:      ptr.To(true),
+				StorageCapacity:      ptr.To(false),
 				VolumeLifecycleModes: []storagev1.VolumeLifecycleMode{storagev1.VolumeLifecyclePersistent},
 			},
 		})

--- a/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
+++ b/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
@@ -75,9 +75,18 @@ var (
 				),
 				Type: &HostPathDirectoryOrCreate}},
 	}
-	KubeSANCSIPluginVolMount = corev1.VolumeMount{
+	KubeSANCSIPluginLocalVolMount = corev1.VolumeMount{
 		Name:             KubeSANCSIPluginVolName,
 		MountPath:        fmt.Sprintf("/run/csi"),
+		MountPropagation: &mountPropagationBidirectional,
+	}
+	KubeSANCSIPluginVolMount = corev1.VolumeMount{
+		Name: KubeSANCSIPluginVolName,
+		MountPath: fmt.Sprintf(
+			"%splugins/%s",
+			GetAbsoluteKubeletPath(constants.CSIKubeletRootDir),
+			constants.KubeSANCSIDriverName,
+		),
 		MountPropagation: &mountPropagationBidirectional,
 	}
 )
@@ -93,6 +102,21 @@ var (
 	}
 	TopoLVMNodePluginVolMount = corev1.VolumeMount{
 		Name: TopoLVMNodePluginVolName, MountPath: filepath.Dir(constants.DefaultCSISocket),
+	}
+)
+
+var (
+	KubeSANNodeLocalControllerSocketVolName = "kubesan-node-local-controller-socket"
+	KubeSANNodeLocalControllerSocketVol     = corev1.Volume{
+		Name: KubeSANNodeLocalControllerSocketVolName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{
+				Medium: corev1.StorageMediumMemory,
+			},
+		},
+	}
+	KubeSANNodeLocalControllerSocketVolMount = corev1.VolumeMount{
+		Name: KubeSANNodeLocalControllerSocketVolName, MountPath: filepath.Dir(constants.ControllerCSILocalPath),
 	}
 )
 
@@ -268,7 +292,7 @@ func templateVGManagerDaemonset(
 	}
 
 	if shared {
-		volumes = append(volumes, KubeSANNBDPluginVol, KubeSANCSIPluginVol)
+		volumes = append(volumes, KubeSANNBDPluginVol, KubeSANCSIPluginVol, KubeSANNodeLocalControllerSocketVol)
 	}
 
 	volumeMounts := []corev1.VolumeMount{
@@ -286,7 +310,7 @@ func templateVGManagerDaemonset(
 	}
 
 	if shared {
-		volumeMounts = append(volumeMounts, KubeSANCSIPluginVolMount)
+		volumeMounts = append(volumeMounts, KubeSANCSIPluginVolMount, KubeSANNodeLocalControllerSocketVolMount)
 	}
 
 	if len(command) == 0 {
@@ -383,23 +407,50 @@ func templateVGManagerDaemonset(
 	}
 
 	if shared {
-		kubesanVolumeMounts := []corev1.VolumeMount{
-			KubeSANCSIPluginVolMount,
+		kubeSANNodeVolumeMounts := []corev1.VolumeMount{
+			KubeSANCSIPluginLocalVolMount,
 			KubeSANNBDPluginMount,
 		}
-		img := "quay.io/kubesan/kubesan:latest"
 		containers = append(containers, corev1.Container{
-			Name:    "kubesan-csi-plugin",
-			Image:   img,
+			Name:    "kubesan-csi-node-plugin",
+			Image:   constants.KubeSANImage,
 			Command: []string{"./kubesan", "csi-node-plugin"},
 			SecurityContext: &corev1.SecurityContext{
 				Privileged: ptr.To(true),
 			},
-			VolumeMounts: kubesanVolumeMounts,
+			VolumeMounts: kubeSANNodeVolumeMounts,
 			Env: []corev1.EnvVar{
 				{
 					Name:  "KUBESAN_IMAGE",
-					Value: img,
+					Value: constants.KubeSANImage,
+				},
+				{
+					Name: "NODE_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "spec.nodeName",
+						},
+					},
+				},
+			},
+		})
+
+		kubeSANControllerVolumeMounts := []corev1.VolumeMount{
+			DevHostDirVolMount,
+			KubeSANNodeLocalControllerSocketVolMount,
+		}
+		containers = append(containers, corev1.Container{
+			Name:    "kubesan-csi-controller-plugin",
+			Image:   constants.KubeSANImage,
+			Command: []string{"./kubesan", "csi-controller-plugin"},
+			SecurityContext: &corev1.SecurityContext{
+				Privileged: ptr.To(true),
+			},
+			VolumeMounts: kubeSANControllerVolumeMounts,
+			Env: []corev1.EnvVar{
+				{
+					Name:  "KUBESAN_IMAGE",
+					Value: constants.KubeSANImage,
 				},
 				{
 					Name: "NODE_NAME",

--- a/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
+++ b/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
@@ -414,7 +414,7 @@ func templateVGManagerDaemonset(
 			CSIPluginVolMount,
 		}
 		containers = append(containers, corev1.Container{
-			Name:    "kubesan-csi-node-plugin",
+			Name:    "csi-node-plugin",
 			Image:   constants.KubeSANImage,
 			Command: []string{"./kubesan", "csi-node-plugin"},
 			SecurityContext: &corev1.SecurityContext{
@@ -450,7 +450,7 @@ func templateVGManagerDaemonset(
 			KubeSANNodeLocalControllerSocketVolMount,
 		}
 		containers = append(containers, corev1.Container{
-			Name:    "kubesan-csi-controller-plugin",
+			Name:    "csi-controller-plugin",
 			Image:   constants.KubeSANImage,
 			Command: []string{"./kubesan", "csi-controller-plugin"},
 			SecurityContext: &corev1.SecurityContext{

--- a/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
+++ b/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
@@ -281,6 +281,7 @@ func templateVGManagerDaemonset(
 		UDevHostDirVol,
 		SysHostDirVol,
 		MetricsCertsDirVol,
+		CSIPluginVol,
 	}
 
 	if standard {
@@ -288,7 +289,7 @@ func templateVGManagerDaemonset(
 		if clusterType == cluster.TypeMicroShift {
 			confMapVolume.VolumeSource.HostPath.Path = filepath.Dir(lvmd.MicroShiftFileConfigPath)
 		}
-		volumes = append(volumes, TopoLVMNodePluginVol, confMapVolume, CSIPluginVol)
+		volumes = append(volumes, TopoLVMNodePluginVol, confMapVolume)
 	}
 
 	if shared {
@@ -410,6 +411,7 @@ func templateVGManagerDaemonset(
 		kubeSANNodeVolumeMounts := []corev1.VolumeMount{
 			KubeSANCSIPluginLocalVolMount,
 			KubeSANNBDPluginMount,
+			CSIPluginVolMount,
 		}
 		containers = append(containers, corev1.Container{
 			Name:    "kubesan-csi-node-plugin",
@@ -423,6 +425,14 @@ func templateVGManagerDaemonset(
 				{
 					Name:  "KUBESAN_IMAGE",
 					Value: constants.KubeSANImage,
+				},
+				{
+					Name: "NAMESPACE",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.namespace",
+						},
+					},
 				},
 				{
 					Name: "NODE_NAME",
@@ -451,6 +461,14 @@ func templateVGManagerDaemonset(
 				{
 					Name:  "KUBESAN_IMAGE",
 					Value: constants.KubeSANImage,
+				},
+				{
+					Name: "NAMESPACE",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.namespace",
+						},
+					},
 				},
 				{
 					Name: "NODE_NAME",

--- a/internal/controllers/vgmanager/controller.go
+++ b/internal/controllers/vgmanager/controller.go
@@ -203,6 +203,17 @@ func (r *Reconciler) reconcile(
 	for _, vg := range vgs {
 		if volumeGroup.Name == vg.Name {
 			vgExistsInLVM = true
+
+			if volumeGroup.Spec.DeviceAccessPolicy == lvmv1alpha1.DeviceAccessPolicyShared {
+				// If we are dealing with a shared volume group, we need to check if the volume group is already in use
+				// by another node. If it is, we need to wait until the other node has finished using it.
+				logger.Info("shared volume group detected, attempting lock space start...", "VGName", vg.Name)
+				if err := r.LVM.LockStart(ctx, vg.Name); err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to start shared lockspace %s: %w", vg.Name, err)
+				}
+				logger.Info("shared lockspace started", "VGName", vg.Name)
+			}
+
 			break
 		}
 	}

--- a/internal/controllers/vgmanager/devices.go
+++ b/internal/controllers/vgmanager/devices.go
@@ -30,8 +30,9 @@ import (
 )
 
 // addDevicesToVG creates or extends a volume group using the provided devices.
-func (r *Reconciler) addDevicesToVG(ctx context.Context, vgs []lvm.VolumeGroup, vgName string, devices []lsblk.BlockDevice) error {
+func (r *Reconciler) addDevicesToVG(ctx context.Context, vgs []lvm.VolumeGroup, vg *lvmv1alpha1.LVMVolumeGroup, devices []lsblk.BlockDevice) error {
 	logger := log.FromContext(ctx)
+	vgName := vg.Name
 
 	if len(devices) < 1 {
 		return fmt.Errorf("can't create vg %q with 0 devices", vgName)
@@ -65,7 +66,12 @@ func (r *Reconciler) addDevicesToVG(ctx context.Context, vgs []lvm.VolumeGroup, 
 		for _, pvName := range args {
 			pvs = append(pvs, lvm.PhysicalVolume{PvName: pvName})
 		}
-		if err := r.LVM.CreateVG(ctx, lvm.VolumeGroup{Name: vgName, PVs: pvs}); err != nil {
+		if err := r.LVM.CreateVG(ctx, lvm.VolumeGroup{Name: vgName, PVs: pvs}, lvm.CreateVGOptions{
+			lvm.SharedVGOptions{
+				DeviceAccessPolicy:  vg.Spec.DeviceAccessPolicy,
+				OwnsGlobalLockSpace: r.IsSharedVGLeader,
+			},
+		}); err != nil {
 			return fmt.Errorf("failed to create volume group %s: %w", vgName, err)
 		}
 	}

--- a/internal/controllers/vgmanager/exec/exec.go
+++ b/internal/controllers/vgmanager/exec/exec.go
@@ -80,7 +80,7 @@ func (e *CommandExecutor) RunCommandAsHostInto(ctx context.Context, into any, co
 func (*CommandExecutor) StartCommandWithOutputAsHost(ctx context.Context, command string, arg ...string) (io.ReadCloser, error) {
 	args := append([]string{"-m", "-u", "-i", "-n", "-p", "-t", "1", command}, arg...)
 	cmd := exec.Command(nsenterPath, args...)
-	log.FromContext(ctx).V(1).Info("executing", "command", cmd.String())
+	log.FromContext(ctx).Info("executing", "command", cmd.String())
 	return runCommandWithOutput(cmd)
 }
 

--- a/internal/controllers/vgmanager/lv_attr.go
+++ b/internal/controllers/vgmanager/lv_attr.go
@@ -72,13 +72,16 @@ const (
 	StateMappedDevicePresentWithoutTables      State = 'd'
 	StateMappedDevicePresentWithInactiveTables State = 'i'
 	StateNone                                  State = '-'
+	StateUnknown                               State = 'X'
+	StateCheckNeeded                           State = 'c'
 )
 
 type Open rune
 
 const (
-	OpenTrue  Open = 'o'
-	OpenFalse Open = '-'
+	OpenTrue    Open = 'o'
+	OpenFalse   Open = '-'
+	OpenUnknown Open = 'X'
 )
 
 type OpenTarget rune

--- a/internal/controllers/vgmanager/lvm/lvm.go
+++ b/internal/controllers/vgmanager/lvm/lvm.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openshift/lvm-operator/v4/api/v1alpha1"
 	"github.com/openshift/lvm-operator/v4/internal/controllers/vgmanager/exec"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var (
@@ -70,6 +72,7 @@ type VGReport struct {
 			Name   string `json:"vg_name"`
 			VgSize string `json:"vg_size"`
 			Tags   string `json:"vg_tags"`
+			VgAttr string `json:"vg_attr"`
 		} `json:"vg"`
 	} `json:"report"`
 }
@@ -100,15 +103,32 @@ type LogicalVolume struct {
 	ChunkSize       string `json:"chunk_size"`
 }
 
+type SharedVGOptions struct {
+	v1alpha1.DeviceAccessPolicy
+	OwnsGlobalLockSpace func() bool
+}
+
+type CreateVGOptions struct {
+	SharedVGOptions
+}
+
+type DeleteVGOptions struct {
+	SharedVGOptions
+}
+
+type ListVGOptions struct {
+	VGName string
+}
+
 type LVM interface {
-	CreateVG(ctx context.Context, vg VolumeGroup) error
+	CreateVG(ctx context.Context, vg VolumeGroup, opts CreateVGOptions) error
 	ExtendVG(ctx context.Context, vg VolumeGroup, pvs []string) (VolumeGroup, error)
 	AddTagToVG(ctx context.Context, vgName string) error
-	DeleteVG(ctx context.Context, vg VolumeGroup) error
+	DeleteVG(ctx context.Context, vg VolumeGroup, opts DeleteVGOptions) error
 	GetVG(ctx context.Context, name string) (VolumeGroup, error)
 
 	ListPVs(ctx context.Context, vgName string) ([]PhysicalVolume, error)
-	ListVGs(ctx context.Context, taggedByLVMS bool) ([]VolumeGroup, error)
+	ListVGs(ctx context.Context, taggedByLVMS bool, opts ListVGOptions) ([]VolumeGroup, error)
 	ListLVsByName(ctx context.Context, vgName string) ([]string, error)
 	ListLVs(ctx context.Context, vgName string) (*LVReport, error)
 
@@ -144,6 +164,8 @@ type VolumeGroup struct {
 
 	// Tags is the list of tags associated with the volume group
 	Tags []string `json:"vg_tags"`
+
+	VgAttr string `json:"vg_attr"`
 }
 
 // PhysicalVolume represents a physical volume of linux lvm.
@@ -174,7 +196,7 @@ type PhysicalVolume struct {
 }
 
 // CreateVG creates a new volume group
-func (hlvm *HostLVM) CreateVG(ctx context.Context, vg VolumeGroup) error {
+func (hlvm *HostLVM) CreateVG(ctx context.Context, vg VolumeGroup, opts CreateVGOptions) error {
 	if vg.Name == "" {
 		return fmt.Errorf("failed to create volume group: volume group name is empty")
 	}
@@ -184,6 +206,23 @@ func (hlvm *HostLVM) CreateVG(ctx context.Context, vg VolumeGroup) error {
 	}
 
 	args := []string{vg.Name, "--addtag", lvmsTag}
+
+	if opts.DeviceAccessPolicy == v1alpha1.DeviceAccessPolicyShared {
+		for _, pv := range vg.PVs {
+			if err := hlvm.RunCommandAsHost(ctx, lvmDevicesCmd, "--adddev", pv.PvName); err != nil {
+				return fmt.Errorf("failed to add PV %s to device file: %w", pv.UUID, err)
+			}
+		}
+
+		if opts.OwnsGlobalLockSpace() {
+			args = append(args, "--shared")
+		} else {
+			log.FromContext(ctx).Info("Skipping shared VG Creation as another node is the lockspace owner.")
+			// If the global lockspace is not present (vg doesn't exist) and we are not the leader,
+			// we need to skip the VG Creation
+			return nil
+		}
+	}
 
 	for _, pv := range vg.PVs {
 		args = append(args, pv.PvName)
@@ -236,11 +275,18 @@ func (hlvm *HostLVM) AddTagToVG(ctx context.Context, vgName string) error {
 }
 
 // DeleteVG deletes a volume group and the physical volumes associated with it
-func (hlvm *HostLVM) DeleteVG(ctx context.Context, vg VolumeGroup) error {
+func (hlvm *HostLVM) DeleteVG(ctx context.Context, vg VolumeGroup, opts DeleteVGOptions) error {
 	// Deactivate Volume Group
 	vgArgs := []string{"-an", vg.Name}
 	if err := hlvm.RunCommandAsHost(ctx, vgChangeCmd, vgArgs...); err != nil {
 		return fmt.Errorf("failed to remove volume group %q: %w", vg.Name, err)
+	}
+
+	if opts.DeviceAccessPolicy == v1alpha1.DeviceAccessPolicyShared && !opts.OwnsGlobalLockSpace() {
+		if err := hlvm.RunCommandAsHost(ctx, vgChangeCmd, vg.Name, "--lock-stop"); err != nil {
+			return fmt.Errorf("failed to stop lock for shared volume group %q: %w", vg.Name, err)
+		}
+		return nil
 	}
 
 	// Remove Volume Group
@@ -274,40 +320,20 @@ func (hlvm *HostLVM) DeleteVG(ctx context.Context, vg VolumeGroup) error {
 
 // GetVG returns a volume group along with the associated physical volumes
 func (hlvm *HostLVM) GetVG(ctx context.Context, name string) (VolumeGroup, error) {
-	res := new(VGReport)
-
-	args := []string{
-		lvmsTag, "--units", "g", "--reportformat", "json",
-	}
-	if err := hlvm.RunCommandAsHostInto(ctx, res, vgsCmd, args...); err != nil {
-		return VolumeGroup{}, fmt.Errorf("failed to list volume groups. %v", err)
-	}
-
-	vgFound := false
-	volumeGroup := VolumeGroup{}
-	for _, report := range res.Report {
-		for _, vg := range report.Vg {
-			if vg.Name == name {
-				volumeGroup.Name = vg.Name
-				volumeGroup.VgSize = vg.VgSize
-				vgFound = true
-				break
-			}
-		}
-	}
-
-	if !vgFound {
+	vgs, err := hlvm.ListVGs(ctx, false, ListVGOptions{
+		VGName: name,
+	})
+	if len(vgs) == 0 {
 		return VolumeGroup{}, ErrVolumeGroupNotFound
 	}
-
-	// Get Physical Volumes associated with the Volume Group
-	pvs, err := hlvm.ListPVs(ctx, name)
-	if err != nil {
-		return VolumeGroup{}, fmt.Errorf("failed to list physical volumes for volume group %q. %v", name, err)
+	if len(vgs) > 1 {
+		return VolumeGroup{}, fmt.Errorf("multiple volume groups found with the name %q", name)
 	}
-
-	volumeGroup.PVs = pvs
-	return volumeGroup, nil
+	if err, ok := exec.AsExecError(err); ok && strings.Contains(err.Error(),
+		fmt.Sprintf("Volume group %q not found", name)) {
+		return VolumeGroup{}, ErrVolumeGroupNotFound
+	}
+	return vgs[0], err
 }
 
 // ListPVs returns list of physical volumes used to create the given volume group
@@ -342,12 +368,17 @@ func (hlvm *HostLVM) ListPVs(ctx context.Context, vgName string) ([]PhysicalVolu
 }
 
 // ListVGs lists all volume groups and the physical volumes associated with them.
-func (hlvm *HostLVM) ListVGs(ctx context.Context, tagged bool) ([]VolumeGroup, error) {
+func (hlvm *HostLVM) ListVGs(ctx context.Context, tagged bool, opts ListVGOptions) ([]VolumeGroup, error) {
 	res := new(VGReport)
 
 	args := []string{
 		"-o", "vg_name,vg_size,vg_tags", "--units", "g", "--reportformat", "json",
 	}
+
+	if opts.VGName != "" {
+		args = append(args, opts.VGName)
+	}
+
 	if tagged {
 		args = append(args, lvmsTag)
 	}
@@ -364,6 +395,7 @@ func (hlvm *HostLVM) ListVGs(ctx context.Context, tagged bool) ([]VolumeGroup, e
 				VgSize: vg.VgSize,
 				PVs:    []PhysicalVolume{},
 				Tags:   strings.Split(vg.Tags, ","),
+				VgAttr: vg.VgAttr,
 			})
 		}
 	}

--- a/internal/controllers/vgmanager/lvm/lvm.go
+++ b/internal/controllers/vgmanager/lvm/lvm.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/openshift/lvm-operator/v4/api/v1alpha1"
 	"github.com/openshift/lvm-operator/v4/internal/controllers/vgmanager/exec"
@@ -233,16 +232,6 @@ func (hlvm *HostLVM) CreateVG(ctx context.Context, vg VolumeGroup, opts CreateVG
 
 	if err := hlvm.RunCommandAsHost(ctx, vgCreateCmd, args...); err != nil {
 		return fmt.Errorf("failed to create volume group %q. %v", vg.Name, err)
-	}
-
-	if opts.DeviceAccessPolicy == v1alpha1.DeviceAccessPolicyShared {
-		start := time.Now()
-		logger := log.FromContext(ctx).WithValues("VolumeGroup", vg.Name)
-		logger.Info("shared volume group created, attempting lock space start...")
-		if err := hlvm.LockStart(ctx, vg.Name); err != nil {
-			return fmt.Errorf("failed to start lock for shared volume group %q after creation: %w", vg.Name, err)
-		}
-		logger.Info("lock space started successfully", "duration", time.Since(start))
 	}
 
 	return nil

--- a/internal/controllers/vgmanager/lvm/mocks/mock_lvm.go
+++ b/internal/controllers/vgmanager/lvm/mocks/mock_lvm.go
@@ -167,17 +167,17 @@ func (_c *MockLVM_CreateLV_Call) RunAndReturn(run func(context.Context, string, 
 	return _c
 }
 
-// CreateVG provides a mock function with given fields: ctx, vg
-func (_m *MockLVM) CreateVG(ctx context.Context, vg lvm.VolumeGroup) error {
-	ret := _m.Called(ctx, vg)
+// CreateVG provides a mock function with given fields: ctx, vg, opts
+func (_m *MockLVM) CreateVG(ctx context.Context, vg lvm.VolumeGroup, opts lvm.CreateVGOptions) error {
+	ret := _m.Called(ctx, vg, opts)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateVG")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, lvm.VolumeGroup) error); ok {
-		r0 = rf(ctx, vg)
+	if rf, ok := ret.Get(0).(func(context.Context, lvm.VolumeGroup, lvm.CreateVGOptions) error); ok {
+		r0 = rf(ctx, vg, opts)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -193,13 +193,14 @@ type MockLVM_CreateVG_Call struct {
 // CreateVG is a helper method to define mock.On call
 //   - ctx context.Context
 //   - vg lvm.VolumeGroup
-func (_e *MockLVM_Expecter) CreateVG(ctx interface{}, vg interface{}) *MockLVM_CreateVG_Call {
-	return &MockLVM_CreateVG_Call{Call: _e.mock.On("CreateVG", ctx, vg)}
+//   - opts lvm.CreateVGOptions
+func (_e *MockLVM_Expecter) CreateVG(ctx interface{}, vg interface{}, opts interface{}) *MockLVM_CreateVG_Call {
+	return &MockLVM_CreateVG_Call{Call: _e.mock.On("CreateVG", ctx, vg, opts)}
 }
 
-func (_c *MockLVM_CreateVG_Call) Run(run func(ctx context.Context, vg lvm.VolumeGroup)) *MockLVM_CreateVG_Call {
+func (_c *MockLVM_CreateVG_Call) Run(run func(ctx context.Context, vg lvm.VolumeGroup, opts lvm.CreateVGOptions)) *MockLVM_CreateVG_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(lvm.VolumeGroup))
+		run(args[0].(context.Context), args[1].(lvm.VolumeGroup), args[2].(lvm.CreateVGOptions))
 	})
 	return _c
 }
@@ -209,7 +210,7 @@ func (_c *MockLVM_CreateVG_Call) Return(_a0 error) *MockLVM_CreateVG_Call {
 	return _c
 }
 
-func (_c *MockLVM_CreateVG_Call) RunAndReturn(run func(context.Context, lvm.VolumeGroup) error) *MockLVM_CreateVG_Call {
+func (_c *MockLVM_CreateVG_Call) RunAndReturn(run func(context.Context, lvm.VolumeGroup, lvm.CreateVGOptions) error) *MockLVM_CreateVG_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -262,17 +263,17 @@ func (_c *MockLVM_DeleteLV_Call) RunAndReturn(run func(context.Context, string, 
 	return _c
 }
 
-// DeleteVG provides a mock function with given fields: ctx, vg
-func (_m *MockLVM) DeleteVG(ctx context.Context, vg lvm.VolumeGroup) error {
-	ret := _m.Called(ctx, vg)
+// DeleteVG provides a mock function with given fields: ctx, vg, opts
+func (_m *MockLVM) DeleteVG(ctx context.Context, vg lvm.VolumeGroup, opts lvm.DeleteVGOptions) error {
+	ret := _m.Called(ctx, vg, opts)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteVG")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, lvm.VolumeGroup) error); ok {
-		r0 = rf(ctx, vg)
+	if rf, ok := ret.Get(0).(func(context.Context, lvm.VolumeGroup, lvm.DeleteVGOptions) error); ok {
+		r0 = rf(ctx, vg, opts)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -288,13 +289,14 @@ type MockLVM_DeleteVG_Call struct {
 // DeleteVG is a helper method to define mock.On call
 //   - ctx context.Context
 //   - vg lvm.VolumeGroup
-func (_e *MockLVM_Expecter) DeleteVG(ctx interface{}, vg interface{}) *MockLVM_DeleteVG_Call {
-	return &MockLVM_DeleteVG_Call{Call: _e.mock.On("DeleteVG", ctx, vg)}
+//   - opts lvm.DeleteVGOptions
+func (_e *MockLVM_Expecter) DeleteVG(ctx interface{}, vg interface{}, opts interface{}) *MockLVM_DeleteVG_Call {
+	return &MockLVM_DeleteVG_Call{Call: _e.mock.On("DeleteVG", ctx, vg, opts)}
 }
 
-func (_c *MockLVM_DeleteVG_Call) Run(run func(ctx context.Context, vg lvm.VolumeGroup)) *MockLVM_DeleteVG_Call {
+func (_c *MockLVM_DeleteVG_Call) Run(run func(ctx context.Context, vg lvm.VolumeGroup, opts lvm.DeleteVGOptions)) *MockLVM_DeleteVG_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(lvm.VolumeGroup))
+		run(args[0].(context.Context), args[1].(lvm.VolumeGroup), args[2].(lvm.DeleteVGOptions))
 	})
 	return _c
 }
@@ -304,7 +306,7 @@ func (_c *MockLVM_DeleteVG_Call) Return(_a0 error) *MockLVM_DeleteVG_Call {
 	return _c
 }
 
-func (_c *MockLVM_DeleteVG_Call) RunAndReturn(run func(context.Context, lvm.VolumeGroup) error) *MockLVM_DeleteVG_Call {
+func (_c *MockLVM_DeleteVG_Call) RunAndReturn(run func(context.Context, lvm.VolumeGroup, lvm.DeleteVGOptions) error) *MockLVM_DeleteVG_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -708,9 +710,9 @@ func (_c *MockLVM_ListPVs_Call) RunAndReturn(run func(context.Context, string) (
 	return _c
 }
 
-// ListVGs provides a mock function with given fields: ctx, taggedByLVMS
-func (_m *MockLVM) ListVGs(ctx context.Context, taggedByLVMS bool) ([]lvm.VolumeGroup, error) {
-	ret := _m.Called(ctx, taggedByLVMS)
+// ListVGs provides a mock function with given fields: ctx, taggedByLVMS, opts
+func (_m *MockLVM) ListVGs(ctx context.Context, taggedByLVMS bool, opts lvm.ListVGOptions) ([]lvm.VolumeGroup, error) {
+	ret := _m.Called(ctx, taggedByLVMS, opts)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListVGs")
@@ -718,19 +720,19 @@ func (_m *MockLVM) ListVGs(ctx context.Context, taggedByLVMS bool) ([]lvm.Volume
 
 	var r0 []lvm.VolumeGroup
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, bool) ([]lvm.VolumeGroup, error)); ok {
-		return rf(ctx, taggedByLVMS)
+	if rf, ok := ret.Get(0).(func(context.Context, bool, lvm.ListVGOptions) ([]lvm.VolumeGroup, error)); ok {
+		return rf(ctx, taggedByLVMS, opts)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, bool) []lvm.VolumeGroup); ok {
-		r0 = rf(ctx, taggedByLVMS)
+	if rf, ok := ret.Get(0).(func(context.Context, bool, lvm.ListVGOptions) []lvm.VolumeGroup); ok {
+		r0 = rf(ctx, taggedByLVMS, opts)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]lvm.VolumeGroup)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, bool) error); ok {
-		r1 = rf(ctx, taggedByLVMS)
+	if rf, ok := ret.Get(1).(func(context.Context, bool, lvm.ListVGOptions) error); ok {
+		r1 = rf(ctx, taggedByLVMS, opts)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -746,13 +748,14 @@ type MockLVM_ListVGs_Call struct {
 // ListVGs is a helper method to define mock.On call
 //   - ctx context.Context
 //   - taggedByLVMS bool
-func (_e *MockLVM_Expecter) ListVGs(ctx interface{}, taggedByLVMS interface{}) *MockLVM_ListVGs_Call {
-	return &MockLVM_ListVGs_Call{Call: _e.mock.On("ListVGs", ctx, taggedByLVMS)}
+//   - opts lvm.ListVGOptions
+func (_e *MockLVM_Expecter) ListVGs(ctx interface{}, taggedByLVMS interface{}, opts interface{}) *MockLVM_ListVGs_Call {
+	return &MockLVM_ListVGs_Call{Call: _e.mock.On("ListVGs", ctx, taggedByLVMS, opts)}
 }
 
-func (_c *MockLVM_ListVGs_Call) Run(run func(ctx context.Context, taggedByLVMS bool)) *MockLVM_ListVGs_Call {
+func (_c *MockLVM_ListVGs_Call) Run(run func(ctx context.Context, taggedByLVMS bool, opts lvm.ListVGOptions)) *MockLVM_ListVGs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(bool))
+		run(args[0].(context.Context), args[1].(bool), args[2].(lvm.ListVGOptions))
 	})
 	return _c
 }
@@ -762,7 +765,7 @@ func (_c *MockLVM_ListVGs_Call) Return(_a0 []lvm.VolumeGroup, _a1 error) *MockLV
 	return _c
 }
 
-func (_c *MockLVM_ListVGs_Call) RunAndReturn(run func(context.Context, bool) ([]lvm.VolumeGroup, error)) *MockLVM_ListVGs_Call {
+func (_c *MockLVM_ListVGs_Call) RunAndReturn(run func(context.Context, bool, lvm.ListVGOptions) ([]lvm.VolumeGroup, error)) *MockLVM_ListVGs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/controllers/vgmanager/vg_attr.go
+++ b/internal/controllers/vgmanager/vg_attr.go
@@ -1,0 +1,65 @@
+package vgmanager
+
+import (
+	"fmt"
+)
+
+type Resizeable rune
+
+const (
+	ResizeableResizable Resizeable = 'z'
+	ResizeableNone      Resizeable = '-'
+)
+
+type Exported rune
+
+const (
+	ExportedExported Exported = 'x'
+	ExportedNone     Exported = '-'
+)
+
+type ClusteredOrShared rune
+
+const (
+	Clustered ClusteredOrShared = 'c'
+	Shared    ClusteredOrShared = 's'
+)
+
+// VgAttr has mapped vg_attr information, see 'man vgs' vg_attr bits.
+// It is a complete parsing of the entire attribute byte flags that is attached to each VG.
+// This is useful when attaching logic to the state of an VG as the state of an VG can be determined
+// from the Attribute.
+type VgAttr struct {
+	Permissions
+	Resizeable
+	Exported
+	Partial
+	AllocationPolicy
+	ClusteredOrShared
+}
+
+func ParsedVgAttr(raw string) (VgAttr, error) {
+	if len(raw) != 6 {
+		return VgAttr{}, fmt.Errorf("%s is an invalid length vg_attr", raw)
+	}
+	return VgAttr{
+		Permissions(raw[0]),
+		Resizeable(raw[1]),
+		Exported(raw[2]),
+		Partial(raw[3]),
+		AllocationPolicy(raw[4]),
+		ClusteredOrShared(raw[5]),
+	}, nil
+}
+
+func (l VgAttr) String() string {
+	return fmt.Sprintf(
+		"%c%c%c%c%c%c",
+		l.Permissions,
+		l.Resizeable,
+		l.Exported,
+		l.Partial,
+		l.AllocationPolicy,
+		l.ClusteredOrShared,
+	)
+}

--- a/internal/csi/grpc_runner.go
+++ b/internal/csi/grpc_runner.go
@@ -51,6 +51,12 @@ func (r gRPCServerRunner) Start(ctx context.Context) error {
 	start := time.Now()
 	end := make(chan any, 1)
 	go func() {
+		// recover panic
+		defer func() {
+			if r := recover(); r != nil {
+				logger.Error(err, "gRPC server panic", "recover", r)
+			}
+		}()
 		r.srv.GracefulStop()
 		end <- nil
 	}()

--- a/internal/csi/provisioner.go
+++ b/internal/csi/provisioner.go
@@ -36,11 +36,20 @@ const (
 	ResyncPeriodOfCsiNodeInformer = 1 * time.Hour
 )
 
+type NodeDeployment struct {
+	NodeName        string
+	NodeCSIEndpoint string
+}
+
 type ProvisionerOptions struct {
 	DriverName          string
 	CSIEndpoint         string
 	CSIOperationTimeout time.Duration
 	Metrics             *connection.ExtendedCSIMetricsManager
+	ExtraCreateMetadata bool
+	*NodeDeployment
+	LeaderElection         bool
+	EnableCapacityTracking bool
 }
 
 type Provisioner struct {
@@ -50,7 +59,7 @@ type Provisioner struct {
 }
 
 func (p *Provisioner) NeedLeaderElection() bool {
-	return true
+	return p.options.LeaderElection
 }
 
 var _ manager.Runnable = &Provisioner{}
@@ -112,6 +121,27 @@ func (p *Provisioner) Start(ctx context.Context) error {
 	nodeLister := factory.Core().V1().Nodes().Lister()
 	claimLister := factory.Core().V1().PersistentVolumeClaims().Lister()
 	vaLister := factory.Storage().V1().VolumeAttachments().Lister()
+
+	var nodeDeployment *provisionctrl.NodeDeployment
+	if p.options.NodeDeployment != nil {
+		nodeGRPCClient, err := connection.Connect(ctx, p.options.NodeCSIEndpoint,
+			p.options.Metrics,
+			connection.OnConnectionLoss(onLostConnection),
+			connection.WithTimeout(p.options.CSIOperationTimeout))
+		defer nodeGRPCClient.Close() //nolint:errcheck,staticcheck
+		if err != nil {
+			return fmt.Errorf("failed to connect to node csi driver: %w", err)
+		}
+		nodeDeployment = &provisionctrl.NodeDeployment{}
+		nodeDeployment.NodeName = p.options.NodeDeployment.NodeName
+		nodeDeployment.ClaimInformer = factory.Core().V1().PersistentVolumeClaims()
+		nodeInfo, err := provisionctrl.GetNodeInfo(nodeGRPCClient, p.options.CSIOperationTimeout)
+		if err != nil {
+			return fmt.Errorf("failed to get node info: %w", err)
+		}
+		nodeDeployment.NodeInfo = *nodeInfo
+	}
+
 	provisioner := provisionctrl.NewCSIProvisioner(
 		clientset,
 		p.options.CSIOperationTimeout,
@@ -133,82 +163,86 @@ func (p *Provisioner) Start(ctx context.Context) error {
 		claimLister,
 		vaLister,
 		nil,
-		false,
+		p.options.ExtraCreateMetadata,
 		"",
-		nil,
+		nodeDeployment,
 		false,
 		false,
 	)
 
-	var capacityController *capacity.Controller
-	namespace := os.Getenv("NAMESPACE")
-	if namespace == "" {
-		return fmt.Errorf("need NAMESPACE env variable for CSIStorageCapacity objects")
-	}
-	podName := os.Getenv("NAME")
-	if podName == "" {
-		return fmt.Errorf("need NAME env variable to determine CSIStorageCapacity owner")
-	}
-	controllerRef, err := owner.Lookup(p.config, namespace, podName,
-		schema.GroupVersionKind{
-			Group:   "",
-			Version: "v1",
-			Kind:    "Pod",
-		}, 2)
-	if err != nil {
-		return fmt.Errorf("look up owner(s) of pod failed: %w", err)
-	}
-	logger.Info(fmt.Sprintf("using %s/%s %s as owner of CSIStorageCapacity objects", controllerRef.APIVersion, controllerRef.Kind, controllerRef.Name))
 	rateLimiter := workqueue.NewItemExponentialFailureRateLimiter(time.Second, 5*time.Minute)
 
-	topologyQueue := workqueue.NewRateLimitingQueueWithConfig(rateLimiter, workqueue.RateLimitingQueueConfig{
-		Name: "csitopology",
-	})
+	var capacityFactoryForNamespace informers.SharedInformerFactory
+	var topologyInformer topology.Informer
+	var capacityController *capacity.Controller
+	var topologyQueue workqueue.RateLimitingInterface
+	if p.options.EnableCapacityTracking {
+		namespace := os.Getenv("NAMESPACE")
+		if namespace == "" {
+			return fmt.Errorf("need NAMESPACE env variable for CSIStorageCapacity objects")
+		}
+		podName := os.Getenv("NAME")
+		if podName == "" {
+			return fmt.Errorf("need NAME env variable to determine CSIStorageCapacity owner")
+		}
+		controllerRef, err := owner.Lookup(p.config, namespace, podName,
+			schema.GroupVersionKind{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Pod",
+			}, 2)
+		if err != nil {
+			return fmt.Errorf("look up owner(s) of pod failed: %w", err)
+		}
+		logger.Info(fmt.Sprintf("using %s/%s %s as owner of CSIStorageCapacity objects", controllerRef.APIVersion, controllerRef.Kind, controllerRef.Name))
 
-	topologyInformer := topology.NewNodeTopology(
-		p.options.DriverName,
-		clientset,
-		factory.Core().V1().Nodes(),
-		factory.Storage().V1().CSINodes(),
-		topologyQueue,
-	)
+		topologyQueue = workqueue.NewRateLimitingQueueWithConfig(rateLimiter, workqueue.RateLimitingQueueConfig{
+			Name: "csitopology",
+		})
 
-	managedByID := "external-provisioner"
+		topologyInformer = topology.NewNodeTopology(
+			p.options.DriverName,
+			clientset,
+			factory.Core().V1().Nodes(),
+			factory.Storage().V1().CSINodes(),
+			topologyQueue,
+		)
 
-	factoryForNamespace := informers.NewSharedInformerFactoryWithOptions(clientset,
-		ResyncPeriodOfCsiNodeInformer,
-		informers.WithNamespace(namespace),
-		informers.WithTweakListOptions(func(lo *metav1.ListOptions) {
-			lo.LabelSelector = labels.Set{
-				capacity.DriverNameLabel: p.options.DriverName,
-				capacity.ManagedByLabel:  managedByID,
-			}.AsSelector().String()
-		}),
-	)
-	// We use the V1 CSIStorageCapacity API if available.
-	clientFactory := capacity.NewV1ClientFactory(clientset)
-	cInformer := factoryForNamespace.Storage().V1().CSIStorageCapacities()
-
-	capacityController = capacity.NewCentralCapacityController(
-		csi.NewControllerClient(grpcClient),
-		p.options.DriverName,
-		clientFactory,
-		// Metrics for the queue is available in the default registry.
-		workqueue.NewRateLimitingQueueWithConfig(rateLimiter, workqueue.RateLimitingQueueConfig{
-			Name: "csistoragecapacity",
-		}),
-		controllerRef,
-		managedByID,
-		namespace,
-		topologyInformer,
-		factory.Storage().V1().StorageClasses(),
-		cInformer,
-		time.Minute,
-		false,
-		p.options.CSIOperationTimeout,
-	)
-	// Wrap Provision and Delete to detect when it is time to refresh capacity.
-	provisioner = capacity.NewProvisionWrapper(provisioner, capacityController)
+		managedByID := "external-provisioner"
+		capacityFactoryForNamespace = informers.NewSharedInformerFactoryWithOptions(clientset,
+			ResyncPeriodOfCsiNodeInformer,
+			informers.WithNamespace(namespace),
+			informers.WithTweakListOptions(func(lo *metav1.ListOptions) {
+				lo.LabelSelector = labels.Set{
+					capacity.DriverNameLabel: p.options.DriverName,
+					capacity.ManagedByLabel:  managedByID,
+				}.AsSelector().String()
+			}),
+		)
+		// We use the V1 CSIStorageCapacity API if available.
+		clientFactory := capacity.NewV1ClientFactory(clientset)
+		cInformer := capacityFactoryForNamespace.Storage().V1().CSIStorageCapacities()
+		capacityController = capacity.NewCentralCapacityController(
+			csi.NewControllerClient(grpcClient),
+			p.options.DriverName,
+			clientFactory,
+			// Metrics for the queue is available in the default registry.
+			workqueue.NewRateLimitingQueueWithConfig(rateLimiter, workqueue.RateLimitingQueueConfig{
+				Name: "csistoragecapacity",
+			}),
+			controllerRef,
+			managedByID,
+			namespace,
+			topologyInformer,
+			factory.Storage().V1().StorageClasses(),
+			cInformer,
+			time.Minute,
+			false,
+			p.options.CSIOperationTimeout,
+		)
+		// Wrap Provision and Delete to detect when it is time to refresh capacity.
+		provisioner = capacity.NewProvisionWrapper(provisioner, capacityController)
+	}
 
 	claimRateLimiter := workqueue.NewItemExponentialFailureRateLimiter(time.Second, 5*time.Minute)
 	claimQueue := workqueue.NewRateLimitingQueueWithConfig(claimRateLimiter, workqueue.RateLimitingQueueConfig{
@@ -243,7 +277,12 @@ func (p *Provisioner) Start(ctx context.Context) error {
 	factory.Start(ctx.Done())
 	// Starting is enough, the capacity controller will
 	// wait for sync.
-	factoryForNamespace.Start(ctx.Done())
+	if p.options.EnableCapacityTracking {
+		if capacityFactoryForNamespace == nil {
+			return fmt.Errorf("capacityFactoryForNamespace is nil but should have been initialized")
+		}
+		capacityFactoryForNamespace.Start(ctx.Done())
+	}
 	cacheSyncResult := factory.WaitForCacheSync(ctx.Done())
 	for _, v := range cacheSyncResult {
 		if !v {
@@ -252,27 +291,32 @@ func (p *Provisioner) Start(ctx context.Context) error {
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(4)
-	go func() {
-		defer wg.Done()
-		topologyInformer.RunWorker(ctx)
-		logger.Info("topology informer finished shutdown")
-	}()
-	go func() {
-		defer wg.Done()
-		capacityController.Run(ctx, 1)
-		logger.Info("capacity controller finished shutdown")
-	}()
+
+	if p.options.EnableCapacityTracking {
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			topologyInformer.RunWorker(ctx)
+			logger.Info("topology informer finished shutdown")
+		}()
+		go func() {
+			defer wg.Done()
+			capacityController.Run(ctx, 1)
+			logger.Info("capacity controller finished shutdown")
+		}()
+		go func() {
+			defer wg.Done()
+			defer topologyQueue.ShutDown()
+			provisionController.Run(ctx)
+			logger.Info("provisioner controller finished shutdown")
+		}()
+	}
+
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		csiClaimController.Run(ctx, 1)
 		logger.Info("csi claim controller finished shutdown")
-	}()
-	go func() {
-		defer wg.Done()
-		defer topologyQueue.ShutDown()
-		provisionController.Run(ctx)
-		logger.Info("provisioner controller finished shutdown")
 	}()
 
 	wg.Wait()

--- a/internal/csi/snapshotter.go
+++ b/internal/csi/snapshotter.go
@@ -26,6 +26,8 @@ type SnapshotterOptions struct {
 	DriverName          string
 	CSIEndpoint         string
 	CSIOperationTimeout time.Duration
+	ExtraCreateMetadata bool
+	LeaderElection      bool
 }
 
 type Snapshotter struct {
@@ -35,7 +37,7 @@ type Snapshotter struct {
 }
 
 func (s *Snapshotter) NeedLeaderElection() bool {
-	return true
+	return s.options.LeaderElection
 }
 
 var _ manager.Runnable = &Snapshotter{}
@@ -90,7 +92,7 @@ func (s *Snapshotter) Start(ctx context.Context) error {
 		-1,
 		"groupsnapshot",
 		-1,
-		false,
+		s.options.ExtraCreateMetadata,
 		rateLimiter,
 		false,
 		factory.Groupsnapshot().V1alpha1().VolumeGroupSnapshotContents(),

--- a/internal/locking/volumegroup_lock.go
+++ b/internal/locking/volumegroup_lock.go
@@ -1,0 +1,114 @@
+package locking
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+const VolumeGroupLockName = "shared-volumegroup-lock"
+
+type VolumeGroupLock interface {
+	manager.Runnable
+	IsLeader() bool
+	Check(req *http.Request) error
+}
+
+type noneVolumeGroupLock struct{}
+
+func (n *noneVolumeGroupLock) Check(_ *http.Request) error {
+	return nil
+}
+
+func (n *noneVolumeGroupLock) Start(_ context.Context) error { return nil }
+func (n *noneVolumeGroupLock) IsLeader() bool                { return true }
+
+var _ VolumeGroupLock = &noneVolumeGroupLock{}
+
+func NewNoneVolumeGroupLock() VolumeGroupLock {
+	return &noneVolumeGroupLock{}
+}
+
+type volumegroupLock struct {
+	leaderElector   *leaderelection.LeaderElector
+	node, namespace string
+	healthCheck     healthz.Checker
+}
+
+var _ manager.Runnable = &volumegroupLock{}
+
+func NewVolumeGroupLock(ctx context.Context, mgr manager.Manager, node, namespace string) (VolumeGroupLock, error) {
+	logger := log.FromContext(ctx)
+
+	leClient, err := kubernetes.NewForConfigAndClient(mgr.GetConfig(), mgr.GetHTTPClient())
+	if err != nil {
+		return nil, fmt.Errorf("unable to create client for leader election: %w", err)
+	}
+
+	wd := leaderelection.NewLeaderHealthzAdaptor(180 * time.Second)
+
+	le, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock: &resourcelock.LeaseLock{
+			LeaseMeta: metav1.ObjectMeta{
+				Name:      VolumeGroupLockName,
+				Namespace: namespace,
+			},
+			Client: leClient.CoordinationV1(),
+			LockConfig: resourcelock.ResourceLockConfig{
+				Identity:      node,
+				EventRecorder: mgr.GetEventRecorderFor(VolumeGroupLockName),
+			},
+		},
+		LeaseDuration: 180 * time.Second, // aligned to sanlock timeout
+		RenewDeadline: 60 * time.Second,
+		RetryPeriod:   30 * time.Second,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				log.FromContext(ctx).Info("Started leading shared volume group creation")
+			},
+			OnStoppedLeading: func() {
+				logger.Info("Stopped leading shared volume group creation")
+			},
+			OnNewLeader: func(identity string) {
+				logger.Info("New leader elected for shared volume group creation", "identity", identity)
+			},
+		},
+		WatchDog:        wd,
+		ReleaseOnCancel: true,
+		Name:            VolumeGroupLockName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to create leader elector: %w", err)
+	}
+
+	return &volumegroupLock{
+		leaderElector: le,
+		healthCheck:   wd.Check,
+	}, nil
+}
+
+// Start implements controller-runtime's manager.Runnable.
+func (s *volumegroupLock) Start(ctx context.Context) error {
+	s.leaderElector.Run(ctx)
+	return nil
+}
+
+func (s *volumegroupLock) IsLeader() bool {
+	return s.leaderElector.IsLeader()
+}
+
+func (s *volumegroupLock) Check(req *http.Request) error {
+	if s.healthCheck == nil {
+		return nil
+	}
+	return s.healthCheck(req)
+}


### PR DESCRIPTION
TODO:

- [X] Setup RBAC for KubeSAN
- [X] Setup Driver Registration via internal node registration of vgmanager
- [X] Setup Health Check in vgmanager to use correct driver
- [X] Allow setting up multiple StorageClasses and drivers based on deviceClasses
- [X] Allow configuration of sidecar container for the kubeSAN driver
- [X] Find a easy way to add lvmlockd and sanlock to test clusters before introducing it in OpenShift CoreOS builds - CoreOS layering and a hack script works good enough
- [x] Integrate the controller of kubesan directly into either vgmanager (unoptimized), lvm-operator (more complex) or as a separate deployment
- [x] Create a first demo case
- [ ] Run CNV on a cluster with LVMS as base

Optional for POC:
- [ ] Find a sophisticated way to add lvmlockd and sanlock to default os builds OR
- [ ] Find a way to create dynamic machine configurations that patch kubesan into the OS (not preferred)
- [ ] Make Unit & E2E tests run (needs multi attach disk setup for testing)
- [ ] Integrate Controllers for performance optimization
- [ ] Have a smarter ValidNodes detection that can use smart nodeselectors to create 2 daemonsets, one for shared and one for not shared volume groups
- [ ] Refactor the logic paths to not have so much code duplication

[Related KubeSAN branch can be found here](https://gitlab.com/jakobmoellerdev/kubesan/-/compare/9ef0764815e7e52bae57fe21ab75e13b029e96ff...lvms-prototype?from_project_id=53788248&straight=false)