### PR TITLE
OCPBUGS-13236: fix: allow deploy on cluster without prometheus

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -31,5 +31,4 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
-- ../prometheus
 - ../webhook

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -10,3 +10,4 @@ images:
   newName: quay.io/lvms_dev/lvms-operator
   newTag: latest
 namePrefix: lvms-
+namespace: openshift-storage

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -3,5 +3,6 @@
 resources:
 - bases
 - ../default
+- ../prometheus
 - ../samples
 - ../scorecard

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -3,3 +3,6 @@ resources:
 - prometheus_rules.yaml
 - metrics_service.yaml
 - vgmanager_metrics_service.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-storage

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 
 configurations:
 - kustomizeconfig.yaml
+namespace: openshift-storage


### PR DESCRIPTION
This PR runs prometheus kustomization applies separately from the base kustomization with the makefile ignore `-` instruction, causing make to ignore any errors from applying to a cluster that does not have the monitoring CRDs installed (e.g. non-openshift).
Also makes the debug deploy easier to maintain by removing duplicated parts in the makefile