### PR TITLE
OCPBUGS-52351: Retry Nodes with not-ready taint

### DIFF
--- a/internal/controllers/lvmcluster/controller.go
+++ b/internal/controllers/lvmcluster/controller.go
@@ -259,7 +259,7 @@ func (r *Reconciler) reconcile(ctx context.Context, instance *lvmv1alpha1.LVMClu
 		return ctrl.Result{}, statusErr
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{Requeue: true, RequeueAfter: 1 * time.Minute}, nil
 }
 
 func (r *Reconciler) updateLVMClusterStatus(ctx context.Context, instance *lvmv1alpha1.LVMCluster) error {

--- a/internal/controllers/lvmcluster/resource/csi_node.go
+++ b/internal/controllers/lvmcluster/resource/csi_node.go
@@ -33,9 +33,6 @@ func (c csiNode) EnsureCreated(r Reconciler, ctx context.Context, cluster *lvmv1
 	logger := log.FromContext(ctx).WithValues("resourceManager", c.GetName())
 
 	csiNodes, err := c.GetAllCSINodeCandidates(ctx, r, cluster)
-	if err != nil {
-		return err
-	}
 
 	for _, csiNode := range csiNodes {
 		found := false
@@ -50,18 +47,17 @@ func (c csiNode) EnsureCreated(r Reconciler, ctx context.Context, cluster *lvmv1
 		}
 	}
 
-	logger.V(2).Info("All CSINode driver registrations have been created by the kubelet")
+	if err == nil {
+		logger.V(2).Info("All CSINode driver registrations have been created by the kubelet")
+	}
 
-	return nil
+	return err
 }
 
 func (c csiNode) EnsureDeleted(r Reconciler, ctx context.Context, cluster *lvmv1alpha1.LVMCluster) error {
 	logger := log.FromContext(ctx).WithValues("resourceManager", c.GetName())
 
 	csiNodes, err := c.GetAllCSINodeCandidates(ctx, r, cluster)
-	if err != nil {
-		return err
-	}
 
 	for _, csiNode := range csiNodes {
 		found := false
@@ -79,9 +75,11 @@ func (c csiNode) EnsureDeleted(r Reconciler, ctx context.Context, cluster *lvmv1
 		}
 	}
 
-	logger.V(2).Info("All CSINode driver registrations have been deleted by the kubelet")
+	if err == nil {
+		logger.V(2).Info("All CSINode driver registrations have been deleted by the kubelet")
+	}
 
-	return nil
+	return err
 }
 
 func (c csiNode) GetAllCSINodeCandidates(ctx context.Context, clnt client.Client, cluster *lvmv1alpha1.LVMCluster) ([]*storagev1.CSINode, error) {
@@ -91,9 +89,6 @@ func (c csiNode) GetAllCSINodeCandidates(ctx context.Context, clnt client.Client
 	}
 
 	valid, err := selector.ValidNodes(cluster, nodeList)
-	if err != nil {
-		return nil, err
-	}
 
 	csiNodes := make([]*storagev1.CSINode, 0, len(valid))
 	for _, node := range valid {
@@ -109,7 +104,7 @@ func (c csiNode) GetAllCSINodeCandidates(ctx context.Context, clnt client.Client
 
 	}
 
-	return csiNodes, nil
+	return csiNodes, err
 }
 
 var _ Manager = csiNode{}

--- a/internal/controllers/lvmcluster/resource/lvm_volumegroupnodestatus.go
+++ b/internal/controllers/lvmcluster/resource/lvm_volumegroupnodestatus.go
@@ -56,11 +56,8 @@ func (l lvmVGNodeStatus) EnsureCreated(r Reconciler, ctx context.Context, cluste
 	}
 
 	validNodes, err := selector.ValidNodes(cluster, &nodes)
-	if err != nil {
-		return fmt.Errorf("failed to get valid nodes: %w", err)
-	}
 
-	logger.V(1).Info("nodes considered for LVMCluster",
+	logger.Info("nodes considered for LVMCluster",
 		"nodes", nodesToStringSummary(validNodes),
 		"total", nodesToStringSummary(nodes.Items),
 	)
@@ -91,7 +88,7 @@ func (l lvmVGNodeStatus) EnsureCreated(r Reconciler, ctx context.Context, cluste
 		}
 	}
 
-	return nil
+	return err
 }
 
 func (l lvmVGNodeStatus) EnsureDeleted(r Reconciler, ctx context.Context, cluster *lvmv1alpha1.LVMCluster) error {
@@ -107,9 +104,6 @@ func (l lvmVGNodeStatus) EnsureDeleted(r Reconciler, ctx context.Context, cluste
 	}
 
 	validNodes, err := selector.ValidNodes(cluster, &nodeList)
-	if err != nil {
-		return fmt.Errorf("failed to get valid nodes: %w", err)
-	}
 
 	for _, status := range nodeStatusList.Items {
 		if isValidNode(status.Name, validNodes) {
@@ -118,7 +112,8 @@ func (l lvmVGNodeStatus) EnsureDeleted(r Reconciler, ctx context.Context, cluste
 			}
 		}
 	}
-	return nil
+
+	return err
 }
 
 // isValidNode checks if the node is in the list of valid nodes for the LVMVolumeGroupNodeStatus.

--- a/internal/controllers/lvmcluster/status.go
+++ b/internal/controllers/lvmcluster/status.go
@@ -277,7 +277,11 @@ func validateDeviceClassSetup(cluster *lvmv1alpha1.LVMCluster, nodes *corev1.Nod
 
 func isNodeValid(node *corev1.Node, cluster *lvmv1alpha1.LVMCluster, deviceClass *lvmv1alpha1.DeviceClass) (bool, error) {
 	// Check if node tolerates all taints
-	if !selector.ToleratesAllTaints(node.Spec.Taints, cluster.Spec.Tolerations) {
+	ok, err := selector.ToleratesAllTaints(node.Spec.Taints, cluster.Spec.Tolerations)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
 		return false, nil
 	}
 


### PR DESCRIPTION
This PR 
- Adds logic to return a reconciliation error in case one of the nodes has a `node.kubernetes.io/not-ready` taint
- Makes lvm-operator reconcile once a minute to catch any changes not caught by the watches.