### PR TITLE
OCPEDGE-1200: feat: allow dynamic add/remove of devices via pvmove

### DIFF
--- a/api/v1alpha1/lvmcluster_types.go
+++ b/api/v1alpha1/lvmcluster_types.go
@@ -143,6 +143,13 @@ type DeviceSelector struct {
 	ForceWipeDevicesAndDestroyAllData *bool `json:"forceWipeDevicesAndDestroyAllData,omitempty"`
 }
 
+func (d *DeviceSelector) AllPaths() []DevicePath {
+	paths := make([]DevicePath, len(d.Paths)+len(d.OptionalPaths))
+	copy(paths, d.Paths)
+	copy(paths[len(d.Paths):], d.OptionalPaths)
+	return paths
+}
+
 type DevicePath string
 
 func (d DevicePath) Unresolved() string {

--- a/api/v1alpha1/lvmcluster_webhook.go
+++ b/api/v1alpha1/lvmcluster_webhook.go
@@ -237,13 +237,13 @@ func (v *lvmClusterValidator) ValidateUpdate(_ context.Context, old, new runtime
 			return warnings, ErrDevicePathsCannotBeAddedInUpdate
 		}
 
-		if err := validateDevicePathsStillExist(oldDevices, newDevices); err != nil {
-			return warnings, fmt.Errorf("invalid: required device paths were deleted from the LVMCluster: %w", err)
-		}
-
-		if err := validateDevicePathsStillExist(oldOptionalDevices, newOptionalDevices); err != nil {
-			return warnings, fmt.Errorf("invalid: optional device paths were deleted from the LVMCluster: %w", err)
-		}
+		// if err := validateDevicePathsStillExist(oldDevices, newDevices); err != nil {
+		// 	return warnings, fmt.Errorf("invalid: required device paths were deleted from the LVMCluster: %w", err)
+		// }
+		//
+		// if err := validateDevicePathsStillExist(oldOptionalDevices, newOptionalDevices); err != nil {
+		// 	return warnings, fmt.Errorf("invalid: optional device paths were deleted from the LVMCluster: %w", err)
+		// }
 
 	}
 
@@ -269,24 +269,24 @@ func validateDeviceClassesStillExist(old, new []DeviceClass) error {
 	return nil
 }
 
-func validateDevicePathsStillExist(old, new []DevicePath) error {
-	deviceMap := make(map[DevicePath]struct{})
-
-	for _, device := range old {
-		deviceMap[device] = struct{}{}
-	}
-
-	for _, device := range new {
-		delete(deviceMap, device)
-	}
-
-	// if any old device is removed now
-	if len(deviceMap) != 0 {
-		return fmt.Errorf("devices can not be removed from the LVMCluster once added oldDevices:%s, newDevices:%s", old, new)
-	}
-
-	return nil
-}
+// func validateDevicePathsStillExist(old, new []DevicePath) error {
+// 	deviceMap := make(map[DevicePath]struct{})
+//
+// 	for _, device := range old {
+// 		deviceMap[device] = struct{}{}
+// 	}
+//
+// 	for _, device := range new {
+// 		delete(deviceMap, device)
+// 	}
+//
+// 	// if any old device is removed now
+// 	if len(deviceMap) != 0 {
+// 		return fmt.Errorf("devices can not be removed from the LVMCluster once added oldDevices:%s, newDevices:%s", old, new)
+// 	}
+//
+// 	return nil
+// }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (v *lvmClusterValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {

