### PR TITLE
NO-JIRA: fix: dropping the renovate task update frequency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,10 +44,7 @@
         "digest"
       ],
       "platformAutomerge": true,
-      "commitMessagePrefix": "NO-JIRA:",
-      "schedule": [
-        "at any time"
-      ]
+      "commitMessagePrefix": "NO-JIRA:"
     },
     {
       "matchUpdateTypes": [
@@ -80,9 +77,6 @@
       "release/**"
     ],
     "platformAutomerge": true,
-    "commitMessagePrefix": "NO-JIRA:",
-    "schedule": [
-      "at any time"
-    ]
+    "commitMessagePrefix": "NO-JIRA:"
   }
 }


### PR DESCRIPTION
Dropping the frequency of renovate triggered updates from "anytime" to the default which is sundays to limit the number of tekton task update PRs we need to manage