### PR TITLE
OCPBUGS-37711: fix: ensure wipefs / dmsetup remove use CombinedOutput to wait for both STDERR and STDOUT before continuing

### DIFF
--- a/internal/controllers/lvmcluster/resource/csi_node.go
+++ b/internal/controllers/lvmcluster/resource/csi_node.go
@@ -72,7 +72,10 @@ func (c csiNode) EnsureDeleted(r Reconciler, ctx context.Context, cluster *lvmv1
 			}
 		}
 		if found {
-			return fmt.Errorf("csi node %s does not have driver %s", csiNode.Name, constants.TopolvmCSIDriverName)
+			return fmt.Errorf("csi node %s still has driver %s, "+
+				"if you think this is by mistake, "+
+				"manually login to the node and remove the driver from the kubelets plugin directory",
+				csiNode.Name, constants.TopolvmCSIDriverName)
 		}
 	}
 

--- a/internal/controllers/vgmanager/dmsetup/dmsetup.go
+++ b/internal/controllers/vgmanager/dmsetup/dmsetup.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
+	exec2 "os/exec"
 
 	"github.com/openshift/lvm-operator/v4/internal/controllers/vgmanager/exec"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var (
@@ -41,23 +42,19 @@ func (dmsetup *HostDmsetup) Remove(ctx context.Context, deviceName string) error
 		return errors.New("failed to remove device-mapper reference. Device name is empty")
 	}
 
-	args := []string{"remove"}
-	args = append(args, deviceName)
-	output, err := dmsetup.StartCommandWithOutputAsHost(ctx, dmsetup.dmsetup, args...)
+	output, err := exec2.CommandContext(ctx, "nsenter",
+		append(
+			[]string{"-m", "-u", "-i", "-n", "-p", "-t", "1"},
+			[]string{dmsetup.dmsetup, "remove", "--force", deviceName}...,
+		)...,
+	).CombinedOutput()
+
 	if err == nil {
+		log.FromContext(ctx).Info(fmt.Sprintf("successfully removed the reference from device-mapper %q: %s", deviceName, string(output)))
 		return nil
 	}
 
