### PR TITLE
OCPEDGE-1169: fix: device selection only by filter

### DIFF
--- a/internal/controllers/vgmanager/devices.go
+++ b/internal/controllers/vgmanager/devices.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	lvmv1alpha1 "github.com/openshift/lvm-operator/v4/api/v1alpha1"
 	"github.com/openshift/lvm-operator/v4/internal/controllers/vgmanager/filter"
 	"github.com/openshift/lvm-operator/v4/internal/controllers/vgmanager/lsblk"
 	"github.com/openshift/lvm-operator/v4/internal/controllers/vgmanager/lvm"
@@ -47,11 +46,7 @@ func (r *Reconciler) addDevicesToVG(ctx context.Context, vgs []lvm.VolumeGroup, 
 
 	var args []string
 	for _, device := range devices {
-		if device.DevicePath != "" {
-			args = append(args, device.DevicePath)
-		} else {
-			args = append(args, device.KName)
-		}
+		args = append(args, device.KName)
 	}
 
 	if existingVolumeGroup != nil {
@@ -82,9 +77,67 @@ type FilteredBlockDevices struct {
 	Excluded  []FilteredBlockDevice
 }
 
+// VerifyMandatoryDevicePaths verifies if the provided device list is either available or already setup correctly.
+// While availability is easy to determine, an exclusion by being already setup can only be determined by
+// checking if the excluded device has been filtered due to filter.ErrDeviceAlreadySetupCorrectly.
+func VerifyMandatoryDevicePaths(f FilteredBlockDevices, paths []string) error {
+	for _, path := range paths {
+		path, err := evalSymlinks(path)
+		if err != nil {
+			return fmt.Errorf("failed to resolve symlink to determine available or setup path: %w", err)
+		}
+		available := f.IsAvailable(path)
+		errs := f.FilterErrors(path)
+		alreadySetup := false
+		for _, err := range errs {
+			if errors.Is(err, filter.ErrDeviceAlreadySetupCorrectly) {
+				alreadySetup = true
+				break
+			}
+		}
+		if !available && !alreadySetup {
+			if len(errs) > 0 {
+				err = errors.Join(errs...)
+			} else {
+				err = fmt.Errorf("the device did not exist on the host, "+
+					"make sure it is connected and visible via \"lsblk --json --paths -o %s\" "+
+					"and confirm it is discoverable via a path resolvable (e.g. via symlink) on the host", lsblk.LSBLK_COLUMNS)
+			}
+			return fmt.Errorf("mandatory device path %q cannot be used, "+
+				"because it is NOT available as a new device for the volume group and "+
+				"NOT part of a valid and tagged existing volume group: %w",
+				path,
+				err,
+			)
+		}
+	}
+	return nil
+}
+
+// IsAvailable checks if the provided device is available for use in a new volume group.
+func (f FilteredBlockDevices) IsAvailable(dev string) bool {
+	for _, available := range f.Available {
+		if dev == available.KName {
+			return true
+		}
+	}
+	return false
+}
+
+// FilterErrors checks if the provided device is already setup correctly in an existing volume group
+// (all filters decided the device is either okay to use or returned filter.ErrDeviceAlreadySetupCorrectly).
+func (f FilteredBlockDevices) FilterErrors(dev string) []error {
+	for _, excluded := range f.Excluded {
+		if dev == excluded.KName {
+			return excluded.FilterErrors
+		}
+	}
+	return nil
+}
+
 // filterDevices returns:
 // availableDevices: the list of blockdevices considered available
-func (r *Reconciler) filterDevices(ctx context.Context, devices []lsblk.BlockDevice, pvs []lvm.PhysicalVolume, bdi lsblk.BlockDeviceInfos, filters filter.Filters) FilteredBlockDevices {
+func filterDevices(ctx context.Context, devices []lsblk.BlockDevice, filters filter.Filters) FilteredBlockDevices {
 	logger := log.FromContext(ctx)
 
 	var availableDevices []lsblk.BlockDevice
@@ -93,7 +146,7 @@ func (r *Reconciler) filterDevices(ctx context.Context, devices []lsblk.BlockDev
 	for _, device := range devices {
 		// check for partitions recursively
 		if device.HasChildren() {
-			filteredChildDevices := r.filterDevices(ctx, device.Children, pvs, bdi, filters)
+			filteredChildDevices := filterDevices(ctx, device.Children, filters)
 			availableDevices = append(availableDevices, filteredChildDevices.Available...)
 			for _, excludedChildDevice := range filteredChildDevices.Excluded {
 				if excluded, ok := excludedByKName[excludedChildDevice.KName]; ok {
@@ -106,7 +159,7 @@ func (r *Reconciler) filterDevices(ctx context.Context, devices []lsblk.BlockDev
 
 		filterErrs := make([]error, 0, len(filters))
 		for name, filterFunc := range filters {
-			if err := filterFunc(device, pvs, bdi); err != nil {
+			if err := filterFunc(device); err != nil {
 				logger.WithValues("device.KName", device.KName, "filter.Name", name).
 					V(3).Info("excluded", "reason", err)
 				filterErrs = append(filterErrs, err)
@@ -136,125 +189,19 @@ func (r *Reconciler) filterDevices(ctx context.Context, devices []lsblk.BlockDev
 	}
 }
 
-// getNewDevicesToBeAdded gets all devices that should be added to the volume group
-func (r *Reconciler) getNewDevicesToBeAdded(ctx context.Context, blockDevices []lsblk.BlockDevice, nodeStatus *lvmv1alpha1.LVMVolumeGroupNodeStatus, volumeGroup *lvmv1alpha1.LVMVolumeGroup) ([]lsblk.BlockDevice, error) {
-	logger := log.FromContext(ctx)
-
-	var validBlockDevices []lsblk.BlockDevice
-	atLeastOneDeviceIsAlreadyInVolumeGroup := false
-
-	if volumeGroup.Spec.DeviceSelector == nil {
-		// return all available block devices if none is specified in the CR
-		return blockDevices, nil
-	}
-
-	// If Paths is specified, treat it as required paths
-	for _, path := range volumeGroup.Spec.DeviceSelector.Paths {
-		blockDevice, err := getValidDevice(path, blockDevices, nodeStatus, volumeGroup)
-		if err != nil {
-			// An error for required devices is critical
-			return nil, fmt.Errorf("unable to validate device %s: %v", path, err)
-		}
-
-		// Check if we should skip this device
-		if blockDevice.DevicePath == "" {
-			logger.Info(fmt.Sprintf("skipping required device that is already part of volume group %s: %s", volumeGroup.Name, path))
-			atLeastOneDeviceIsAlreadyInVolumeGroup = true
-			continue
-		}
-
-		validBlockDevices = append(validBlockDevices, blockDevice)
-	}
-
-	for _, path := range volumeGroup.Spec.DeviceSelector.OptionalPaths {
-		blockDevice, err := getValidDevice(path, blockDevices, nodeStatus, volumeGroup)
-
-		// Check if we should skip this device
-		if err != nil {
-			logger.Info(fmt.Sprintf("skipping optional device path: %v", err))
-			continue
-		}
-
-		// Check if we should skip this device
-		if blockDevice.DevicePath == "" {
-			logger.Info(fmt.Sprintf("skipping optional device path that is already part of volume group %s: %s", volumeGroup.Name, path))
-			atLeastOneDeviceIsAlreadyInVolumeGroup = true
-			continue
-		}
-
-		validBlockDevices = append(validBlockDevices, blockDevice)
-	}
-
-	// Check for any optional paths
-	// At least 1 of the optional paths are required if:
-	//   - OptionalPaths was specified AND
-	//   - There were no required paths
-	//   - Devices were not already part of the volume group (meaning this was run after vg creation)
-	// This guarantees at least 1 device could be found between optionalPaths and paths
-	// if len(FilteredBlockDevices) == 0 && !atLeastOneDeviceIsAlreadyInVolumeGroup {
-	if len(validBlockDevices) == 0 && !atLeastOneDeviceIsAlreadyInVolumeGroup {
-		return nil, errors.New("at least 1 valid device is required if DeviceSelector paths or optionalPaths are specified")
-	}
-
-	return validBlockDevices, nil
-}
-
-func isDeviceAlreadyPartOfVG(nodeStatus *lvmv1alpha1.LVMVolumeGroupNodeStatus, diskName string, volumeGroup *lvmv1alpha1.LVMVolumeGroup) bool {
-	if nodeStatus == nil {
-		return false
-	}
-	for _, vgStatus := range nodeStatus.Spec.LVMVGStatus {
-		if vgStatus.Name == volumeGroup.Name {
-			for _, pv := range vgStatus.Devices {
-				if resolvedPV, _ := evalSymlinks(pv); resolvedPV == diskName {
-					return true
-				}
+func isDeviceAlreadyPartOfVG(vgs []lvm.VolumeGroup, path string) (string, bool) {
+	for _, vg := range vgs {
+		for _, pv := range vg.PVs {
+			if pv.PvName == path {
+				return vg.Name, true
+			}
+			if resolved, _ := evalSymlinks(pv.PvName); resolved == path {
+				return vg.Name, true
 			}
 		}
 	}
-
-	return false
-}
-
-func hasExactDisk(blockDevices []lsblk.BlockDevice, deviceName string) (lsblk.BlockDevice, bool) {
-	for _, blockDevice := range blockDevices {
-		if blockDevice.KName == deviceName {
-			return blockDevice, true
-		}
-		if blockDevice.HasChildren() {
-			if device, ok := hasExactDisk(blockDevice.Children, deviceName); ok {
-				return device, true
-			}
-		}
-	}
-	return lsblk.BlockDevice{}, false
+	return "", false
 }
 
 // evalSymlinks redefined to be able to override in tests
 var evalSymlinks = filepath.EvalSymlinks
-
-// getValidDevice will do various checks on a device path to make sure it is a valid device
-//
-//	An error will be returned if the device is invalid
-//	No error and an empty BlockDevice object will be returned if this device should be skipped (ex: duplicate device)
-func getValidDevice(devicePath string, blockDevices []lsblk.BlockDevice, nodeStatus *lvmv1alpha1.LVMVolumeGroupNodeStatus, volumeGroup *lvmv1alpha1.LVMVolumeGroup) (lsblk.BlockDevice, error) {
-	// Make sure the symlink exists
-	diskName, err := evalSymlinks(devicePath)
-	if err != nil {
-		return lsblk.BlockDevice{}, fmt.Errorf("unable to find symlink for disk path %s: %v", devicePath, err)
-	}
-
-	// Make sure this isn't a duplicate in the VG
-	if isDeviceAlreadyPartOfVG(nodeStatus, diskName, volumeGroup) {
-		return lsblk.BlockDevice{}, nil // No error, we just don't want a duplicate
-	}
-
-	// Make sure the block device exists
-	blockDevice, ok := hasExactDisk(blockDevices, diskName)
-	if !ok {
-		return lsblk.BlockDevice{}, fmt.Errorf("can not find device name %s in the available block devices", devicePath)
-	}
-
-	blockDevice.DevicePath = devicePath
-	return blockDevice, nil
-}

--- a/internal/controllers/vgmanager/filter/filter_test.go
+++ b/internal/controllers/vgmanager/filter/filter_test.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	lvmv1alpha1 "github.com/openshift/lvm-operator/v4/api/v1alpha1"
@@ -17,10 +18,11 @@ type filterTestCase struct {
 }
 
 type advancedFilterTestCase struct {
-	label     string
-	device    lsblk.BlockDevice
-	assertErr assert.ErrorAssertionFunc
-	lvmExpect []lvm.PhysicalVolume
+	label           string
+	device          lsblk.BlockDevice
+	assertErr       assert.ErrorAssertionFunc
+	volumeGroupSpec *lvmv1alpha1.LVMVolumeGroupSpec
+	lvmExpect       []lvm.PhysicalVolume
 }
 
 func TestNotReadOnly(t *testing.T) {
@@ -30,7 +32,7 @@ func TestNotReadOnly(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.label, func(t *testing.T) {
-			err := DefaultFilters(nil)[notReadOnly](tc.device, nil, nil)
+			err := DefaultFilters(nil)[notReadOnly](tc.device)
 			if tc.expectErr {
 				assert.Error(t, err)
 			} else {
@@ -48,7 +50,7 @@ func TestNotSuspended(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.label, func(t *testing.T) {
-			err := DefaultFilters(nil)[notSuspended](tc.device, nil, nil)
+			err := DefaultFilters(nil)[notSuspended](tc.device)
 			if tc.expectErr {
 				assert.Error(t, err)
 			} else {
@@ -66,7 +68,7 @@ func TestNoFilesystemSignature(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.label, func(t *testing.T) {
-			err := DefaultFilters(nil)[onlyValidFilesystemSignatures](tc.device, nil, nil)
+			err := DefaultFilters(nil)[onlyValidFilesystemSignatures](tc.device)
 			if tc.expectErr {
 				assert.Error(t, err)
 			} else {
@@ -83,7 +85,7 @@ func TestNoChildren(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.label, func(t *testing.T) {
-			err := DefaultFilters(nil)[noChildren](tc.device, nil, nil)
+			err := DefaultFilters(nil)[noChildren](tc.device)
 			if tc.expectErr {
 				assert.Error(t, err)
 			} else {
@@ -99,7 +101,7 @@ func TestIsUsableDeviceType(t *testing.T) {
 		{label: "tc Disk", device: lsblk.BlockDevice{Name: "dev2", Type: "disk"}, expectErr: false},
 	}
 	for _, tc := range testcases {
-		err := DefaultFilters(nil)[usableDeviceType](tc.device, nil, nil)
+		err := DefaultFilters(nil)[usableDeviceType](tc.device)
 		if tc.expectErr {
 			assert.Error(t, err)
 		} else {
@@ -123,7 +125,7 @@ func TestNoBiosBootInPartLabel(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.label, func(t *testing.T) {
-			err := DefaultFilters(nil)[noInvalidPartitionLabel](tc.device, nil, nil)
+			err := DefaultFilters(nil)[noInvalidPartitionLabel](tc.device)
 			if tc.expectErr {
 				assert.Error(t, err)
 			} else {
@@ -131,6 +133,51 @@ func TestNoBiosBootInPartLabel(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPartOfDeviceSelector(t *testing.T) {
+	testcases := []advancedFilterTestCase{
+		{label: "match path selector", device: lsblk.BlockDevice{KName: "dev1"},
+			volumeGroupSpec: &lvmv1alpha1.LVMVolumeGroupSpec{DeviceSelector: &lvmv1alpha1.DeviceSelector{
+				Paths: []string{"dev1"},
+			}},
+			assertErr: assert.NoError,
+		},
+		{label: "match optional path selector", device: lsblk.BlockDevice{KName: "dev1"},
+			volumeGroupSpec: &lvmv1alpha1.LVMVolumeGroupSpec{DeviceSelector: &lvmv1alpha1.DeviceSelector{
+				OptionalPaths: []string{"dev1"},
+			}},
+			assertErr: assert.NoError,
+		},
+		{label: "no match", device: lsblk.BlockDevice{KName: "dev1"},
+			volumeGroupSpec: &lvmv1alpha1.LVMVolumeGroupSpec{DeviceSelector: &lvmv1alpha1.DeviceSelector{
+				Paths: []string{"dev2"},
+			}},
+			assertErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "is not part of the device selector")
+			},
+		},
+		{label: "no selector", device: lsblk.BlockDevice{KName: "dev1"},
+			volumeGroupSpec: &lvmv1alpha1.LVMVolumeGroupSpec{},
+			assertErr:       assert.NoError,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.label, func(t *testing.T) {
+			evalSymlinks = func(path string) (string, error) {
+				return path, nil
+			}
+			defer func() {
+				evalSymlinks = filepath.EvalSymlinks
+			}()
+			vg := &lvmv1alpha1.LVMVolumeGroup{}
+			vg.SetName("vg1")
+			vg.Spec = *tc.volumeGroupSpec
+			err := DefaultFilters(&Options{VG: vg})[partOfDeviceSelector](tc.device)
+			tc.assertErr(t, err, fmt.Sprintf("partOfDeviceSelector(%v)", tc.device))
+		})
+	}
+
 }
 
 func TestOnlyValidFilesystemSignatures(t *testing.T) {
@@ -159,7 +206,7 @@ func TestOnlyValidFilesystemSignatures(t *testing.T) {
 			label:  "LVM2_Member with matching pvs,no children,mismatching vg",
 			device: lsblk.BlockDevice{KName: "dev1", FSType: FSTypeLVM2Member},
 			assertErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.ErrorContains(t, err, "already part of another volume group")
+				return assert.ErrorContains(t, err, "already a LVM2_Member of another volume group")
 			},
 			lvmExpect: []lvm.PhysicalVolume{{PvName: "dev1", VgName: "random"}},
 		},
@@ -196,7 +243,10 @@ func TestOnlyValidFilesystemSignatures(t *testing.T) {
 			vg := &lvmv1alpha1.LVMVolumeGroup{}
 			vg.SetName("vg1")
 
-			err := DefaultFilters(vg)[onlyValidFilesystemSignatures](tc.device, tc.lvmExpect, nil)
+			err := DefaultFilters(&Options{
+				VG:  vg,
+				PVs: tc.lvmExpect,
+			})[onlyValidFilesystemSignatures](tc.device)
 			tc.assertErr(t, err, fmt.Sprintf("onlyValidFilesystemSignatures(%v)", tc.device))
 		})
 	}

--- a/internal/controllers/vgmanager/lvm/lvm.go
+++ b/internal/controllers/vgmanager/lvm/lvm.go
@@ -48,7 +48,7 @@ const (
 	lvChangeCmd   = "/usr/sbin/lvchange"
 	lvmDevicesCmd = "/usr/sbin/lvmdevices"
 
-	lvmsTag = "@lvms"
+	DefaultTag = "@lvms"
 )
 
 var (
@@ -183,7 +183,7 @@ func (hlvm *HostLVM) CreateVG(ctx context.Context, vg VolumeGroup) error {
 		return fmt.Errorf("failed to create volume group: physical volume list is empty")
 	}
 
-	args := []string{vg.Name, "--addtag", lvmsTag}
+	args := []string{vg.Name, "--addtag", DefaultTag}
 
 	for _, pv := range vg.PVs {
 		args = append(args, pv.PvName)
@@ -226,7 +226,7 @@ func (hlvm *HostLVM) AddTagToVG(ctx context.Context, vgName string) error {
 		return fmt.Errorf("failed to add tag to the volume group. Volume group name is empty")
 	}
 
-	args := []string{vgName, "--addtag", lvmsTag}
+	args := []string{vgName, "--addtag", DefaultTag}
 
 	if err := hlvm.RunCommandAsHost(ctx, vgChangeCmd, args...); err != nil {
 		return fmt.Errorf("failed to add tag to the volume group %q. %v", vgName, err)
@@ -277,7 +277,7 @@ func (hlvm *HostLVM) GetVG(ctx context.Context, name string) (VolumeGroup, error
 	res := new(VGReport)
 
 	args := []string{
-		lvmsTag, "--units", "g", "--reportformat", "json",
+		DefaultTag, "--units", "g", "--reportformat", "json",
 	}
 	if err := hlvm.RunCommandAsHostInto(ctx, res, vgsCmd, args...); err != nil {
 		return VolumeGroup{}, fmt.Errorf("failed to list volume groups. %v", err)
@@ -349,7 +349,7 @@ func (hlvm *HostLVM) ListVGs(ctx context.Context, tagged bool) ([]VolumeGroup, e
 		"-o", "vg_name,vg_size,vg_tags", "--units", "g", "--reportformat", "json",
 	}
 	if tagged {
-		args = append(args, lvmsTag)
+		args = append(args, DefaultTag)
 	}
 
 	if err := hlvm.RunCommandAsHostInto(ctx, res, vgsCmd, args...); err != nil {
@@ -545,7 +545,7 @@ func untaggedVGs(vgs []VolumeGroup) []VolumeGroup {
 	for _, vg := range vgs {
 		tagPresent := false
 		for _, tag := range vg.Tags {
-			if tag == lvmsTag {
+			if tag == DefaultTag {
 				tagPresent = true
 				break
 			}

--- a/internal/controllers/vgmanager/lvm/lvm_test.go
+++ b/internal/controllers/vgmanager/lvm/lvm_test.go
@@ -588,7 +588,7 @@ func TestNewDefaultHostLVM(t *testing.T) {
 func Test_untaggedVGs(t *testing.T) {
 	vgs := []VolumeGroup{
 		{Name: "vg1", Tags: []string{"tag1"}},
-		{Name: "vg2", Tags: []string{lvmsTag}},
+		{Name: "vg2", Tags: []string{DefaultTag}},
 	}
 
 	vgs = untaggedVGs(vgs)

--- a/internal/controllers/vgmanager/wipe_devices_test.go
+++ b/internal/controllers/vgmanager/wipe_devices_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/lvm-operator/v4/api/v1alpha1"
 	dmsetupmocks "github.com/openshift/lvm-operator/v4/internal/controllers/vgmanager/dmsetup/mocks"
 	"github.com/openshift/lvm-operator/v4/internal/controllers/vgmanager/lsblk"
+	"github.com/openshift/lvm-operator/v4/internal/controllers/vgmanager/lvm"
 	wipefsmocks "github.com/openshift/lvm-operator/v4/internal/controllers/vgmanager/wipefs/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -25,7 +26,7 @@ func TestWipeDevices(t *testing.T) {
 		devicePaths          []string
 		optionalDevicePaths  []string
 		blockDevices         []lsblk.BlockDevice
-		nodeStatus           v1alpha1.LVMVolumeGroupNodeStatus
+		vgs                  []lvm.VolumeGroup
 		wipeCount            int
 		removeReferenceCount int
 	}{
@@ -44,13 +45,10 @@ func TestWipeDevices(t *testing.T) {
 			removeReferenceCount: 0,
 		},
 		{
-			name:         "Device exist in the device list",
-			devicePaths:  []string{"/dev/loop1"},
-			blockDevices: []lsblk.BlockDevice{{KName: "/dev/sda"}, {KName: "/dev/sdb"}, {KName: "/dev/loop1"}},
-			nodeStatus: v1alpha1.LVMVolumeGroupNodeStatus{Spec: v1alpha1.LVMVolumeGroupNodeStatusSpec{
-				LVMVGStatus: []v1alpha1.VGStatus{
-					{Name: "vg1", Devices: []string{"/dev/sda"}}},
-			}},
+			name:                 "Device exist in the device list",
+			devicePaths:          []string{"/dev/loop1"},
+			blockDevices:         []lsblk.BlockDevice{{KName: "/dev/sda"}, {KName: "/dev/sdb"}, {KName: "/dev/loop1"}},
+			vgs:                  []lvm.VolumeGroup{{Name: "vg1", PVs: []lvm.PhysicalVolume{{PvName: "/dev/sda"}}}},
 			wipeCount:            1,
 			removeReferenceCount: 0,
 		},
@@ -83,92 +81,68 @@ func TestWipeDevices(t *testing.T) {
 			removeReferenceCount: 1,
 		},
 		{
-			name:         "Device exist in the device list and is already part of a vg",
-			devicePaths:  []string{"/dev/loop1"},
-			blockDevices: []lsblk.BlockDevice{{KName: "/dev/sda"}, {KName: "/dev/sdb"}, {KName: "/dev/loop1"}},
-			nodeStatus: v1alpha1.LVMVolumeGroupNodeStatus{Spec: v1alpha1.LVMVolumeGroupNodeStatusSpec{
-				LVMVGStatus: []v1alpha1.VGStatus{
-					{Name: "vg1", Devices: []string{"/dev/loop1"}}},
-			}},
+			name:                 "Device exist in the device list and is already part of a vg",
+			devicePaths:          []string{"/dev/loop1"},
+			blockDevices:         []lsblk.BlockDevice{{KName: "/dev/sda"}, {KName: "/dev/sdb"}, {KName: "/dev/loop1"}},
+			vgs:                  []lvm.VolumeGroup{{Name: "vg1", PVs: []lvm.PhysicalVolume{{PvName: "/dev/loop1"}}}},
 			wipeCount:            0,
 			removeReferenceCount: 0,
 		},
 		{
-			name:         "Only one device out of two exists in the device list",
-			devicePaths:  []string{"/dev/loop1", "/dev/loop2"},
-			blockDevices: []lsblk.BlockDevice{{KName: "/dev/sda"}, {KName: "/dev/sdb"}, {KName: "/dev/loop1"}},
-			nodeStatus: v1alpha1.LVMVolumeGroupNodeStatus{Spec: v1alpha1.LVMVolumeGroupNodeStatusSpec{
-				LVMVGStatus: []v1alpha1.VGStatus{
-					{Name: "vg1", Devices: []string{"/dev/sda"}}},
-			}},
+			name:                 "Only one device out of two exists in the device list",
+			devicePaths:          []string{"/dev/loop1", "/dev/loop2"},
+			blockDevices:         []lsblk.BlockDevice{{KName: "/dev/sda"}, {KName: "/dev/sdb"}, {KName: "/dev/loop1"}},
+			vgs:                  []lvm.VolumeGroup{{Name: "vg1", PVs: []lvm.PhysicalVolume{{PvName: "/dev/sda"}}}},
 			wipeCount:            1,
 			removeReferenceCount: 0,
 		},
 		{
-			name:         "Both devices exist in the device list",
-			devicePaths:  []string{"/dev/loop1", "/dev/loop2"},
-			blockDevices: []lsblk.BlockDevice{{KName: "/dev/sda"}, {KName: "/dev/loop1"}, {KName: "/dev/loop2", Children: []lsblk.BlockDevice{{KName: "/dev/loop2p1"}}}},
-			nodeStatus: v1alpha1.LVMVolumeGroupNodeStatus{Spec: v1alpha1.LVMVolumeGroupNodeStatusSpec{
-				LVMVGStatus: []v1alpha1.VGStatus{
-					{Name: "vg1", Devices: []string{"/dev/sda"}}},
-			}},
+			name:                 "Both devices exist in the device list",
+			devicePaths:          []string{"/dev/loop1", "/dev/loop2"},
+			blockDevices:         []lsblk.BlockDevice{{KName: "/dev/sda"}, {KName: "/dev/loop1"}, {KName: "/dev/loop2", Children: []lsblk.BlockDevice{{KName: "/dev/loop2p1"}}}},
+			vgs:                  []lvm.VolumeGroup{{Name: "vg1", PVs: []lvm.PhysicalVolume{{PvName: "/dev/sda"}}}},
 			wipeCount:            2,
 			removeReferenceCount: 1,
 		},
 		{
-			name:                "One required and one optional device exist in the device list",
-			devicePaths:         []string{"/dev/loop1"},
-			optionalDevicePaths: []string{"/dev/loop2"},
-			blockDevices:        []lsblk.BlockDevice{{KName: "/dev/sda"}, {KName: "/dev/loop1"}, {KName: "/dev/loop2", Children: []lsblk.BlockDevice{{KName: "/dev/loop2p1"}}}},
-			nodeStatus: v1alpha1.LVMVolumeGroupNodeStatus{Spec: v1alpha1.LVMVolumeGroupNodeStatusSpec{
-				LVMVGStatus: []v1alpha1.VGStatus{
-					{Name: "vg1", Devices: []string{"/dev/sda"}}},
-			}},
+			name:                 "One required and one optional device exist in the device list",
+			devicePaths:          []string{"/dev/loop1"},
+			optionalDevicePaths:  []string{"/dev/loop2"},
+			blockDevices:         []lsblk.BlockDevice{{KName: "/dev/sda"}, {KName: "/dev/loop1"}, {KName: "/dev/loop2", Children: []lsblk.BlockDevice{{KName: "/dev/loop2p1"}}}},
+			vgs:                  []lvm.VolumeGroup{{Name: "vg1", PVs: []lvm.PhysicalVolume{{PvName: "/dev/sda"}}}},
 			wipeCount:            2,
 			removeReferenceCount: 1,
 		},
 		{
-			name:                "Optional device does not exist in the device list",
-			devicePaths:         []string{"/dev/loop1"},
-			optionalDevicePaths: []string{"/dev/loop2"},
-			blockDevices:        []lsblk.BlockDevice{{KName: "/dev/sda"}, {KName: "/dev/loop1"}},
-			nodeStatus: v1alpha1.LVMVolumeGroupNodeStatus{Spec: v1alpha1.LVMVolumeGroupNodeStatusSpec{
-				LVMVGStatus: []v1alpha1.VGStatus{
-					{Name: "vg1", Devices: []string{"/dev/sda"}}},
-			}},
+			name:                 "Optional device does not exist in the device list",
+			devicePaths:          []string{"/dev/loop1"},
+			optionalDevicePaths:  []string{"/dev/loop2"},
+			blockDevices:         []lsblk.BlockDevice{{KName: "/dev/sda"}, {KName: "/dev/loop1"}},
+			vgs:                  []lvm.VolumeGroup{{Name: "vg1", PVs: []lvm.PhysicalVolume{{PvName: "/dev/sda"}}}},
 			wipeCount:            1,
 			removeReferenceCount: 0,
 		},
 		{
-			name:         "Both devices, one of them is a child, exist in the device list",
-			devicePaths:  []string{"/dev/loop1", "/dev/loop2p1"},
-			blockDevices: []lsblk.BlockDevice{{KName: "/dev/sda"}, {KName: "/dev/loop1"}, {KName: "/dev/loop2", Children: []lsblk.BlockDevice{{KName: "/dev/loop2p1"}}}},
-			nodeStatus: v1alpha1.LVMVolumeGroupNodeStatus{Spec: v1alpha1.LVMVolumeGroupNodeStatusSpec{
-				LVMVGStatus: []v1alpha1.VGStatus{
-					{Name: "vg1", Devices: []string{"/dev/sda"}}},
-			}},
+			name:                 "Both devices, one of them is a child, exist in the device list",
+			devicePaths:          []string{"/dev/loop1", "/dev/loop2p1"},
+			blockDevices:         []lsblk.BlockDevice{{KName: "/dev/sda"}, {KName: "/dev/loop1"}, {KName: "/dev/loop2", Children: []lsblk.BlockDevice{{KName: "/dev/loop2p1"}}}},
+			vgs:                  []lvm.VolumeGroup{{Name: "vg1", PVs: []lvm.PhysicalVolume{{PvName: "/dev/sda"}}}},
 			wipeCount:            2,
 			removeReferenceCount: 0,
 		},
 		{
-			name:         "Both devices exist in the device list, one of them is part of the vg",
-			devicePaths:  []string{"/dev/loop1", "/dev/loop2"},
-			blockDevices: []lsblk.BlockDevice{{KName: "/dev/sda"}, {KName: "/dev/loop1"}, {KName: "/dev/loop2", Children: []lsblk.BlockDevice{{KName: "/dev/loop2p1"}}}},
-			nodeStatus: v1alpha1.LVMVolumeGroupNodeStatus{Spec: v1alpha1.LVMVolumeGroupNodeStatusSpec{
-				LVMVGStatus: []v1alpha1.VGStatus{
-					{Name: "vg1", Devices: []string{"/dev/loop1"}}},
-			}},
+			name:                 "Both devices exist in the device list, one of them is part of the vg",
+			devicePaths:          []string{"/dev/loop1", "/dev/loop2"},
+			blockDevices:         []lsblk.BlockDevice{{KName: "/dev/sda"}, {KName: "/dev/loop1"}, {KName: "/dev/loop2", Children: []lsblk.BlockDevice{{KName: "/dev/loop2p1"}}}},
+			vgs:                  []lvm.VolumeGroup{{Name: "vg1", PVs: []lvm.PhysicalVolume{{PvName: "/dev/loop1"}}}},
 			wipeCount:            1,
 			removeReferenceCount: 1,
 		},
 		{
-			name:         "Both devices are part of the vg",
-			devicePaths:  []string{"/dev/loop1", "/dev/loop2"},
-			blockDevices: []lsblk.BlockDevice{{KName: "/dev/sda"}, {KName: "/dev/loop1"}, {KName: "/dev/loop2", Children: []lsblk.BlockDevice{{KName: "/dev/loop2p1"}}}},
-			nodeStatus: v1alpha1.LVMVolumeGroupNodeStatus{Spec: v1alpha1.LVMVolumeGroupNodeStatusSpec{
-				LVMVGStatus: []v1alpha1.VGStatus{
-					{Name: "vg1", Devices: []string{"/dev/loop1", "/dev/loop2"}}},
-			}},
+			name:                 "Both devices are part of the vg",
+			devicePaths:          []string{"/dev/loop1", "/dev/loop2"},
+			blockDevices:         []lsblk.BlockDevice{{KName: "/dev/sda"}, {KName: "/dev/loop1"}, {KName: "/dev/loop2", Children: []lsblk.BlockDevice{{KName: "/dev/loop2p1"}}}},
+			vgs:                  []lvm.VolumeGroup{{Name: "vg1", PVs: []lvm.PhysicalVolume{{PvName: "/dev/loop1"}, {PvName: "/dev/loop2"}}}},
 			wipeCount:            0,
 			removeReferenceCount: 0,
 		},
@@ -200,7 +174,7 @@ func TestWipeDevices(t *testing.T) {
 				}},
 			}
 
-			wiped, err := r.wipeDevicesIfNecessary(ctx, volumeGroup, &tt.nodeStatus, tt.blockDevices)
+			wiped, err := r.wipeDevicesIfNecessary(ctx, volumeGroup, tt.blockDevices, tt.vgs)
 			if tt.wipeCount > 0 {
 				assert.True(t, wiped)
 			} else {


### PR DESCRIPTION
This changes our device selection methodology to try to unify all selection criteria into the filters.

Previously, we had a complex flow with getNewDevicesToBeAdded and filters together.
This now changes this so that all filter criteria are purely handled through filterDevices.

It achieves this by:
1. Creating a new filter function to verify that a block device must be part of the deviceSelector if the deviceSelector is present, otherwise this is a no-op filter
2. Introducing `VerifyMandatoryDevicePaths(devs FilteredBlockDevices, paths[]string) error` as a shortcut to determine if a given path is already setup. This can be used together with `.Spec.storage.deviceClasses[].deviceSelector.Paths` to ensure presence of mandatory paths. For optional paths this check is simply skipped