### PR TITLE
OCPBUGS-72257: feat(vgmanager): improve encrypted devices deletion

### DIFF
--- a/test/e2e/lvm_cluster_test.go
+++ b/test/e2e/lvm_cluster_test.go
@@ -72,8 +72,8 @@ func lvmClusterTest() {
 	Describe("Storage Class", Serial, func() {
 		It("should become ready without a default storageclass", func(ctx SpecContext) {
 			// set default to false
-			for _, dc := range cluster.Spec.Storage.DeviceClasses {
-				dc.Default = false
+			for i := range cluster.Spec.Storage.DeviceClasses {
+				cluster.Spec.Storage.DeviceClasses[i].Default = false
 			}
 
 			CreateResource(ctx, cluster)
@@ -83,8 +83,8 @@ func lvmClusterTest() {
 
 	Describe("Thick Provisioning", Serial, func() {
 		It("should become ready if ThinPoolConfig is empty (thick provisioning)", func(ctx SpecContext) {
-			for _, dc := range cluster.Spec.Storage.DeviceClasses {
-				dc.ThinPoolConfig = nil
+			for i := range cluster.Spec.Storage.DeviceClasses {
+				cluster.Spec.Storage.DeviceClasses[i].ThinPoolConfig = nil
 			}
 			CreateResource(ctx, cluster)
 			VerifyLVMSSetup(ctx, cluster)

--- a/test/e2e/lvm_pvc_test.go
+++ b/test/e2e/lvm_pvc_test.go
@@ -113,8 +113,8 @@ func pvcTestThickProvisioning() {
 		cluster = GetDefaultTestLVMClusterTemplate()
 
 		// set ThinPoolConfig to nil
-		for _, dc := range cluster.Spec.Storage.DeviceClasses {
-			dc.ThinPoolConfig = nil
+		for i := range cluster.Spec.Storage.DeviceClasses {
+			cluster.Spec.Storage.DeviceClasses[i].ThinPoolConfig = nil
 		}
 
 		CreateResource(ctx, cluster)
@@ -207,6 +207,9 @@ func pvcTestsForMode(options pvcTestOptions) {
 	})
 
 	It("Cloning", func(ctx SpecContext) {
+		if !options.snapshot {
+			Skip("Skipping cloning tests because snapshots are disabled")
+		}
 		CreateResource(ctx, clonePVC)
 		CreateResource(ctx, clonePod)
 


### PR DESCRIPTION
Improve deletion logic for encrypted devices as user provided device name and actual device name on host usually doesnt match