### PR TITLE
OCPBUGS-34227: fix: increase vgmanager startup timeout to 10 mins to cover long running volume group initialization

### DIFF
--- a/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
+++ b/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
@@ -272,10 +272,10 @@ func templateVGManagerDaemonset(
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{Path: "/healthz",
 						Port: intstr.FromString(constants.TopolvmNodeContainerHealthzName)}},
-				FailureThreshold:    10,
-				InitialDelaySeconds: 0,
+				FailureThreshold:    60, // 60*10 = 600s / 10 min for long startup due to large volume group initialization
+				InitialDelaySeconds: 2,
 				TimeoutSeconds:      2,
-				PeriodSeconds:       2},
+				PeriodSeconds:       10},
 			LivenessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{Path: "/healthz",


### PR DESCRIPTION
This is done as a workaround until we have a better fix available
Since im unable to stabilize #658 right now and I have to do more debugging there this should provide a valid workaround that can sit until release if no better option is found.