### PR TITLE
lvmcluster: Clean up stale node finalizers and annotations

### DIFF
--- a/internal/controllers/node/removal/controller.go
+++ b/internal/controllers/node/removal/controller.go
@@ -6,12 +6,14 @@ import (
 
 	lvmv1alpha1 "github.com/openshift/lvm-operator/v4/api/v1alpha1"
 	"github.com/openshift/lvm-operator/v4/internal/controllers/constants"
+	"github.com/openshift/lvm-operator/v4/internal/controllers/vgmanager"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -33,9 +35,11 @@ func NewReconciler(client client.Client, namespace string) *Reconciler {
 //+kubebuilder:rbac:groups=lvm.topolvm.io,resources=lvmvolumegroupnodestatuses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=lvm.topolvm.io,resources=lvmvolumegroupnodestatuses/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=lvm.topolvm.io,resources=lvmvolumegroupnodestatuses/finalizers,verbs=update
+//+kubebuilder:rbac:groups=lvm.topolvm.io,resources=lvmvolumegroups,verbs=get;list;watch;update;patch
 
 // Reconcile takes care of watching a LVMVolumeGroupNodeStatus, and reacting to a node removal request by deleting
-// the unwanted LVMVolumeGroupNodeStatus that was associated with the node.
+// the unwanted LVMVolumeGroupNodeStatus that was associated with the node, as well as cleaning up any finalizers
+// and annotations on LVMVolumeGroups that reference the deleted node.
 // It does nothing on active Nodes. If it can be assumed that there will always be only one node (SNO),
 // this controller should not be started.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -51,9 +55,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	err := r.Get(ctx, client.ObjectKeyFromObject(nodeStatus), node)
 
 	if errors.IsNotFound(err) {
-		logger.Info("node not found, removing LVMVolumeGroupNodeStatus", "node", nodeStatus.GetName())
+		nodeName := nodeStatus.GetName()
+		logger.Info("node not found, cleaning up node resources", "node", nodeName)
+
+		// Clean up finalizers and annotations for this specific node
+		if err := r.cleanupNodeFinalizers(ctx, nodeName); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to cleanup finalizers for node %s: %w", nodeName, err)
+		}
+
+		if err := r.cleanupNodeAnnotations(ctx, nodeName); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to cleanup annotations for node %s: %w", nodeName, err)
+		}
+
+		// Delete the NodeStatus CR
 		if err := r.Delete(ctx, nodeStatus); err != nil {
-			return ctrl.Result{}, fmt.Errorf("error deleting LVMVolumeGroupNodeStatus for Node %s: %w", nodeStatus.GetName(), err)
+			return ctrl.Result{}, fmt.Errorf("error deleting LVMVolumeGroupNodeStatus for Node %s: %w", nodeName, err)
 		}
 		logger.Info("initiated LVMVolumeGroupNodeStatus deletion", "nodeStatus", client.ObjectKeyFromObject(nodeStatus))
 
@@ -112,4 +128,67 @@ func removeDeleteProtectionFinalizer(status *lvmv1alpha1.LVMVolumeGroupNodeStatu
 		}
 	}
 	return false
+}
+
+// cleanupNodeFinalizers removes finalizers for the deleted node from all LVMVolumeGroups
+func (r *Reconciler) cleanupNodeFinalizers(ctx context.Context, nodeName string) error {
+	logger := log.FromContext(ctx)
+
+	volumeGroups := &lvmv1alpha1.LVMVolumeGroupList{}
+	if err := r.List(ctx, volumeGroups, &client.ListOptions{Namespace: r.Namespace}); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to list volume groups: %w", err)
+	}
+
+	finalizerToRemove := vgmanager.NodeCleanupFinalizer + "/" + nodeName
+
+	for _, vg := range volumeGroups.Items {
+		if controllerutil.ContainsFinalizer(&vg, finalizerToRemove) {
+			controllerutil.RemoveFinalizer(&vg, finalizerToRemove)
+			if err := r.Update(ctx, &vg); err != nil {
+				return fmt.Errorf("failed to remove finalizer from volumegroup %s: %w", vg.Name, err)
+			}
+			logger.Info("removed node finalizer from VolumeGroup",
+				"volumeGroup", vg.Name,
+				"node", nodeName)
+		}
+	}
+
+	return nil
+}
+
+// cleanupNodeAnnotations removes wiped-devices annotations for the deleted node from all LVMVolumeGroups
+func (r *Reconciler) cleanupNodeAnnotations(ctx context.Context, nodeName string) error {
+	logger := log.FromContext(ctx)
+
+	volumeGroups := &lvmv1alpha1.LVMVolumeGroupList{}
+	if err := r.List(ctx, volumeGroups, &client.ListOptions{Namespace: r.Namespace}); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to list volume groups: %w", err)
+	}
+
+	annotationKey := constants.DevicesWipedAnnotationPrefix + nodeName
+
+	for _, vg := range volumeGroups.Items {
+		if vg.Annotations == nil {
+			continue
+		}
+
+		if _, exists := vg.Annotations[annotationKey]; exists {
+			delete(vg.Annotations, annotationKey)
+			if err := r.Update(ctx, &vg); err != nil {
+				return fmt.Errorf("failed to remove annotation from volumegroup %s: %w", vg.Name, err)
+			}
+			logger.Info("removed wiped-devices annotation from VolumeGroup",
+				"volumeGroup", vg.Name,
+				"node", nodeName,
+				"annotation", annotationKey)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
LVMVolumeGroup objects accumulate annotations with the prefix
wiped.devices.lvms.openshift.io/ (one per node) that are never cleaned up
when nodes are deleted, causing annotations to exceed Kubernetes' 256KB
limit and resulting in vg-manager reconciliation errors.

Add cleanupNodeAnnotations() to remove stale node annotations and move
existing finalizer cleanup from poll-based LVMCluster reconciliation to the
dedicated node removal controller. This provides event-driven cleanup at the
precise moment of LVMVolumeGroupNodeStatus deletion, eliminating race
conditions and improving efficiency by targeting the specific deleted node
rather than scanning all VolumeGroups on every reconciliation.