### PR TITLE
[release-4.19] OCPBUGS-63037: fix: multipart builds doesn't work for catalogs due to allowed images…

### DIFF
--- a/release/catalog/catalog.konflux.Dockerfile
+++ b/release/catalog/catalog.konflux.Dockerfile
@@ -1,18 +1,10 @@
 ARG CATALOG_VERSION
 ARG BASE_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 as builder
-# Patch the staging references to be post-release compatible
-WORKDIR /catalog
-COPY release/catalog/lvm-operator-catalog.json ./release/catalog/lvm-operator-catalog.json
-COPY release/hack/render-catalog.sh ./release/hack/render-catalog.sh
-
-RUN ./release/hack/render-catalog.sh
-
 # Global args to be used to build the final base image url
 FROM ${BASE_IMAGE}:${CATALOG_VERSION}
 ARG CATALOG_VERSION
 
-COPY --from=builder catalog/release/catalog/lvm-operator-catalog.json /configs/lvms-operator/catalog.json
+COPY release/catalog/lvm-operator-catalog.json /configs/lvms-operator/catalog.json
 
 RUN ["/bin/opm", "validate", "/configs/lvms-operator"]
 

--- a/release/hack/generate_catalog.sh
+++ b/release/hack/generate_catalog.sh
@@ -22,6 +22,9 @@ patched_catalog=$(echo "${catalog}" | ch="${channel}" sr="${skip_range}" yq -e e
 echo "Patching the channel names to use legacy naming conventions"
 patched_catalog=$(echo "${patched_catalog}" | yq -o=json eval-all '(.. | select(tag == "!!str")) |= sub("stable-v", "stable-") | (.. | select(tag == "!!str")) |= sub("candidate-v", "candidate-")')
 
+# Update any pre-release references to be registry.redhat.io
+patched_catalog="${patched_catalog//registry.stage/registry}"
+
 echo "${patched_catalog}" > ${output_file}
 
 echo "Catalog generated: ${output_file}"


### PR DESCRIPTION
Conforma doesn't allow for other images in the catalog pipeline so we have to run the script prior to the catalog image being built