### PR TITLE
[hold] [release-4.16] NO-JIRA: Single stream catalog

### DIFF
--- a/release/catalog/lvm-operator-catalog-template.yaml
+++ b/release/catalog/lvm-operator-catalog-template.yaml
@@ -5,18 +5,6 @@ GenerateMajorChannels: false
 GenerateMinorChannels: true
 Stable:
   Bundles:
-    - Image: registry.redhat.io/lvms4/lvms-operator-bundle@sha256:f5cfac1cb7ac1646d5c71195f95d9a7dc30c7d90958e19c63e6d95725a4d9c9f # v4.15.0
-    - Image: registry.redhat.io/lvms4/lvms-operator-bundle@sha256:6bb6c7025ecf274b7cb0a83fea04e0de4a7d360b22fa913790e0f0c415175943 # v4.15.1
-    - Image: registry.redhat.io/lvms4/lvms-operator-bundle@sha256:587d60a7a4f21d92df4f15fda7ac7c69b0a2f10a00e2310fb2ba5a246c2ab088 # v4.15.10
-    - Image: registry.redhat.io/lvms4/lvms-operator-bundle@sha256:761cbbcb8df3491d034c997a4fe2769e7b55a534b3288d1c673547d882cfa469 # v4.15.11
-    - Image: registry.redhat.io/lvms4/lvms-operator-bundle@sha256:7b0b9d096e47042c4bf4ecf5d74241eb2ec0ee1a177ee69fa3e399eb41ea771c # v4.15.2
-    - Image: registry.redhat.io/lvms4/lvms-operator-bundle@sha256:82483ec339d7be961bca18eb3153d63ddf4d190777aa6a47a3d08b1f9ba143b6 # v4.15.3
-    - Image: registry.redhat.io/lvms4/lvms-operator-bundle@sha256:47784f1252311cb39911d251a465b286ed8bb2e523c236b93725e47ef299a599 # v4.15.4
-    - Image: registry.redhat.io/lvms4/lvms-operator-bundle@sha256:4307cf65bf83da139d3f530d7a305152839e7d738daf585435f4deb0d8246139 # v4.15.5
-    - Image: registry.redhat.io/lvms4/lvms-operator-bundle@sha256:65626acf2aba05fcc0385b719c1a884dddaa6826742de3b21793f203f51d9a7e # v4.15.6
-    - Image: registry.redhat.io/lvms4/lvms-operator-bundle@sha256:940a7b026e4403dbfe5bed3b94f1bca9541e561499893a05ad5ac745586c5a47 # v4.15.7
-    - Image: registry.redhat.io/lvms4/lvms-operator-bundle@sha256:9943f992e3443450a98ff3b8200e1ec37e80c35f6197e48a0d699aff0774b75e # v4.15.8
-    - Image: registry.redhat.io/lvms4/lvms-operator-bundle@sha256:5360c261de0bdb80575e4634f6325cf00d1a0db28b03e73b5ac698c74a5e364f # v4.15.9
     - Image: registry.redhat.io/lvms4/lvms-operator-bundle@sha256:34e8a05ebdf1da51caab80268b48d43d9e49d75328dec57b648cc17761b3203c # v4.16.0
     - Image: registry.redhat.io/lvms4/lvms-operator-bundle@sha256:e999539df695437d62215c9ed64b7145e2d555ec2ffd5c7cff4c3a8282408df4 # v4.16.1
     - Image: registry.redhat.io/lvms4/lvms-operator-bundle@sha256:a77528ddec73205b72cc028c76b212870a7219bc33c7b5e87652c33c2a3ead3c # v4.16.2


### PR DESCRIPTION
Dropping the 4.15 references from the 4.16 catalog. I've seen other operators use this approach and I want to test and make sure it works for our catalog as well