### PR TITLE
[DO NOT MERGE] fix: set termination grace period to 0

### DIFF
--- a/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
+++ b/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
@@ -359,7 +359,7 @@ func templateVGManagerDaemonset(
 				},
 
 				Spec: corev1.PodSpec{
-					TerminationGracePeriodSeconds: ptr.To(int64(30)),
+					TerminationGracePeriodSeconds: ptr.To(int64(0)),
 					PriorityClassName:             constants.PriorityClassNameUserCritical,
 					Volumes:                       volumes,
 					Containers:                    containers,


### PR DESCRIPTION
Attempts to set termination grace to 0 to see if killing the pod helps with the registration races