### PR TITLE
OCPEDGE-2109: Allow device deletion on day2

### DIFF
--- a/internal/controllers/vgmanager/device_mapping_helper.go
+++ b/internal/controllers/vgmanager/device_mapping_helper.go
@@ -1,0 +1,63 @@
+/*
+Copyright © 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vgmanager
+
+import (
+	"context"
+	"fmt"
+
+	lvmv1alpha1 "github.com/openshift/lvm-operator/v4/api/v1alpha1"
+	symlinkResolver "github.com/openshift/lvm-operator/v4/internal/controllers/symlink-resolver"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// buildDevicePathMappings creates a mapping from user-provided paths to resolved device paths
+// for devices that are actually in the VG (using VG state from ListVGs)
+func buildDevicePathMappings(ctx context.Context, volumeGroup *lvmv1alpha1.LVMVolumeGroup, resolver *symlinkResolver.Resolver) ([]string, error) {
+	logger := log.FromContext(ctx).WithValues("VGName", volumeGroup.Name)
+
+	if volumeGroup.Spec.DeviceSelector == nil {
+		return nil, nil
+	}
+
+	resolvedPaths := make([]string, 0)
+
+	// Process required paths
+	for _, path := range volumeGroup.Spec.DeviceSelector.Paths {
+		originalPath := path.Unresolved()
+		resolved, err := resolver.Resolve(originalPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve path %s, %w", originalPath, err)
+		}
+
+		resolvedPaths = append(resolvedPaths, resolved)
+	}
+
+	// Process optional paths
+	for _, path := range volumeGroup.Spec.DeviceSelector.OptionalPaths {
+		originalPath := path.Unresolved()
+		resolved, err := resolver.Resolve(originalPath)
+		if err != nil {
+			logger.Info("failed to resolve optional device path during mapping build", "path", originalPath, "error", err)
+			continue
+		}
+
+		resolvedPaths = append(resolvedPaths, resolved)
+	}
+
+	return resolvedPaths, nil
+}

--- a/internal/controllers/vgmanager/lvm/lvm_test.go
+++ b/internal/controllers/vgmanager/lvm/lvm_test.go
@@ -101,7 +101,7 @@ func TestHostLVM_GetVG(t *testing.T) {
 							return fmt.Errorf("mocked error")
 						}
 						argsConcat := strings.Join(args, " ")
-						out := "--units b --nosuffix -v --reportformat json -S vgname=%s"
+						out := "--units b --nosuffix -v --reportformat json -o +pv_missing -S vgname=%s"
 						if argsConcat == fmt.Sprintf(out, "vg1") {
 							return json.Unmarshal([]byte(mockPvsOutputForVG1), &into)
 						} else if argsConcat == fmt.Sprintf(out, "vg2") {

--- a/internal/controllers/vgmanager/lvm/mocks/mock_lvm.go
+++ b/internal/controllers/vgmanager/lvm/mocks/mock_lvm.go
@@ -818,6 +818,101 @@ func (_c *MockLVM_ListVGs_Call) RunAndReturn(run func(context.Context, bool) ([]
 	return _c
 }
 
+// ReduceVG provides a mock function with given fields: ctx, vgName, devices
+func (_m *MockLVM) ReduceVG(ctx context.Context, vgName string, devices string) error {
+	ret := _m.Called(ctx, vgName, devices)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReduceVG")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, vgName, devices)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockLVM_ReduceVG_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReduceVG'
+type MockLVM_ReduceVG_Call struct {
+	*mock.Call
+}
+
+// ReduceVG is a helper method to define mock.On call
+//   - ctx context.Context
+//   - vgName string
+//   - devices string
+func (_e *MockLVM_Expecter) ReduceVG(ctx interface{}, vgName interface{}, devices interface{}) *MockLVM_ReduceVG_Call {
+	return &MockLVM_ReduceVG_Call{Call: _e.mock.On("ReduceVG", ctx, vgName, devices)}
+}
+
+func (_c *MockLVM_ReduceVG_Call) Run(run func(ctx context.Context, vgName string, devices string)) *MockLVM_ReduceVG_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockLVM_ReduceVG_Call) Return(_a0 error) *MockLVM_ReduceVG_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockLVM_ReduceVG_Call) RunAndReturn(run func(context.Context, string, string) error) *MockLVM_ReduceVG_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RemovePV provides a mock function with given fields: ctx, devicePath
+func (_m *MockLVM) RemovePV(ctx context.Context, devicePath string) error {
+	ret := _m.Called(ctx, devicePath)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemovePV")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, devicePath)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockLVM_RemovePV_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemovePV'
+type MockLVM_RemovePV_Call struct {
+	*mock.Call
+}
+
+// RemovePV is a helper method to define mock.On call
+//   - ctx context.Context
+//   - devicePath string
+func (_e *MockLVM_Expecter) RemovePV(ctx interface{}, devicePath interface{}) *MockLVM_RemovePV_Call {
+	return &MockLVM_RemovePV_Call{Call: _e.mock.On("RemovePV", ctx, devicePath)}
+}
+
+func (_c *MockLVM_RemovePV_Call) Run(run func(ctx context.Context, devicePath string)) *MockLVM_RemovePV_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockLVM_RemovePV_Call) Return(_a0 error) *MockLVM_RemovePV_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockLVM_RemovePV_Call) RunAndReturn(run func(context.Context, string) error) *MockLVM_RemovePV_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockLVM creates a new instance of MockLVM. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockLVM(t interface {


### PR DESCRIPTION
This is a POC of device deletion for LVMS operator.
Currently we do allow to user to delete required devices and optional devices from the CR, but there are few limitations:
1. You can't delete all devices from device class, at least one required or optional device must present in CR
2. If device is no longer available on the node, user must fix LVM's VG on the node first and then modify the CR to reflect current state of the VG on the node. The reason for that is because we can't remove exact missing device, only all of them if there are more than one device is missing
3. You can't delete device which has data on it. If LVMS detects that there are data on the disk, it will ask user to do `pvmove` command manually on the node to remove all the data from the disk in VG

The standard user workflow might be defined in 2 ways.
1. If the disk is lost, fix the VG on the node first and then delete disk from the CR
2. Delete the disk from CR, but make sure that there are no data on this disk, otherwise use `pvmove` command on the host to remove any data leftowers