### PR TITLE
OCPEDGE-1593: feat(controller): skip controller name validation

### DIFF
--- a/internal/controllers/lvmcluster/controller_watches.go
+++ b/internal/controllers/lvmcluster/controller_watches.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	corev1helper "k8s.io/component-helpers/scheduling/corev1"
+	"k8s.io/utils/ptr"
 
 	secv1 "github.com/openshift/api/security/v1"
 
@@ -34,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -67,6 +69,8 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.getManagedLabelObjsForReconcile),
 		)
 	}
+
+	builder.WithOptions(controller.Options{SkipNameValidation: ptr.To(true)})
 
 	return builder.Complete(r)
 }

--- a/internal/controllers/node/removal/controller.go
+++ b/internal/controllers/node/removal/controller.go
@@ -7,8 +7,10 @@ import (
 	lvmv1alpha1 "github.com/openshift/lvm-operator/v4/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -64,8 +66,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).For(&lvmv1alpha1.LVMVolumeGroupNodeStatus{}).Watches(&v1.Node{},
-		handler.EnqueueRequestsFromMapFunc(r.GetNodeStatusFromNode)).Complete(r)
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&lvmv1alpha1.LVMVolumeGroupNodeStatus{}).
+		Watches(&v1.Node{}, handler.EnqueueRequestsFromMapFunc(r.GetNodeStatusFromNode)).
+		WithOptions(controller.Options{SkipNameValidation: ptr.To(true)}).
+		Complete(r)
 }
 
 // GetNodeStatusFromNode can be used to derive a reconcile.Request from a Node for a NodeStatus.

--- a/internal/controllers/persistent-volume-claim/controller.go
+++ b/internal/controllers/persistent-volume-claim/controller.go
@@ -15,8 +15,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -136,6 +138,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		WithEventFilter(r.Predicates()).
 		For(&corev1.PersistentVolumeClaim{}).
+		WithOptions(controller.Options{SkipNameValidation: ptr.To(true)}).
 		Named("lvms_persistentvolumeclaim").
 		Complete(r)
 }

--- a/internal/controllers/persistent-volume/controller.go
+++ b/internal/controllers/persistent-volume/controller.go
@@ -8,8 +8,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -65,6 +67,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		WithEventFilter(r.Predicates()).
 		For(&corev1.PersistentVolume{}).
+		WithOptions(controller.Options{SkipNameValidation: ptr.To(true)}).
 		Complete(r)
 }
 

--- a/internal/controllers/vgmanager/controller.go
+++ b/internal/controllers/vgmanager/controller.go
@@ -43,6 +43,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -81,6 +82,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&lvmv1alpha1.LVMVolumeGroup{}).
 		Owns(&lvmv1alpha1.LVMVolumeGroupNodeStatus{}, builder.MatchEveryOwner, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		WithOptions(controller.Options{SkipNameValidation: ptr.To(true)}).
 		Complete(r)
 }
 


### PR DESCRIPTION
With new controller runtime kubernetes introduced controller name check. Because of that, graceful restarts started to fail. Because there are no other workaround - we simply disable this check