### PR TITLE
OCPBUGS-44377: Add migration logic for wipe refactor

### DIFF
--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -37,6 +37,7 @@ import (
 	persistent_volume_claim "github.com/openshift/lvm-operator/v4/internal/controllers/persistent-volume-claim"
 	internalCSI "github.com/openshift/lvm-operator/v4/internal/csi"
 	"github.com/openshift/lvm-operator/v4/internal/migration/microlvms"
+	wipe_refactor "github.com/openshift/lvm-operator/v4/internal/migration/wipe-refactor"
 	"github.com/spf13/cobra"
 	topolvmcontrollers "github.com/topolvm/topolvm/pkg/controller"
 	"github.com/topolvm/topolvm/pkg/driver"
@@ -179,6 +180,10 @@ func run(cmd *cobra.Command, _ []string, opts *Options) error {
 
 	if err := microlvms.NewCleanup(setupClient, operatorNamespace).RemovePreMicroLVMSComponents(ctx); err != nil {
 		return fmt.Errorf("failed to run pre 4.16 MicroLVMS cleanup: %w", err)
+	}
+
+	if err := wipe_refactor.NewWipeRefactor(setupClient, operatorNamespace).AnnotateExistingLVMVolumeGroupsIfWipingEnabled(ctx); err != nil {
+		return fmt.Errorf("failed to run wipe migration logic: %w", err)
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{

--- a/internal/migration/wipe-refactor/annotate.go
+++ b/internal/migration/wipe-refactor/annotate.go
@@ -1,0 +1,74 @@
+package wipe_refactor
+
+import (
+	"context"
+	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"time"
+
+	lvmv1alpha1 "github.com/openshift/lvm-operator/v4/api/v1alpha1"
+	"github.com/openshift/lvm-operator/v4/internal/controllers/constants"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type WipeRefactor struct {
+	namespace string
+	client    client.Client
+}
+
+func NewWipeRefactor(client client.Client, namespace string) *WipeRefactor {
+	return &WipeRefactor{
+		namespace: namespace,
+		client:    client,
+	}
+}
+
+func (w *WipeRefactor) AnnotateExistingLVMVolumeGroupsIfWipingEnabled(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+	nodeStatusList := &lvmv1alpha1.LVMVolumeGroupNodeStatusList{}
+	if err := w.client.List(ctx, nodeStatusList, &client.ListOptions{Namespace: w.namespace}); err != nil {
+		return fmt.Errorf("failed to list LVMVolumeGroupNodeStatus instances: %w", err)
+	}
+	if len(nodeStatusList.Items) < 1 {
+		return nil
+	}
+
+	lvmVolumeGroupList := &lvmv1alpha1.LVMVolumeGroupList{}
+	if err := w.client.List(ctx, lvmVolumeGroupList, &client.ListOptions{Namespace: w.namespace}); err != nil {
+		return fmt.Errorf("failed to list LVMVolumeGroup instances: %w", err)
+	}
+	if len(lvmVolumeGroupList.Items) < 1 {
+		return nil
+	}
+
+	for _, volumeGroup := range lvmVolumeGroupList.Items {
+		updated := false
+		for _, nodeStatus := range nodeStatusList.Items {
+			for _, vgStatus := range nodeStatus.Spec.LVMVGStatus {
+				if vgStatus.Name == volumeGroup.Name {
+					if volumeGroup.Spec.DeviceSelector == nil || volumeGroup.Spec.DeviceSelector.ForceWipeDevicesAndDestroyAllData == nil || !*volumeGroup.Spec.DeviceSelector.ForceWipeDevicesAndDestroyAllData {
+						continue
+					}
+					if volumeGroup.Annotations == nil {
+						volumeGroup.Annotations = make(map[string]string)
+					}
+					volumeGroup.Annotations[constants.DevicesWipedAnnotationPrefix+nodeStatus.GetName()] = fmt.Sprintf(
+						"the devices of this volume group have been wiped at %s by lvms according to policy. This marker"+
+							"serves as indicator that the devices have been wiped before and should not be wiped again."+
+							"removal of this annotation is unsupported and may lead to data loss due to additional wiping.",
+						time.Now().Format(time.RFC3339))
+					updated = true
+				}
+			}
+		}
+		if updated {
+			if err := w.client.Update(ctx, &volumeGroup); err != nil {
+				return fmt.Errorf("failed to add wiped annotation to LVMVolumeGroup instance: %w", err)
+			}
+			logger.Info("successfully added wiped annotation to LVMVolumeGroup instance", "LVMVolumeGroupName", volumeGroup.GetName())
+		}
+	}
+
+	return nil
+}

--- a/internal/migration/wipe-refactor/annotate_test.go
+++ b/internal/migration/wipe-refactor/annotate_test.go
@@ -1,0 +1,298 @@
+package wipe_refactor
+
+import (
+	"context"
+	"testing"
+
+	lvmv1alpha1 "github.com/openshift/lvm-operator/v4/api/v1alpha1"
+	"github.com/openshift/lvm-operator/v4/internal/controllers/constants"
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const namespace = "openshift-storage"
+
+func TestAnnotateExistingLVMVolumeGroupsIfWipingEnabled(t *testing.T) {
+	truePtr := true
+	tests := []struct {
+		name                   string
+		inObjs                 []client.Object
+		expectedAnnotationKeys map[string][]string
+	}{
+		{
+			name: "nodeStatus does not exist, return nil",
+		},
+		{
+			name: "nodeStatus exist but wipe flag not set, return nil",
+			inObjs: []client.Object{
+				&lvmv1alpha1.LVMVolumeGroupNodeStatus{
+					Spec: lvmv1alpha1.LVMVolumeGroupNodeStatusSpec{
+						LVMVGStatus: []lvmv1alpha1.VGStatus{
+							{
+								Name: "vg1",
+							},
+						},
+					},
+				},
+				&lvmv1alpha1.LVMVolumeGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "vg1",
+					},
+				},
+			},
+		},
+		{
+			name: "nodeStatus exist and wipe flag set, annotate vg",
+			inObjs: []client.Object{
+				&lvmv1alpha1.LVMVolumeGroupNodeStatus{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "node1",
+						Namespace: namespace,
+					},
+					Spec: lvmv1alpha1.LVMVolumeGroupNodeStatusSpec{
+						LVMVGStatus: []lvmv1alpha1.VGStatus{
+							{
+								Name: "vg1",
+							},
+						},
+					},
+				},
+				&lvmv1alpha1.LVMVolumeGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "vg1",
+						Namespace: namespace,
+					},
+					Spec: lvmv1alpha1.LVMVolumeGroupSpec{
+						DeviceSelector: &lvmv1alpha1.DeviceSelector{
+							ForceWipeDevicesAndDestroyAllData: &truePtr,
+						},
+					},
+				},
+			},
+			expectedAnnotationKeys: map[string][]string{"vg1": {constants.DevicesWipedAnnotationPrefix + "node1"}},
+		},
+		{
+			name: "nodeStatus exist and wipe flag set for vg1, annotate vg1",
+			inObjs: []client.Object{
+				&lvmv1alpha1.LVMVolumeGroupNodeStatus{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "node1",
+						Namespace: namespace,
+					},
+					Spec: lvmv1alpha1.LVMVolumeGroupNodeStatusSpec{
+						LVMVGStatus: []lvmv1alpha1.VGStatus{
+							{
+								Name: "vg1",
+							},
+							{
+								Name: "vg2",
+							},
+						},
+					},
+				},
+				&lvmv1alpha1.LVMVolumeGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "vg1",
+						Namespace: namespace,
+					},
+					Spec: lvmv1alpha1.LVMVolumeGroupSpec{
+						DeviceSelector: &lvmv1alpha1.DeviceSelector{
+							ForceWipeDevicesAndDestroyAllData: &truePtr,
+						},
+					},
+				},
+				&lvmv1alpha1.LVMVolumeGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "vg2",
+						Namespace: namespace,
+					},
+				},
+			},
+			expectedAnnotationKeys: map[string][]string{"vg1": {constants.DevicesWipedAnnotationPrefix + "node1"}},
+		},
+		{
+			name: "nodeStatus exist and wipe flag set for vg1 and vg2, annotate both",
+			inObjs: []client.Object{
+				&lvmv1alpha1.LVMVolumeGroupNodeStatus{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "node1",
+						Namespace: namespace,
+					},
+					Spec: lvmv1alpha1.LVMVolumeGroupNodeStatusSpec{
+						LVMVGStatus: []lvmv1alpha1.VGStatus{
+							{
+								Name: "vg1",
+							},
+							{
+								Name: "vg2",
+							},
+						},
+					},
+				},
+				&lvmv1alpha1.LVMVolumeGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "vg1",
+						Namespace: namespace,
+					},
+					Spec: lvmv1alpha1.LVMVolumeGroupSpec{
+						DeviceSelector: &lvmv1alpha1.DeviceSelector{
+							ForceWipeDevicesAndDestroyAllData: &truePtr,
+						},
+					},
+				},
+				&lvmv1alpha1.LVMVolumeGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "vg2",
+						Namespace: namespace,
+					},
+					Spec: lvmv1alpha1.LVMVolumeGroupSpec{
+						DeviceSelector: &lvmv1alpha1.DeviceSelector{
+							ForceWipeDevicesAndDestroyAllData: &truePtr,
+						},
+					},
+				},
+			},
+			expectedAnnotationKeys: map[string][]string{"vg1": {constants.DevicesWipedAnnotationPrefix + "node1"}, "vg2": {constants.DevicesWipedAnnotationPrefix + "node1"}},
+		},
+		{
+			name: "nodeStatus exist and wipe flag set, annotate vg on multiple nodes",
+			inObjs: []client.Object{
+				&lvmv1alpha1.LVMVolumeGroupNodeStatus{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "node1",
+						Namespace: namespace,
+					},
+					Spec: lvmv1alpha1.LVMVolumeGroupNodeStatusSpec{
+						LVMVGStatus: []lvmv1alpha1.VGStatus{
+							{
+								Name: "vg1",
+							},
+						},
+					},
+				},
+				&lvmv1alpha1.LVMVolumeGroupNodeStatus{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "node2",
+						Namespace: namespace,
+					},
+					Spec: lvmv1alpha1.LVMVolumeGroupNodeStatusSpec{
+						LVMVGStatus: []lvmv1alpha1.VGStatus{
+							{
+								Name: "vg1",
+							},
+						},
+					},
+				},
+				&lvmv1alpha1.LVMVolumeGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "vg1",
+						Namespace: namespace,
+					},
+					Spec: lvmv1alpha1.LVMVolumeGroupSpec{
+						DeviceSelector: &lvmv1alpha1.DeviceSelector{
+							ForceWipeDevicesAndDestroyAllData: &truePtr,
+						},
+					},
+				},
+			},
+			expectedAnnotationKeys: map[string][]string{"vg1": {constants.DevicesWipedAnnotationPrefix + "node1", constants.DevicesWipedAnnotationPrefix + "node2"}},
+		},
+		{
+			name: "nodeStatus exist and wipe flag set for vg1 but not for vg2, annotate vg1 on multiple nodes",
+			inObjs: []client.Object{
+				&lvmv1alpha1.LVMVolumeGroupNodeStatus{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "node1",
+						Namespace: namespace,
+					},
+					Spec: lvmv1alpha1.LVMVolumeGroupNodeStatusSpec{
+						LVMVGStatus: []lvmv1alpha1.VGStatus{
+							{
+								Name: "vg1",
+							},
+							{
+								Name: "vg2",
+							},
+						},
+					},
+				},
+				&lvmv1alpha1.LVMVolumeGroupNodeStatus{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "node2",
+						Namespace: namespace,
+					},
+					Spec: lvmv1alpha1.LVMVolumeGroupNodeStatusSpec{
+						LVMVGStatus: []lvmv1alpha1.VGStatus{
+							{
+								Name: "vg1",
+							},
+							{
+								Name: "vg2",
+							},
+						},
+					},
+				},
+				&lvmv1alpha1.LVMVolumeGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "vg1",
+						Namespace: namespace,
+					},
+					Spec: lvmv1alpha1.LVMVolumeGroupSpec{
+						DeviceSelector: &lvmv1alpha1.DeviceSelector{
+							ForceWipeDevicesAndDestroyAllData: &truePtr,
+						},
+					},
+				},
+				&lvmv1alpha1.LVMVolumeGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "vg2",
+						Namespace: namespace,
+					},
+				},
+			},
+			expectedAnnotationKeys: map[string][]string{"vg1": {constants.DevicesWipedAnnotationPrefix + "node1", constants.DevicesWipedAnnotationPrefix + "node2"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(setUpScheme()).
+				WithObjects(tt.inObjs...).
+				Build()
+
+			wipeRefactor := NewWipeRefactor(fakeClient, namespace)
+			assert.NoError(t, wipeRefactor.AnnotateExistingLVMVolumeGroupsIfWipingEnabled(context.Background()))
+
+			lvmVolumeGroups := &lvmv1alpha1.LVMVolumeGroupList{}
+			assert.NoError(t, fakeClient.List(context.Background(), lvmVolumeGroups))
+
+			for vgName, expectedAnnotationKeys := range tt.expectedAnnotationKeys {
+				vgExists := false
+				for _, volumeGroup := range lvmVolumeGroups.Items {
+					if volumeGroup.Name == vgName {
+						vgExists = true
+						for _, key := range expectedAnnotationKeys {
+							if _, ok := volumeGroup.Annotations[key]; !ok {
+								t.Errorf("Annotation %s does not exist in LVMVolumeGroup %s", key, vgName)
+							}
+						}
+					}
+				}
+				if !vgExists {
+					t.Errorf("LVMVolumeGroup %s does not exist", vgName)
+				}
+			}
+		})
+	}
+}
+
+func setUpScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = lvmv1alpha1.AddToScheme(scheme)
+	return scheme
+}


### PR DESCRIPTION
This PR introduces migration logic for updates to the wipe feature in version 4.17. Previously, the LVM Operator used the `LVMVolumeGroupNodeStatus` resource to verify if a device was wiped—if the device appeared in a VG under `LVMVGStatus`, it was considered wiped. In 4.17, we refactored this approach to rely on the `wiped.devices.lvms.openshift.io` annotation within an `LVMVolumeGroup`, indicating whether all devices in the VG have been wiped. However, during upgrades from 4.16 to 4.17 or 4.18, the LVM Operator would re-wipe devices due to the missing annotation. This migration logic resolves that by checking existing `LVMVolumeGroupNodeStatus` resources in the operator namespace and applying the necessary annotations to `LVMVolumeGroups`.