### PR TITLE
KONFLUX-6210: chore: fix and set name and cpe label for lvm-operator-4-19

### DIFF
--- a/release/operator/konflux.Dockerfile
+++ b/release/operator/konflux.Dockerfile
@@ -51,6 +51,7 @@ LABEL io.k8s.description="LVM Storage Operator container based on Red Hat Enterp
 LABEL io.openshift.tags="lvms"
 LABEL lvms.tags="${LVMS_TAGS}"
 LABEL konflux.additional-tags="${LVMS_TAGS} v${OPERATOR_VERSION}"
+LABEL cpe="cpe:/a:redhat:lvms:4.19::el9"
 
 
 ENTRYPOINT ["/lvms"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
