### PR TITLE
OCPEDGE-1249: fix: introduce vgmanager file lock on start

### DIFF
--- a/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
+++ b/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/lvm-operator/v4/internal/controllers/constants"
 	"github.com/openshift/lvm-operator/v4/internal/controllers/lvmcluster/selector"
 	"github.com/openshift/lvm-operator/v4/internal/controllers/vgmanager/lvmd"
+	"github.com/openshift/lvm-operator/v4/internal/controllers/vgmanager/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -73,6 +74,22 @@ var (
 	}
 	NodePluginVolMount = corev1.VolumeMount{
 		Name: NodePluginVolName, MountPath: filepath.Dir(constants.DefaultCSISocket),
+	}
+)
+
+var (
+	FileLockVolName = "file-lock-dir"
+	FileLockVol     = corev1.Volume{
+		Name: FileLockVolName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: filepath.Dir(util.FileLockDir),
+				Type: &HostPathDirectoryOrCreate},
+		},
+	}
+	FileLockVolMount = corev1.VolumeMount{
+		Name:      FileLockVolName,
+		MountPath: filepath.Dir(util.FileLockDir),
 	}
 )
 
@@ -222,6 +239,7 @@ func templateVGManagerDaemonset(
 	volumes := []corev1.Volume{
 		RegistrationVol,
 		NodePluginVol,
+		FileLockVol,
 		CSIPluginVol,
 		PodVol,
 		confMapVolume,
@@ -233,6 +251,7 @@ func templateVGManagerDaemonset(
 	volumeMounts := []corev1.VolumeMount{
 		RegistrationVolMount,
 		NodePluginVolMount,
+		FileLockVolMount,
 		CSIPluginVolMount,
 		PodVolMount,
 		LVMDConfMapVolMount,

--- a/internal/controllers/vgmanager/util/startlock.go
+++ b/internal/controllers/vgmanager/util/startlock.go
@@ -1,0 +1,71 @@
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const FileLockDir = "/var/lock/vgmanager"
+
+// FileLock is a lock file used to ensure that only one instance of the operator is running,
+// For example, when an old instance is still terminating its controllers, the new instance should not start.
+// In this case the old instance will still hold the lock file and the new instance will wait for the lock to be released
+// with WaitForLock.
+type FileLock struct {
+	file *os.File
+}
+
+func NewFileLock(name string) (*FileLock, error) {
+	if err := os.Mkdir(FileLockDir, 0755); err != nil && !os.IsExist(err) {
+		return nil, err
+	}
+
+	fileName := filepath.Join(FileLockDir, fmt.Sprintf("%s.lock", name))
+	file, err := os.OpenFile(fileName, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		return nil, err
+	}
+	return &FileLock{file: file}, nil
+}
+
+func (l *FileLock) WaitForLock(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+	logger.Info("Waiting for lock", "lockFile", l.file.Name())
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			err := l.TryLock()
+			if err == nil {
+				logger.Info("Lock acquired", "lockFile", l.file.Name())
+				return nil
+			}
+			if !errors.Is(err, syscall.EAGAIN) {
+				return fmt.Errorf("could not wait for lock because it was already locked by another process: %w", err)
+			}
+			logger.Info("Waiting for lock to be released", "lockFile", l.file.Name())
+		}
+	}
+}
+
+func (l *FileLock) TryLock() error {
+	return syscall.Flock(int(l.file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+}
+
+func (l *FileLock) Unlock() error {
+	return syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+}
+
+func (l *FileLock) Close() error {
+	if err := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN); err != nil {
+		return err
+	}
+	return l.file.Close()
+}


### PR DESCRIPTION
Alternative to https://github.com/openshift/lvm-operator/pull/707 which should allow for termination grace period, but also prohibit parallel container starts