### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for lvm-operator-bundle-4-19

### DIFF
--- a/release/bundle/bundle.konflux.Dockerfile
+++ b/release/bundle/bundle.konflux.Dockerfile
@@ -45,6 +45,7 @@ LABEL com.redhat.openshift.versions="${OPENSHIFT_VERSIONS}"
 LABEL com.redhat.delivery.backport=false
 
 # Standard Red Hat labels
+LABEL cpe="cpe:/a:redhat:lvms:4.19::el9"
 LABEL com.redhat.component="lvms-operator-bundle-container"
 LABEL name="lvms4/lvms-operator-bundle"
 LABEL version="${OPERATOR_VERSION}"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
