### PR TITLE
Fix cleanup for 67004 case

### DIFF
--- a/test/integration/qe_tests/lvms.go
+++ b/test/integration/qe_tests/lvms.go
@@ -752,11 +752,15 @@ var _ = g.Describe("[sig-storage] STORAGE", func() {
 		selectedDisk := strings.Fields(diskPaths)[0]
 		logf("Selected Disk Path: %s\n", selectedDisk)
 
-		g.By("#. Remove finalizers from LVMCluster and LVMVolumeGroup and delete LVMCluster")
-		// Use deleteLVMClusterSafely (finalizer removal) intentionally — this test verifies
-		// recovery from on-disk metadata, so VG must be left on disk (matching upstream)
-		err = deleteLVMClusterSafely(newLVMClusterName, lvmsNamespace, deviceClassName)
-		o.Expect(err).NotTo(o.HaveOccurred())
+		g.By("#. Remove finalizers from LVMCluster, LVMVolumeGroup, and LVMVolumeGroupNodeStatus, then delete LVMCluster")
+		// Matching upstream exactly: non-blocking delete, then immediately remove all finalizers
+		deleteCmd := exec.Command("oc", "delete", "lvmcluster", newLVMClusterName, "-n", lvmsNamespace, "--ignore-not-found", "--wait=false")
+		deleteCmdOutput, err := deleteCmd.CombinedOutput()
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to delete lvmcluster: %s", string(deleteCmdOutput))
+		removeLVMClusterFinalizers(newLVMClusterName, lvmsNamespace)
+		removeLVMVolumeGroupFinalizers(deviceClassName, lvmsNamespace)
+		removeLVMVolumeGroupNodeStatusFinalizers(lvmsNamespace)
+		logf("LVMCluster %s deleted with all finalizers removed\n", newLVMClusterName)
 
 		g.By("#. Create a new LVMCluster resource with same disk path (testing recovery)")
 		// Use same cluster name pattern - this tests actual recovery where VG on disk is reused
@@ -1635,6 +1639,9 @@ var _ = g.Describe("[sig-storage] STORAGE", func() {
 		duplicatePath := "/dev/diskpath-1"
 		paths := []string{duplicatePath}
 		optionalPaths := []string{duplicatePath}
+
+		// Cleanup test LVMCluster in case webhook fails to reject (matches upstream pattern)
+		defer deleteLVMClusterSafely(newLVMClusterName, lvmsNamespace, deviceClassName)
 
 		g.By("Attempt to create LVMCluster with duplicate paths - expect error")
 		err = createLVMClusterWithPathsAndOptionalPaths(newLVMClusterName, lvmsNamespace, deviceClassName, paths, optionalPaths)

--- a/test/integration/qe_tests/lvms_utils.go
+++ b/test/integration/qe_tests/lvms_utils.go
@@ -575,7 +575,14 @@ func createLogicalVolumeOnDisk(tc *TestClient, nodeHostName string, disk string,
 	_, err := execCommandInNodeWithError(tc, nodeHostName, createPartitionCmd)
 	o.Expect(err).NotTo(o.HaveOccurred())
 
-	partitionName := diskName + "p1"
+	// Devices ending with a digit (nvme0n1, mmcblk0, md0) use "p" separator for
+	// partitions (e.g. nvme0n1p1), others (sda, vdb) don't (e.g. sda1)
+	var partitionName string
+	if len(diskName) > 0 && diskName[len(diskName)-1] >= '0' && diskName[len(diskName)-1] <= '9' {
+		partitionName = diskName + "p1"
+	} else {
+		partitionName = diskName + "1"
+	}
 	// Unmount the partition if it's mounted
 	unmountCmd := "umount " + partitionName + " || true"
 	_, err = execCommandInNodeWithError(tc, nodeHostName, unmountCmd)
@@ -599,8 +606,16 @@ func createLogicalVolumeOnDisk(tc *TestClient, nodeHostName string, disk string,
 
 func removeLogicalVolumeOnDisk(tc *TestClient, nodeHostName string, disk string, vgName string, lvName string) {
 	diskName := "/dev/" + disk
-	partitionName := disk + "p1"
-	pvName := diskName + "p1"
+	// Devices ending with a digit (nvme0n1, mmcblk0, md0) use "p" separator for
+	// partitions (e.g. nvme0n1p1), others (sda, vdb) don't (e.g. sda1)
+	var partitionName, pvName string
+	if len(disk) > 0 && disk[len(disk)-1] >= '0' && disk[len(disk)-1] <= '9' {
+		partitionName = disk + "p1"
+		pvName = diskName + "p1"
+	} else {
+		partitionName = disk + "1"
+		pvName = diskName + "1"
+	}
 
 	existsLV := `lvdisplay /dev/` + vgName + `/` + lvName + ` && echo "true" || echo "false"`
 	outputLV, err := execCommandInNodeWithError(tc, nodeHostName, existsLV)
@@ -1541,7 +1556,7 @@ func getLvmClusterPathsWithOptional(namespace string) ([]string, []string, error
 		for _, node := range workerNodes {
 			// Check device existence and filesystem type separately
 			// so an unformatted device (blkid returns non-zero) is not misclassified as missing
-			checkCmd := exec.Command("oc", "debug", "node/"+node, "--", "chroot", "/host", "bash", "-c",
+			checkCmd := exec.Command("oc", "debug", "node/"+node, "--to-namespace=default", "--", "chroot", "/host", "bash", "-c",
 				fmt.Sprintf("if test -b %s; then echo 'DEVICE_EXISTS'; blkid %s 2>/dev/null || true; else echo 'DEVICE_NOT_FOUND'; fi", path, path))
 			checkOutput, err := checkCmd.CombinedOutput()
 			outputStr := string(checkOutput)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved teardown to perform non-blocking deletion and clear finalizers for reliable cluster cleanup and recovery.
  * Added preemptive cleanup for tests that may leave clusters behind if validation doesn't block creation.
  * Enhanced device handling to distinguish NVMe vs non-NVMe naming during volume create/remove operations.
  * Test probing now explicitly targets the default namespace for per-node device inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->