### PR TITLE
OCPBUGS-37844: fix: resource sync fail -> progressing

### DIFF
--- a/internal/controllers/lvmcluster/controller.go
+++ b/internal/controllers/lvmcluster/controller.go
@@ -44,9 +44,9 @@ type EventReasonInfo string
 type EventReasonError string
 
 const (
-	EventReasonErrorDeletionPending              EventReasonError = "DeletionPending"
-	EventReasonErrorResourceReconciliationFailed EventReasonError = "ResourceReconciliationFailed"
-	EventReasonResourceReconciliationSuccess     EventReasonInfo  = "ResourceReconciliationSuccess"
+	EventReasonErrorDeletionPending                  EventReasonError = "DeletionPending"
+	EventReasonErrorResourceReconciliationIncomplete EventReasonError = "ResourceReconciliationIncomplete"
+	EventReasonResourceReconciliationSuccess         EventReasonInfo  = "ResourceReconciliationSuccess"
 
 	lvmClusterFinalizer = "lvmcluster.topolvm.io"
 	podNameEnv          = "NAME"
@@ -240,8 +240,8 @@ func (r *Reconciler) reconcile(ctx context.Context, instance *lvmv1alpha1.LVMClu
 
 	resourceSyncElapsedTime := time.Since(resourceSyncStart)
 	if len(errs) > 0 {
-		err := fmt.Errorf("failed to reconcile resources managed by LVMCluster: %w", errors.Join(errs...))
-		r.WarningEvent(ctx, instance, EventReasonErrorResourceReconciliationFailed, err)
+		err := fmt.Errorf("LVMCluster's resources are not yet fully synchronized: %w", errors.Join(errs...))
+		r.WarningEvent(ctx, instance, EventReasonErrorResourceReconciliationIncomplete, err)
 		setResourcesAvailableConditionFalse(instance, err)
 		statusErr := r.updateLVMClusterStatus(ctx, instance)
 		if statusErr != nil {

--- a/internal/controllers/lvmcluster/status_test.go
+++ b/internal/controllers/lvmcluster/status_test.go
@@ -924,8 +924,8 @@ func TestComputeReadiness(t *testing.T) {
 				{
 					Type:    lvmv1alpha1.ResourcesAvailable,
 					Status:  metav1.ConditionFalse,
-					Reason:  ReasonResourcesSyncFailed,
-					Message: MessageReasonResourcesSyncFailed,
+					Reason:  ReasonResourcesIncomplete,
+					Message: MessageReasonResourcesSyncIncomplete,
 				},
 				{
 					Type:    lvmv1alpha1.VolumeGroupsReady,
@@ -938,13 +938,13 @@ func TestComputeReadiness(t *testing.T) {
 			expectedReady: false,
 		},
 		{
-			desc: "one failing, one degraded",
+			desc: "one progressing, one degraded",
 			conditions: []metav1.Condition{
 				{
 					Type:    lvmv1alpha1.ResourcesAvailable,
 					Status:  metav1.ConditionFalse,
-					Reason:  ReasonResourcesSyncFailed,
-					Message: MessageReasonResourcesSyncFailed,
+					Reason:  ReasonResourcesIncomplete,
+					Message: MessageReasonResourcesSyncIncomplete,
 				},
 				{
 					Type:    lvmv1alpha1.VolumeGroupsReady,
@@ -953,7 +953,7 @@ func TestComputeReadiness(t *testing.T) {
 					Message: MessageVGsDegraded,
 				},
 			},
-			expectedState: lvmv1alpha1.LVMStatusFailed,
+			expectedState: lvmv1alpha1.LVMStatusDegraded,
 			expectedReady: false,
 		},
 		{
@@ -1000,8 +1000,8 @@ func TestComputeReadiness(t *testing.T) {
 				{
 					Type:    lvmv1alpha1.ResourcesAvailable,
 					Status:  metav1.ConditionFalse,
-					Reason:  ReasonResourcesSyncFailed,
-					Message: MessageReasonResourcesSyncFailed,
+					Reason:  ReasonResourcesIncomplete,
+					Message: MessageReasonResourcesSyncIncomplete,
 				},
 				{
 					Type:    lvmv1alpha1.VolumeGroupsReady,
@@ -1010,7 +1010,7 @@ func TestComputeReadiness(t *testing.T) {
 					Message: MessageVGsUnmanaged,
 				},
 			},
-			expectedState: lvmv1alpha1.LVMStatusFailed,
+			expectedState: lvmv1alpha1.LVMStatusProgressing,
 			expectedReady: false,
 		},
 	}


### PR DESCRIPTION
When the resource syncrhonization fails (e.g. because of an irrepairable error due to cluster state or due to the CSI node not being synchronized) we should move the status to progressing. That is because all of the resource sync problems are either resolvable automatically (after a certain time), or can be remediated by the user through changes in the cluster.

There is an edge that if we configure the pods wrong in the reconcile, then we have a permanent failure with state Progressing. However this is still technically correct since the Reconciler will keep trying to apply the resources (as opposed to perceived Failed which users would expect to not conclude with a retry)