--- a/api/v1alpha1/lvmvolumegroupnodestatus_types.go
+++ b/api/v1alpha1/lvmvolumegroupnodestatus_types.go
@@ -58,9 +58,11 @@ type VGStatus struct {
 	// Reason provides more detail on the volume group creation status
 	Reason string `json:"reason,omitempty"`
 	// Devices is the list of devices used by the volume group
+	//+listType=atomic
 	Devices []string `json:"devices,omitempty"`
 	// Excluded contains the per node status of applied device exclusions that were picked up via selector,
 	// but were not used for other reasons.
+	//+listType=atomic
 	Excluded []ExcludedDevice `json:"excluded,omitempty"`
 	// DeviceDiscoveryPolicy is a field to indicate whether the devices are discovered
 	// at runtime or preconfigured through a DeviceSelector

--- a/config/crd/bases/lvm.topolvm.io_lvmclusters.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmclusters.yaml
@@ -382,6 +382,7 @@ spec:
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                           excluded:
                             description: |-
                               Excluded contains the per node status of applied device exclusions that were picked up via selector,
@@ -402,6 +403,7 @@ spec:
                               - reasons
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           name:
                             description: Name is the name of the volume group
                             type: string

--- a/config/crd/bases/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
@@ -63,6 +63,7 @@ spec:
                       items:
                         type: string
                       type: array
+                      x-kubernetes-list-type: atomic
                     excluded:
                       description: |-
                         Excluded contains the per node status of applied device exclusions that were picked up via selector,
@@ -83,6 +84,7 @@ spec:
                         - reasons
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     name:
                       description: Name is the name of the volume group
                       type: string

--- a/internal/controllers/lvmcluster/controller.go
+++ b/internal/controllers/lvmcluster/controller.go
@@ -241,7 +241,9 @@ func (r *Reconciler) reconcile(ctx context.Context, instance *lvmv1alpha1.LVMClu
 	resourceSyncElapsedTime := time.Since(resourceSyncStart)
 	if len(errs) > 0 {
 		err := fmt.Errorf("LVMCluster's resources are not yet fully synchronized: %w", errors.Join(errs...))
-		r.WarningEvent(ctx, instance, EventReasonErrorResourceReconciliationIncomplete, err)
+		if logger.V(1).Enabled() {
+			r.WarningEvent(ctx, instance, EventReasonErrorResourceReconciliationIncomplete, err)
+		}
 		setResourcesAvailableConditionFalse(instance, err)
 		statusErr := r.updateLVMClusterStatus(ctx, instance)
 		if statusErr != nil {

--- a/internal/controllers/vgmanager/lvm/lvm_test.go
+++ b/internal/controllers/vgmanager/lvm/lvm_test.go
@@ -100,7 +100,7 @@ func TestHostLVM_GetVG(t *testing.T) {
 							return fmt.Errorf("mocked error")
 						}
 						argsConcat := strings.Join(args, " ")
-						out := "--units g -v --reportformat json -S vgname=%s"
+						out := "--units b -v --reportformat json -S vgname=%s"
 						if argsConcat == fmt.Sprintf(out, "vg1") {
 							return json.Unmarshal([]byte(mockPvsOutputForVG1), &into)
 						} else if argsConcat == fmt.Sprintf(out, "vg2") {
@@ -586,7 +586,7 @@ func TestNewDefaultHostLVM(t *testing.T) {
 }
 
 func Test_untaggedVGs(t *testing.T) {
-	vgs := []VolumeGroup{
+	vgs := []*VolumeGroup{
 		{Name: "vg1", Tags: []string{"tag1"}},
 		{Name: "vg2", Tags: []string{DefaultTag}},
 	}

--- a/internal/controllers/vgmanager/lvm/mocks/mock_lvm.go
+++ b/internal/controllers/vgmanager/lvm/mocks/mock_lvm.go
@@ -768,11 +768,11 @@ func (_c *MockLVM_ListVGs_Call) RunAndReturn(run func(context.Context, bool) ([]
 }
 
 // MoveExtentsBetweenPVs provides a mock function with given fields: ctx, from, to
-func (_m *MockLVM) MoveExtentsBetweenPVs(ctx context.Context, from []string, to []string) error {
+func (_m *MockLVM) MovePhysicalExtents(ctx context.Context, from []string, to []string) error {
 	ret := _m.Called(ctx, from, to)
 
 	if len(ret) == 0 {
-		panic("no return value specified for MoveExtentsBetweenPVs")
+		panic("no return value specified for MovePhysicalExtents")
 	}
 
 	var r0 error
@@ -785,7 +785,7 @@ func (_m *MockLVM) MoveExtentsBetweenPVs(ctx context.Context, from []string, to 
 	return r0
 }
 
-// MockLVM_MoveExtentsBetweenPVs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MoveExtentsBetweenPVs'
+// MockLVM_MoveExtentsBetweenPVs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MovePhysicalExtents'
 type MockLVM_MoveExtentsBetweenPVs_Call struct {
 	*mock.Call
 }
@@ -795,7 +795,7 @@ type MockLVM_MoveExtentsBetweenPVs_Call struct {
 //   - from []string
 //   - to []string
 func (_e *MockLVM_Expecter) MoveExtentsBetweenPVs(ctx interface{}, from interface{}, to interface{}) *MockLVM_MoveExtentsBetweenPVs_Call {
-	return &MockLVM_MoveExtentsBetweenPVs_Call{Call: _e.mock.On("MoveExtentsBetweenPVs", ctx, from, to)}
+	return &MockLVM_MoveExtentsBetweenPVs_Call{Call: _e.mock.On("MovePhysicalExtents", ctx, from, to)}
 }
 
 func (_c *MockLVM_MoveExtentsBetweenPVs_Call) Run(run func(ctx context.Context, from []string, to []string)) *MockLVM_MoveExtentsBetweenPVs_Call {

--- a/internal/controllers/vgmanager/lvm/mocks/mock_lvm.go
+++ b/internal/controllers/vgmanager/lvm/mocks/mock_lvm.go
@@ -709,23 +709,23 @@ func (_c *MockLVM_ListPVs_Call) RunAndReturn(run func(context.Context, string) (
 }
 
 // ListVGs provides a mock function with given fields: ctx, taggedByLVMS
-func (_m *MockLVM) ListVGs(ctx context.Context, taggedByLVMS bool) ([]lvm.VolumeGroup, error) {
+func (_m *MockLVM) ListVGs(ctx context.Context, taggedByLVMS bool) ([]*lvm.VolumeGroup, error) {
 	ret := _m.Called(ctx, taggedByLVMS)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListVGs")
 	}
 
-	var r0 []lvm.VolumeGroup
+	var r0 []*lvm.VolumeGroup
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, bool) ([]lvm.VolumeGroup, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, bool) ([]*lvm.VolumeGroup, error)); ok {
 		return rf(ctx, taggedByLVMS)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, bool) []lvm.VolumeGroup); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, bool) []*lvm.VolumeGroup); ok {
 		r0 = rf(ctx, taggedByLVMS)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]lvm.VolumeGroup)
+			r0 = ret.Get(0).([]*lvm.VolumeGroup)
 		}
 	}
 
@@ -757,12 +757,108 @@ func (_c *MockLVM_ListVGs_Call) Run(run func(ctx context.Context, taggedByLVMS b
 	return _c
 }
 
-func (_c *MockLVM_ListVGs_Call) Return(_a0 []lvm.VolumeGroup, _a1 error) *MockLVM_ListVGs_Call {
+func (_c *MockLVM_ListVGs_Call) Return(_a0 []*lvm.VolumeGroup, _a1 error) *MockLVM_ListVGs_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockLVM_ListVGs_Call) RunAndReturn(run func(context.Context, bool) ([]lvm.VolumeGroup, error)) *MockLVM_ListVGs_Call {
+func (_c *MockLVM_ListVGs_Call) RunAndReturn(run func(context.Context, bool) ([]*lvm.VolumeGroup, error)) *MockLVM_ListVGs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MoveExtentsBetweenPVs provides a mock function with given fields: ctx, from, to
+func (_m *MockLVM) MoveExtentsBetweenPVs(ctx context.Context, from []string, to []string) error {
+	ret := _m.Called(ctx, from, to)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MoveExtentsBetweenPVs")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, []string, []string) error); ok {
+		r0 = rf(ctx, from, to)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockLVM_MoveExtentsBetweenPVs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MoveExtentsBetweenPVs'
+type MockLVM_MoveExtentsBetweenPVs_Call struct {
+	*mock.Call
+}
+
+// MoveExtentsBetweenPVs is a helper method to define mock.On call
+//   - ctx context.Context
+//   - from []string
+//   - to []string
+func (_e *MockLVM_Expecter) MoveExtentsBetweenPVs(ctx interface{}, from interface{}, to interface{}) *MockLVM_MoveExtentsBetweenPVs_Call {
+	return &MockLVM_MoveExtentsBetweenPVs_Call{Call: _e.mock.On("MoveExtentsBetweenPVs", ctx, from, to)}
+}
+
+func (_c *MockLVM_MoveExtentsBetweenPVs_Call) Run(run func(ctx context.Context, from []string, to []string)) *MockLVM_MoveExtentsBetweenPVs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]string), args[2].([]string))
+	})
+	return _c
+}
+
+func (_c *MockLVM_MoveExtentsBetweenPVs_Call) Return(_a0 error) *MockLVM_MoveExtentsBetweenPVs_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockLVM_MoveExtentsBetweenPVs_Call) RunAndReturn(run func(context.Context, []string, []string) error) *MockLVM_MoveExtentsBetweenPVs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ReduceVG provides a mock function with given fields: ctx, name, reduce
+func (_m *MockLVM) ReduceVG(ctx context.Context, name string, reduce []string) error {
+	ret := _m.Called(ctx, name, reduce)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReduceVG")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, []string) error); ok {
+		r0 = rf(ctx, name, reduce)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockLVM_ReduceVG_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReduceVG'
+type MockLVM_ReduceVG_Call struct {
+	*mock.Call
+}
+
+// ReduceVG is a helper method to define mock.On call
+//   - ctx context.Context
+//   - name string
+//   - reduce []string
+func (_e *MockLVM_Expecter) ReduceVG(ctx interface{}, name interface{}, reduce interface{}) *MockLVM_ReduceVG_Call {
+	return &MockLVM_ReduceVG_Call{Call: _e.mock.On("ReduceVG", ctx, name, reduce)}
+}
+
+func (_c *MockLVM_ReduceVG_Call) Run(run func(ctx context.Context, name string, reduce []string)) *MockLVM_ReduceVG_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].([]string))
+	})
+	return _c
+}
+
+func (_c *MockLVM_ReduceVG_Call) Return(_a0 error) *MockLVM_ReduceVG_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockLVM_ReduceVG_Call) RunAndReturn(run func(context.Context, string, []string) error) *MockLVM_ReduceVG_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/controllers/vgmanager/pvworker/move_worker.go
+++ b/internal/controllers/vgmanager/pvworker/move_worker.go
@@ -1,0 +1,131 @@
+package pvworker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"time"
+)
+
+var ErrWorkerAlreadySyncingPVs = errors.New("worker is already syncing PVs")
+
+type MoveExtentFn = func(ctx context.Context, from []string, to []string) error
+
+type AsyncExtentMover interface {
+	Sync(from, to []string) error
+	IsSyncing() bool
+	Status() *SyncStatus
+	Reset() error
+}
+
+type SyncStatus struct {
+	state    SyncState
+	err      error
+	start    time.Time
+	end      time.Time
+	from, to []string
+}
+
+func (s *SyncStatus) State() SyncState {
+	return s.state
+}
+
+func (s *SyncStatus) Error() error {
+	return s.err
+}
+
+func (s *SyncStatus) Operation() (from []string, to []string) {
+	return s.from, s.to
+}
+
+// SyncDuration returns the duration of the sync operation since it started and until it finished.
+func (s *SyncStatus) SyncDuration() time.Duration {
+	if s.end.IsZero() {
+		return time.Since(s.start)
+	}
+	return s.end.Sub(s.start)
+}
+
+type SyncState string
+
+const (
+	SyncStateSyncing SyncState = "syncing"
+	SyncStateError   SyncState = "error"
+	SyncStateIdle    SyncState = "idle"
+	SyncStateDone    SyncState = "done"
+)
+
+func NewAsyncExtentMover(move MoveExtentFn) AsyncExtentMover {
+	worker := &asyncExtentMover{
+		syncStatus: atomic.Pointer[SyncStatus]{},
+		pvMove:     move,
+	}
+	worker.syncStatus.Store(&SyncStatus{state: SyncStateIdle})
+	return worker
+}
+
+type asyncExtentMover struct {
+	syncStatus atomic.Pointer[SyncStatus]
+	pvMove     MoveExtentFn
+}
+
+func (w *asyncExtentMover) Sync(from, to []string) error {
+	if w.IsSyncing() {
+		return ErrWorkerAlreadySyncingPVs
+	}
+
+	if w.syncStatus.Load().state == SyncStateError {
+		return fmt.Errorf("cannot start new sync operation when previous one failed, "+
+			"explicit reset is necessary: %w", w.syncStatus.Load().err)
+	}
+
+	w.startSync(from, to)
+	go func(ctx context.Context, from, to []string) {
+		err := w.pvMove(ctx, from, to)
+		w.finishSync(err)
+	}(context.Background(), from, to)
+
+	return nil
+}
+
+func (w *asyncExtentMover) Status() *SyncStatus {
+	return w.syncStatus.Load()
+}
+
+func (w *asyncExtentMover) IsSyncing() bool {
+	return w.syncStatus.Load().state == SyncStateSyncing
+}
+
+func (w *asyncExtentMover) startSync(from, to []string) {
+	w.syncStatus.Store(&SyncStatus{
+		state: SyncStateSyncing,
+		start: time.Now(),
+		from:  from,
+		to:    to,
+	})
+}
+
+func (w *asyncExtentMover) finishSync(err error) {
+	var state SyncState
+	if err != nil {
+		state = SyncStateError
+	} else {
+		state = SyncStateDone
+	}
+	status := w.syncStatus.Load()
+	status.err = err
+	status.state = state
+	status.end = time.Now()
+	w.syncStatus.Store(status)
+}
+
+func (w *asyncExtentMover) Reset() error {
+	if w.IsSyncing() {
+		return fmt.Errorf("cannot reset running worker: %w", ErrWorkerAlreadySyncingPVs)
+	}
+
+	w.syncStatus.Store(&SyncStatus{state: SyncStateIdle})
+
+	return nil
+}

