### PR TITLE
NO-JIRA: Fix typo in lvmvolumegroupnodestatus during lvm must-gather collection

### DIFF
--- a/must-gather/collection-scripts/gather_namespaced_resources
+++ b/must-gather/collection-scripts/gather_namespaced_resources
@@ -46,7 +46,7 @@ commands_desc=()
 commands_desc+=("lvmcluster")
 commands_desc+=("logicalvolume")
 commands_desc+=("lvmvolumegroup")
-commands_desc+=("lvmvolumegroupsnodestatus")
+commands_desc+=("lvmvolumegroupnodestatus")
 commands_desc+=("pods")
 
 # collect yaml output of OC commands


### PR DESCRIPTION
Previously, due to a typo in the lvmvolumegroupnodestatus resource name within the must-gather script, only the 'get' output was collected, while the 'describe' output was missing. This fix corrects the resource name, ensuring that both 'get' and 'describe' outputs are properly gathered.