### PR TITLE
OCPEDGE-1168: change DevicePath field to its own type 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,8 +114,8 @@ Here are some tutorials on remotely connecting to a running binary:
 
 1. set up a running OpenShift cluster and install LVMS either via CSV or locally as described above.
 2. login via username & password, ideally kubeadmin, and get the token via `oc whoami -t` to later inject into the test suite. OIDC logins dont use tokens and cannot be used.
-2. download go and install it on your machine (https://golang.org/doc/install) if not already done
-3. use `go run ./test/performance --help` to see the available options for performance testing.
+3. download go and install it on your machine (https://golang.org/doc/install) if not already done
+4. use `go run ./test/performance --help` to see the available options for performance testing.
 
 Mainly we differentiate between 2 kinds of performance tests: Load/Stress Testing, and Idle testing.
 This is important to differentiate because for most installations on edge, LVMS will not be actively working all the time.

--- a/api/v1alpha1/lvmcluster_test.go
+++ b/api/v1alpha1/lvmcluster_test.go
@@ -167,7 +167,7 @@ var _ = Describe("webhook acceptance tests", func() {
 					SizePercent:        90,
 					OverprovisionRatio: 10,
 				},
-				DeviceSelector: &DeviceSelector{Paths: []string{
+				DeviceSelector: &DeviceSelector{Paths: []DevicePath{
 					"/dev/test1",
 				}},
 				FilesystemType: "xfs",
@@ -179,7 +179,7 @@ var _ = Describe("webhook acceptance tests", func() {
 					SizePercent:        90,
 					OverprovisionRatio: 10,
 				},
-				DeviceSelector: &DeviceSelector{Paths: []string{
+				DeviceSelector: &DeviceSelector{Paths: []DevicePath{
 					"/dev/test2",
 				}},
 				FilesystemType: "xfs",
@@ -196,7 +196,7 @@ var _ = Describe("webhook acceptance tests", func() {
 					SizePercent:        90,
 					OverprovisionRatio: 10,
 				},
-				DeviceSelector: &DeviceSelector{Paths: []string{
+				DeviceSelector: &DeviceSelector{Paths: []DevicePath{
 					"/dev/test1",
 				}},
 				FilesystemType: "xfs",
@@ -208,7 +208,7 @@ var _ = Describe("webhook acceptance tests", func() {
 					SizePercent:        90,
 					OverprovisionRatio: 10,
 				},
-				DeviceSelector: &DeviceSelector{Paths: []string{
+				DeviceSelector: &DeviceSelector{Paths: []DevicePath{
 					"/dev/test3",
 				}},
 				FilesystemType: "xfs",
@@ -277,7 +277,7 @@ var _ = Describe("webhook acceptance tests", func() {
 
 	It("device selector with non-dev path is forbidden", func(ctx SpecContext) {
 		resource := defaultLVMClusterInUniqueNamespace(ctx)
-		resource.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{Paths: []string{
+		resource.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{Paths: []DevicePath{
 			"some-random-path",
 		}}
 
@@ -292,7 +292,7 @@ var _ = Describe("webhook acceptance tests", func() {
 
 	It("device selector with non-dev optional path is forbidden", func(ctx SpecContext) {
 		resource := defaultLVMClusterInUniqueNamespace(ctx)
-		resource.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{OptionalPaths: []string{
+		resource.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{OptionalPaths: []DevicePath{
 			"some-random-path",
 		}}
 
@@ -307,7 +307,7 @@ var _ = Describe("webhook acceptance tests", func() {
 
 	It("device selector with overlapping devices in paths is forbidden", func(ctx SpecContext) {
 		resource := defaultLVMClusterInUniqueNamespace(ctx)
-		resource.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{Paths: []string{
+		resource.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{Paths: []DevicePath{
 			"/dev/test1",
 		}}
 		dupe := *resource.Spec.Storage.DeviceClasses[0].DeepCopy()
@@ -326,7 +326,7 @@ var _ = Describe("webhook acceptance tests", func() {
 
 	It("device selector with overlapping devices in optional paths is forbidden", func(ctx SpecContext) {
 		resource := defaultLVMClusterInUniqueNamespace(ctx)
-		resource.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{OptionalPaths: []string{
+		resource.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{OptionalPaths: []DevicePath{
 			"/dev/test1",
 		}}
 		dupe := *resource.Spec.Storage.DeviceClasses[0].DeepCopy()
@@ -477,7 +477,7 @@ var _ = Describe("webhook acceptance tests", func() {
 		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 		updated := resource.DeepCopy()
-		updated.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{Paths: []string{"/dev/newpath"}}
+		updated.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{Paths: []DevicePath{"/dev/newpath"}}
 
 		err := k8sClient.Update(ctx, updated)
 		Expect(err).To(HaveOccurred())
@@ -494,7 +494,7 @@ var _ = Describe("webhook acceptance tests", func() {
 		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 		updated := resource.DeepCopy()
-		updated.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{OptionalPaths: []string{"/dev/newpath"}}
+		updated.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{OptionalPaths: []DevicePath{"/dev/newpath"}}
 
 		err := k8sClient.Update(ctx, updated)
 		Expect(err).To(HaveOccurred())
@@ -508,11 +508,11 @@ var _ = Describe("webhook acceptance tests", func() {
 
 	It("device paths cannot be removed from device class in update", func(ctx SpecContext) {
 		resource := defaultLVMClusterInUniqueNamespace(ctx)
-		resource.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{Paths: []string{"/dev/newpath"}}
+		resource.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{Paths: []DevicePath{"/dev/newpath"}}
 		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 		updated := resource.DeepCopy()
-		updated.Spec.Storage.DeviceClasses[0].DeviceSelector.Paths = []string{"/dev/otherpath"}
+		updated.Spec.Storage.DeviceClasses[0].DeviceSelector.Paths = []DevicePath{"/dev/otherpath"}
 
 		err := k8sClient.Update(ctx, updated)
 		Expect(err).To(HaveOccurred())
@@ -526,11 +526,11 @@ var _ = Describe("webhook acceptance tests", func() {
 
 	It("optional device paths cannot be removed from device class in update", func(ctx SpecContext) {
 		resource := defaultLVMClusterInUniqueNamespace(ctx)
-		resource.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{OptionalPaths: []string{"/dev/newpath"}}
+		resource.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{OptionalPaths: []DevicePath{"/dev/newpath"}}
 		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 		updated := resource.DeepCopy()
-		updated.Spec.Storage.DeviceClasses[0].DeviceSelector.OptionalPaths = []string{"/dev/otherpath"}
+		updated.Spec.Storage.DeviceClasses[0].DeviceSelector.OptionalPaths = []DevicePath{"/dev/otherpath"}
 
 		err := k8sClient.Update(ctx, updated)
 		Expect(err).To(HaveOccurred())
@@ -544,7 +544,7 @@ var _ = Describe("webhook acceptance tests", func() {
 
 	It("force wipe option cannot be added in update", func(ctx SpecContext) {
 		resource := defaultLVMClusterInUniqueNamespace(ctx)
-		resource.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{Paths: []string{"/dev/newpath"}}
+		resource.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{Paths: []DevicePath{"/dev/newpath"}}
 		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 		updated := resource.DeepCopy()
@@ -562,7 +562,7 @@ var _ = Describe("webhook acceptance tests", func() {
 
 	It("force wipe option cannot be changed in update", func(ctx SpecContext) {
 		resource := defaultLVMClusterInUniqueNamespace(ctx)
-		resource.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{Paths: []string{"/dev/newpath"}, ForceWipeDevicesAndDestroyAllData: ptr.To[bool](false)}
+		resource.Spec.Storage.DeviceClasses[0].DeviceSelector = &DeviceSelector{Paths: []DevicePath{"/dev/newpath"}, ForceWipeDevicesAndDestroyAllData: ptr.To[bool](false)}
 		Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 
 		updated := resource.DeepCopy()

--- a/api/v1alpha1/lvmcluster_types.go
+++ b/api/v1alpha1/lvmcluster_types.go
@@ -130,17 +130,23 @@ type DeviceSelector struct {
 
 	// Paths specify the device paths.
 	// +optional
-	Paths []string `json:"paths,omitempty"`
+	Paths []DevicePath `json:"paths,omitempty"`
 
 	// OptionalPaths specify the optional device paths.
 	// +optional
-	OptionalPaths []string `json:"optionalPaths,omitempty"`
+	OptionalPaths []DevicePath `json:"optionalPaths,omitempty"`
 
 	// ForceWipeDevicesAndDestroyAllData is a flag to force wipe the selected devices.
 	// This wipes the file signatures on the devices. Use this feature with caution.
 	// Force wipe the devices only when you know that they do not contain any important data.
 	// +optional
 	ForceWipeDevicesAndDestroyAllData *bool `json:"forceWipeDevicesAndDestroyAllData,omitempty"`
+}
+
+type DevicePath string
+
+func (d DevicePath) Unresolved() string {
+	return string(d)
 }
 
 type LVMStateType string

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -83,12 +83,12 @@ func (in *DeviceSelector) DeepCopyInto(out *DeviceSelector) {
 	*out = *in
 	if in.Paths != nil {
 		in, out := &in.Paths, &out.Paths
-		*out = make([]string, len(*in))
+		*out = make([]DevicePath, len(*in))
 		copy(*out, *in)
 	}
 	if in.OptionalPaths != nil {
 		in, out := &in.OptionalPaths, &out.OptionalPaths
-		*out = make([]string, len(*in))
+		*out = make([]DevicePath, len(*in))
 		copy(*out, *in)
 	}
 	if in.ForceWipeDevicesAndDestroyAllData != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,9 +27,9 @@ import (
 )
 
 func main() {
-	logr := ctrl.Log.WithName("setup")
-	if err := NewCmd(logr).Execute(); err != nil {
-		logr.Error(err, "fatal error encountered")
+	log := ctrl.Log.WithName("setup")
+	if err := NewCmd(log).Execute(); err != nil {
+		log.Error(err, "fatal error encountered")
 		os.Exit(1)
 	}
 }

--- a/cmd/vgmanager/vgmanager.go
+++ b/cmd/vgmanager/vgmanager.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -192,17 +193,18 @@ func run(cmd *cobra.Command, _ []string, opts *Options) error {
 	}
 
 	if err = (&vgmanager.Reconciler{
-		Client:        mgr.GetClient(),
-		EventRecorder: mgr.GetEventRecorderFor(vgmanager.ControllerName),
-		LVMD:          lvmd.DefaultConfigurator(),
-		Scheme:        mgr.GetScheme(),
-		LSBLK:         lsblk.NewDefaultHostLSBLK(),
-		Wipefs:        wipefs.NewDefaultHostWipefs(),
-		Dmsetup:       dmsetup.NewDefaultHostDmsetup(),
-		LVM:           lvm.NewDefaultHostLVM(),
-		NodeName:      nodeName,
-		Namespace:     operatorNamespace,
-		Filters:       filter.DefaultFilters,
+		Client:           mgr.GetClient(),
+		EventRecorder:    mgr.GetEventRecorderFor(vgmanager.ControllerName),
+		LVMD:             lvmd.DefaultConfigurator(),
+		Scheme:           mgr.GetScheme(),
+		LSBLK:            lsblk.NewDefaultHostLSBLK(),
+		Wipefs:           wipefs.NewDefaultHostWipefs(),
+		Dmsetup:          dmsetup.NewDefaultHostDmsetup(),
+		LVM:              lvm.NewDefaultHostLVM(),
+		NodeName:         nodeName,
+		Namespace:        operatorNamespace,
+		Filters:          filter.DefaultFilters,
+		SymlinkResolveFn: filepath.EvalSymlinks,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller VGManager: %w", err)
 	}

--- a/docs/design/lvm-operator-manager.md
+++ b/docs/design/lvm-operator-manager.md
@@ -61,7 +61,7 @@ The Operator requires elevated permissions to interact with the host's LVM comma
 
 ## Implementation Notes
 
-Each unit of reconciliation should implement the `reconcileUnit` interface. This is run by the controller. Errors and success messages are propagated as Operator status and events. This interface is defined in [lvmcluster_controller.go](../../internal/controllers/lvmcluster/lvmcluster_controller.go)
+Each unit of reconciliation should implement the `reconcileUnit` interface. This is run by the controller. Errors and success messages are propagated as Operator status and events. This interface is defined in [manager.go](../../internal/controllers/lvmcluster/resource/manager.go)
 
 ```go
 type resourceManager interface {

--- a/hack/debug.Dockerfile
+++ b/hack/debug.Dockerfile
@@ -2,7 +2,7 @@
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETPLATFORM
-FROM golang:1.20 as builder
+FROM golang:1.22 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -26,7 +26,7 @@ ENV CGO_ENABLED=0
 # Build
 RUN go build -gcflags "all=-N -l" -mod=vendor -a -o lvms cmd/main.go
 
-FROM golang:1.20 as dlv
+FROM golang:1.22 as dlv
 RUN go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@latest
 
 # vgmanager needs 'nsenter' and other basic linux utils to correctly function

--- a/internal/controllers/symlink-resolver/resolver.go
+++ b/internal/controllers/symlink-resolver/resolver.go
@@ -1,0 +1,42 @@
+package symlinkResolver
+
+import (
+	"path/filepath"
+	"sync"
+)
+
+type Resolver struct {
+	resolveFn ResolveFn
+	cache     sync.Map
+}
+
+type ResolveFn func(string) (string, error)
+
+var defaultResolverFn = filepath.EvalSymlinks
+
+func NewWithDefaultResolver() *Resolver {
+	return NewWithResolver(defaultResolverFn)
+}
+
+func NewWithResolver(resolveFn ResolveFn) *Resolver {
+	if resolveFn == nil {
+		resolveFn = defaultResolverFn
+	}
+	return &Resolver{
+		resolveFn: resolveFn,
+		cache:     sync.Map{},
+	}
+}
+
+func (r *Resolver) Resolve(path string) (string, error) {
+	var err error
+	val, ok := r.cache.Load(path)
+	if !ok {
+		val, err = r.resolveFn(path)
+		if err != nil {
+			return "", err
+		}
+		r.cache.Store(path, val)
+	}
+	return val.(string), nil
+}

--- a/internal/controllers/symlink-resolver/resolver_test.go
+++ b/internal/controllers/symlink-resolver/resolver_test.go
@@ -1,0 +1,73 @@
+package symlinkResolver
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestNewWithDefaultResolver(t *testing.T) {
+	resolver := NewWithDefaultResolver()
+	assert.Assert(t, resolver != nil)
+	assert.Assert(t, resolver.resolveFn != nil)
+}
+
+func TestNewWithResolver(t *testing.T) {
+	resolver := NewWithResolver(func(s string) (string, error) {
+		return "super-test", nil
+	})
+	assert.Assert(t, resolver != nil)
+
+	path, err := resolver.Resolve("test")
+	assert.NilError(t, err)
+	assert.Equal(t, "super-test", path)
+}
+
+func TestResolver_Resolve(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		resolveFn ResolveFn
+		args      string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "successful resolution",
+			resolveFn: func(s string) (string, error) { return s, nil },
+			args:      "1",
+			want:      "1",
+			wantErr:   false,
+		},
+		{
+			name:      "resolve error",
+			resolveFn: func(s string) (string, error) { return "", fmt.Errorf("test error") },
+			args:      "1",
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Resolver{
+				resolveFn: tt.resolveFn,
+				cache:     sync.Map{},
+			}
+			got, err := r.Resolve(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Resolve() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Resolve() got = %v, want %v", got, tt.want)
+			}
+
+			if !tt.wantErr {
+				val, ok := r.cache.Load("1")
+				assert.Assert(t, ok)
+				assert.Equal(t, val, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controllers/vgmanager/kname_test.go
+++ b/internal/controllers/vgmanager/kname_test.go
@@ -3,15 +3,17 @@ package vgmanager
 import (
 	"path/filepath"
 	"runtime"
+
+	"github.com/openshift/lvm-operator/v4/api/v1alpha1"
 )
 
-func getKNameFromDevice(device string) string {
+func getKNameFromDevice(device string) v1alpha1.DevicePath {
 	// HACK: if we are on unix, we can simply use the "/tmp" path.
 	// if we are on darwin, then the symlink of the temp file
 	// will resolve to /private/var from /var, so we have to adjust
 	// the block device name
 	if runtime.GOOS == "darwin" {
-		return filepath.Join("/", "private", device)
+		return v1alpha1.DevicePath(filepath.Join("/", "private", device))
 	}
-	return device
+	return v1alpha1.DevicePath(device)
 }

--- a/test/performance/collector.go
+++ b/test/performance/collector.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	toml "github.com/pelletier/go-toml/v2"
+	"github.com/pelletier/go-toml/v2"
 )
 
 type Collector struct {

--- a/test/performance/parse.go
+++ b/test/performance/parse.go
@@ -31,7 +31,7 @@ func parseMetrics(metricsResult string) ([]RawMetric, error) {
 		return nil, fmt.Errorf("failed to unmarshal metrics: %w", err)
 	}
 
-	metrics := []RawMetric{}
+	metrics := make([]RawMetric, 0)
 
 	for _, res := range d.Data.Result {
 		if res.Metric.Container == "POD" {


### PR DESCRIPTION
Introduce a new type called DevicePath to contain user provided device path. This is done in order to create a standard way of working with resolved if symlink or raw(unresolved) device path and avoid errors when it's not resolved while it's expected to be.