-	// if err != nil (ExitCode != 0), we can check the cmd output to verify if we have a non-found device
-	data, err := io.ReadAll(output)
-	if err != nil {
-		return fmt.Errorf("failed to read output from device-mapper %q: %w", deviceName, err)
-	}
-	if err := output.Close(); err != nil {
-		return fmt.Errorf("failed to close output from device-mapper %q: %w", deviceName, err)
-	}
-
-	if bytes.Contains(data, []byte("not found")) {
+	if bytes.Contains(output, []byte("not found")) {
 		return ErrReferenceNotFound
 	}
 	return fmt.Errorf("failed to remove the reference from device-mapper %q: %w", deviceName, err)

--- a/internal/controllers/vgmanager/dmsetup/dmsetup_test.go
+++ b/internal/controllers/vgmanager/dmsetup/dmsetup_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
-	"strings"
 	"testing"
 
 	"github.com/go-logr/logr/testr"
@@ -26,16 +24,19 @@ func TestRemove(t *testing.T) {
 	}
 
 	executor := &mockExec.MockExecutor{
-		MockExecuteCommandWithOutputAsHost: func(ctx context.Context, command string, args ...string) (io.ReadCloser, error) {
+		MockCombinedOutputCommandAsHost: func(ctx context.Context, command string, args ...string) ([]byte, error) {
 			if args[0] != "remove" {
-				return io.NopCloser(strings.NewReader("")), fmt.Errorf("invalid args %q", args[0])
+				return nil, fmt.Errorf("invalid args %q", args[0])
 			}
-			if args[1] == "/dev/loop1" {
-				return io.NopCloser(strings.NewReader("")), nil
-			} else if args[1] == "/dev/loop2" {
-				return io.NopCloser(strings.NewReader("device loop2 not found")), errors.New("device loop2 not found")
+			if args[1] != "--force" {
+				return nil, fmt.Errorf("invalid args %q", args[1])
 			}
-			return io.NopCloser(strings.NewReader("")), fmt.Errorf("invalid args %q", args[1])
+			if args[2] == "/dev/loop1" {
+				return nil, nil
+			} else if args[2] == "/dev/loop2" {
+				return []byte("device loop2 not found"), errors.New("device loop2 not found")
+			}
+			return nil, fmt.Errorf("invalid args %q", args[1])
 		},
 	}
 

--- a/internal/controllers/vgmanager/exec/exec.go
+++ b/internal/controllers/vgmanager/exec/exec.go
@@ -31,14 +31,17 @@ import (
 )
 
 var (
-	nsenterPath = "/usr/bin/nsenter"
+	nsEnterPath  = "/usr/bin/nsenter"
+	nsEnterFlags = []string{"-m", "-u", "-i", "-n", "-p", "-t", "1"}
 )
 
 // Executor is the interface for running exec commands
 type Executor interface {
 	StartCommandWithOutputAsHost(ctx context.Context, command string, arg ...string) (io.ReadCloser, error)
 	RunCommandAsHost(ctx context.Context, command string, arg ...string) error
+	CombinedOutputCommandAsHost(ctx context.Context, command string, arg ...string) ([]byte, error)
 	RunCommandAsHostInto(ctx context.Context, into any, command string, arg ...string) error
+	WrapCommandWithNSenter(command string, arg ...string) (string, []string)
 }
 
 // CommandExecutor is an Executor type
@@ -48,6 +51,15 @@ type CommandExecutor struct{}
 // it finishes the run and the output will be printed to the log.
 func (e *CommandExecutor) RunCommandAsHost(ctx context.Context, command string, arg ...string) error {
 	return e.RunCommandAsHostInto(ctx, nil, command, arg...)
+}
+
+// CombinedOutputCommandAsHost executes a command as host and returns an error if the command fails.
+// it finishes the run and the output will be printed to the log.
+func (e *CommandExecutor) CombinedOutputCommandAsHost(ctx context.Context, command string, arg ...string) ([]byte, error) {
+	command, arg = e.WrapCommandWithNSenter(command, arg...)
+	cmd := exec.Command(command, arg...)
+	log.FromContext(ctx).Info("executing", "command", cmd.String())
+	return cmd.CombinedOutput()
 }
 
 // RunCommandAsHostInto executes a command as host and returns an error if the command fails.
@@ -77,11 +89,16 @@ func (e *CommandExecutor) RunCommandAsHostInto(ctx context.Context, into any, co
 // StartCommandWithOutputAsHost executes a command with output as host and returns the output as a ReadCloser.
 // The caller is responsible for closing the ReadCloser.
 // Not calling close on this method will result in a resource leak.
-func (*CommandExecutor) StartCommandWithOutputAsHost(ctx context.Context, command string, arg ...string) (io.ReadCloser, error) {
-	args := append([]string{"-m", "-u", "-i", "-n", "-p", "-t", "1", command}, arg...)
-	cmd := exec.Command(nsenterPath, args...)
+func (e *CommandExecutor) StartCommandWithOutputAsHost(ctx context.Context, command string, arg ...string) (io.ReadCloser, error) {
+	command, arg = e.WrapCommandWithNSenter(command, arg...)
+	cmd := exec.Command(command, arg...)
 	log.FromContext(ctx).Info("executing", "command", cmd.String())
 	return runCommandWithOutput(cmd)
+}
+
+// WrapCommandWithNSenter wraps the command and arguments with nsenter arguments.
+func (*CommandExecutor) WrapCommandWithNSenter(command string, arg ...string) (string, []string) {
+	return nsEnterPath, append(append(nsEnterFlags, command), arg...)
 }
 
 type pipeClosingReadCloser struct {
@@ -91,9 +108,6 @@ type pipeClosingReadCloser struct {
 }
 
 func (p pipeClosingReadCloser) Close() error {
-	if err := p.ReadCloser.Close(); err != nil {
-		return err
-	}
 	// Read the stderr output after the read has finished since we are sure by then the command must have run.
 	stderr, err := io.ReadAll(p.stderr)
 	if err != nil {
@@ -121,9 +135,12 @@ func runCommandWithOutput(cmd *exec.Cmd) (io.ReadCloser, error) {
 	}
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
+		_ = stdout.Close()
 		return nil, err
 	}
 	if err := cmd.Start(); err != nil {
+		_ = stdout.Close()
+		_ = stderr.Close()
 		return nil, err
 	}
 

--- a/internal/controllers/vgmanager/exec/exec.go
+++ b/internal/controllers/vgmanager/exec/exec.go
@@ -80,7 +80,7 @@ func (e *CommandExecutor) RunCommandAsHostInto(ctx context.Context, into any, co
 func (*CommandExecutor) StartCommandWithOutputAsHost(ctx context.Context, command string, arg ...string) (io.ReadCloser, error) {
 	args := append([]string{"-m", "-u", "-i", "-n", "-p", "-t", "1", command}, arg...)
 	cmd := exec.Command(nsenterPath, args...)
-	log.FromContext(ctx).V(1).Info("executing", "command", cmd.String())
+	log.FromContext(ctx).Info("executing", "command", cmd.String())
 	return runCommandWithOutput(cmd)
 }
 
@@ -94,10 +94,13 @@ func (p pipeClosingReadCloser) Close() error {
 	if err := p.ReadCloser.Close(); err != nil {
 		return err
 	}
-
 	// Read the stderr output after the read has finished since we are sure by then the command must have run.
 	stderr, err := io.ReadAll(p.stderr)
 	if err != nil {
+		return err
+	}
+
+	if err := p.stderr.Close(); err != nil {
 		return err
 	}
 

--- a/internal/controllers/vgmanager/exec/test/mock_exec.go
+++ b/internal/controllers/vgmanager/exec/test/mock_exec.go
@@ -21,14 +21,19 @@ import (
 	"errors"
 	"io"
 	"strings"
+
+	vgmanagerexec "github.com/openshift/lvm-operator/v4/internal/controllers/vgmanager/exec"
 )
 
 type MockExecutor struct {
 	MockExecuteCommandWithOutputAsHost func(ctx context.Context, command string, arg ...string) (io.ReadCloser, error)
 
-	MockRunCommandAsHost     func(ctx context.Context, command string, arg ...string) error
-	MockRunCommandAsHostInto func(ctx context.Context, into any, command string, arg ...string) error
+	MockRunCommandAsHost            func(ctx context.Context, command string, arg ...string) error
+	MockRunCommandAsHostInto        func(ctx context.Context, into any, command string, arg ...string) error
+	MockCombinedOutputCommandAsHost func(ctx context.Context, command string, arg ...string) ([]byte, error)
 }
+
+var _ vgmanagerexec.Executor = &MockExecutor{}
 
 // StartCommandWithOutputAsHost mocks StartCommandWithOutputAsHost
 func (e *MockExecutor) StartCommandWithOutputAsHost(ctx context.Context, command string, arg ...string) (io.ReadCloser, error) {
@@ -55,4 +60,16 @@ func (e *MockExecutor) RunCommandAsHostInto(ctx context.Context, into any, comma
 	}
 
 	return errors.New("RunCommandAsHostInto not mocked")
+}
+
+func (e *MockExecutor) CombinedOutputCommandAsHost(ctx context.Context, command string, arg ...string) ([]byte, error) {
+	if e.MockCombinedOutputCommandAsHost != nil {
+		return e.MockCombinedOutputCommandAsHost(ctx, command, arg...)
+	}
+
+	return nil, errors.New("CombinedOutputCommandAsHost not mocked")
+}
+
+func (e *MockExecutor) WrapCommandWithNSenter(command string, arg ...string) (string, []string) {
+	return (&vgmanagerexec.CommandExecutor{}).WrapCommandWithNSenter(command, arg...)
 }

--- a/internal/controllers/vgmanager/wipefs/wipefs_test.go
+++ b/internal/controllers/vgmanager/wipefs/wipefs_test.go
@@ -24,16 +24,16 @@ func TestWipe(t *testing.T) {
 	}
 
 	executor := &mockExec.MockExecutor{
-		MockRunCommandAsHost: func(ctx context.Context, command string, args ...string) error {
+		MockCombinedOutputCommandAsHost: func(ctx context.Context, command string, args ...string) ([]byte, error) {
 			if args[0] != "--all" || args[1] != "--force" {
-				return fmt.Errorf("invalid args %q", args[0:2])
+				return nil, fmt.Errorf("invalid args %q", args[0:2])
 			}
 			if args[2] == "/dev/loop1" {
-				return nil
+				return nil, nil
 			} else if args[2] == "/dev/loop2" {
-				return errors.New("no such file or directory")
+				return nil, errors.New("no such file or directory")
 			}
-			return fmt.Errorf("invalid args %q", args[2])
+			return nil, fmt.Errorf("invalid args %q", args[2])
 		},
 	}
 


### PR DESCRIPTION
This fix is a set of corrections applied to our wiping behavior in order to prohibit a race between different command invocations:

for given
```
for given 
lsblk -o Kname,name
(vdb was created with one partition (type 8E), after which a vg and lv thin pool have been created on it)
vdb   vdb
vdb1  `-vdb1
dm-0    |-some--other--vg-some--lv_tmeta
dm-2    | `-some--other--vg-some--lv
dm-1    `-some--other--vg-some--lv_tdata
dm-2      `-some--other--vg-some--lv
```

the commands will now be
```
dmsetup remove --force /dev/dm-2
dmsetup remove --force /dev/dm-0
dmsetup remove --force /dev/dm-2 //no-op
dmsetup remove --force /dev/dm-1
wipefs --all --force /dev/vdb // will do ioctl reload and cause partition table refresh
```

Previously, we encountered an issue because we used the `RunCommandAsHostInto` method as well as `StartCommandWithOutputAsHost`. However, these methods assume that (as is the case with lvm2) STDERR is not necessary to determine program completion, just STDOUT. However, if a program like wipefs / dmsetup issues a STDERR log after the STDOUT pipe closes, then this is not recognized. This results in the situation that wipefs calls can sometimes "double up" and race each other, which causes unpredictable wiping behavior.

By switching to `CombinedOutputCommandAsHost` we wait for both STDOUT & STDERR to complete fully before moving on as the optimizations for parsing via streaming are not necessary in dmsetup or wipefs.