--- a/internal/controllers/vgmanager/status.go
+++ b/internal/controllers/vgmanager/status.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func (r *Reconciler) setVolumeGroupProgressingStatus(ctx context.Context, vg *lvmv1alpha1.LVMVolumeGroup, vgs []lvm.VolumeGroup, devices FilteredBlockDevices) (bool, error) {
+func (r *Reconciler) setVolumeGroupProgressingStatus(ctx context.Context, vg *lvmv1alpha1.LVMVolumeGroup, vgs []*lvm.VolumeGroup, devices *FilteredBlockDevices) (bool, error) {
 	status := &lvmv1alpha1.VGStatus{
 		Name:   vg.GetName(),
 		Status: lvmv1alpha1.VGStatusProgressing,
@@ -46,7 +46,7 @@ func (r *Reconciler) setVolumeGroupProgressingStatus(ctx context.Context, vg *lv
 	return r.setVolumeGroupStatus(ctx, vg, status)
 }
 
-func (r *Reconciler) setVolumeGroupReadyStatus(ctx context.Context, vg *lvmv1alpha1.LVMVolumeGroup, vgs []lvm.VolumeGroup, devices FilteredBlockDevices) (bool, error) {
+func (r *Reconciler) setVolumeGroupReadyStatus(ctx context.Context, vg *lvmv1alpha1.LVMVolumeGroup, vgs []*lvm.VolumeGroup, devices *FilteredBlockDevices) (bool, error) {
 	status := &lvmv1alpha1.VGStatus{
 		Name:   vg.GetName(),
 		Status: lvmv1alpha1.VGStatusReady,
@@ -60,7 +60,7 @@ func (r *Reconciler) setVolumeGroupReadyStatus(ctx context.Context, vg *lvmv1alp
 	return r.setVolumeGroupStatus(ctx, vg, status)
 }
 
-func (r *Reconciler) setVolumeGroupFailedStatus(ctx context.Context, vg *lvmv1alpha1.LVMVolumeGroup, vgs []lvm.VolumeGroup, devices FilteredBlockDevices, err error) (bool, error) {
+func (r *Reconciler) setVolumeGroupFailedStatus(ctx context.Context, vg *lvmv1alpha1.LVMVolumeGroup, vgs []*lvm.VolumeGroup, devices *FilteredBlockDevices, err error) (bool, error) {
 	status := &lvmv1alpha1.VGStatus{
 		Name:   vg.GetName(),
 		Status: lvmv1alpha1.VGStatusFailed,
@@ -170,7 +170,7 @@ func (r *Reconciler) removeVolumeGroupStatus(ctx context.Context, vg *lvmv1alpha
 	return nil
 }
 
-func (r *Reconciler) setDevices(status *lvmv1alpha1.VGStatus, vgs []lvm.VolumeGroup, devices FilteredBlockDevices) (bool, error) {
+func (r *Reconciler) setDevices(status *lvmv1alpha1.VGStatus, vgs []*lvm.VolumeGroup, devices *FilteredBlockDevices) (bool, error) {
 	devicesExist := false
 	for _, vg := range vgs {
 		if status.Name == vg.Name {


### PR DESCRIPTION
This is a sample implementation of dynamic device selectors via pvmove and vgreduce. Here is an example of a modified LVMCluster:

```
apiVersion: v1
count: 1
eventTime: null
firstTimestamp: "2024-08-26T15:29:33Z"
involvedObject:
  apiVersion: lvm.topolvm.io/v1alpha1
  kind: LVMCluster
  name: my-lvmcluster
  namespace: openshift-storage
  uid: 0dc5f864-0404-4a44-a0f7-c47e296d1aea
kind: Event
lastTimestamp: "2024-08-26T15:29:33Z"
message: 'update on node openshift-storage/crc in volume group openshift-storage/vg1:
  moving extents from reduction candidates (/dev/vdc) to left pvs (/dev/vdb) to ensure
  consistent data after path removal'
metadata:
  creationTimestamp: "2024-08-26T15:29:33Z"
  name: my-lvmcluster.17ef50efdc764466
  namespace: openshift-storage
  resourceVersion: "819668"
  uid: 05d96f72-8864-46e2-862a-7d6b8f02a062
reason: ExtentMigrationStarted
reportingComponent: vg-manager
reportingInstance: ""
source:
  component: vg-manager
type: Normal
```

```
apiVersion: v1
count: 1
eventTime: null
firstTimestamp: "2024-08-26T15:30:03Z"
involvedObject:
  apiVersion: lvm.topolvm.io/v1alpha1
  kind: LVMCluster
  name: my-lvmcluster
  namespace: openshift-storage
  uid: 0dc5f864-0404-4a44-a0f7-c47e296d1aea
kind: Event
lastTimestamp: "2024-08-26T15:30:03Z"
message: 'update on node openshift-storage/crc in volume group openshift-storage/vg1:
  moved extents from reduction candidates (/dev/vdc) to left pvs (/dev/vdb) to ensure
  consistent data after path removal'
metadata:
  creationTimestamp: "2024-08-26T15:30:03Z"
  name: my-lvmcluster.17ef50f6de83df23
  namespace: openshift-storage
  resourceVersion: "819774"
  uid: e999fcac-52d4-42f9-9bc2-66c0815d3b44
reason: ExtentMigrationFinished
reportingComponent: vg-manager
reportingInstance: ""
source:
  component: vg-manager
type: Normal
```


```
apiVersion: lvm.topolvm.io/v1alpha1
kind: LVMCluster
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"lvm.topolvm.io/v1alpha1","kind":"LVMCluster","metadata":{"annotations":{},"name":"my-lvmcluster","namespace":"openshift-storage"},"spec":{"storage":{"deviceClasses":[{"default":true,"deviceSelector":{"paths":["/dev/vdb","/dev/vdc"]},"fstype":"ext4","name":"vg1","thinPoolConfig":{"name":"thin-pool-1","overprovisionRatio":10,"sizePercent":40}}]}}}
  creationTimestamp: "2024-08-26T15:29:16Z"
  finalizers:
  - lvmcluster.topolvm.io
  generation: 2
  name: my-lvmcluster
  namespace: openshift-storage
  resourceVersion: "819780"
  uid: 0dc5f864-0404-4a44-a0f7-c47e296d1aea
spec:
  storage:
    deviceClasses:
    - default: true
      deviceSelector:
        paths:
        - /dev/vdb
      fstype: ext4
      name: vg1
      thinPoolConfig:
        chunkSizeCalculationPolicy: Static
        name: thin-pool-1
        overprovisionRatio: 10
        sizePercent: 40
status:
  conditions:
  - lastTransitionTime: "2024-08-26T15:30:03Z"
    message: Reconciliation is complete and all the resources are available
    reason: ResourcesAvailable
    status: "True"
    type: ResourcesAvailable
  - lastTransitionTime: "2024-08-26T15:30:03Z"
    message: All the VGs are ready
    reason: VGsReady
    status: "True"
    type: VolumeGroupsReady
  deviceClassStatuses:
  - name: vg1
    nodeStatus:
    - deviceDiscoveryPolicy: Preconfigured
      devices:
      - /dev/vdb
      excluded:
      - name: /dev/vda
        reasons:
        - /dev/vda has children block devices and could not be considered
        - /dev/vda is not part of the device selector
      - name: /dev/vda1
        reasons:
        - /dev/vda1 has an invalid partition label "BIOS-BOOT"
        - /dev/vda1 is not part of the device selector
      - name: /dev/vda2
        reasons:
        - /dev/vda2 has an invalid filesystem signature (vfat) and cannot be used
        - /dev/vda2 is not part of the device selector
      - name: /dev/vda3
        reasons:
        - /dev/vda3 has an invalid filesystem signature (ext4) and cannot be used
        - /dev/vda3 has an invalid partition label "boot"
        - /dev/vda3 is not part of the device selector
      - name: /dev/vda4
        reasons:
        - /dev/vda4 has an invalid filesystem signature (xfs) and cannot be used
        - /dev/vda4 is not part of the device selector
      - name: /dev/vdc
        reasons:
        - /dev/vdc is not part of the device selector
      name: vg1
      node: crc
      status: Ready
  ready: true
  state: Ready
```

Possible Gotchas that need to be considered for a merge:
- How do we deal with long pvmoves (even empty thin pools can take upwards of 1 minute on a ssd under bad conditions) => Asynchronous? If not, then how do we properly lock the lvmcluster for modification?
- How do we deal with crashing nodes during migration? Pickup again with pvmove without args? How do we test that