### PR TITLE
OCPEDGE-2238:feat(e2e test): add device class removal test

### DIFF
--- a/internal/controllers/lvmcluster/controller.go
+++ b/internal/controllers/lvmcluster/controller.go
@@ -216,8 +216,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 		logger.Info("processing LVMCluster deletion")
 		if err := r.processDelete(ctx, lvmCluster); err != nil {
-			// check in backing off intervals if there are still PVCs present or the LogicalVolumes are removed
-			return ctrl.Result{}, fmt.Errorf("failed to process LVMCluster deletion: %w", err)
+			logger.Info("LVMCluster deletion in progress, requeueing", "reason", err.Error())
+			return ctrl.Result{RequeueAfter: waitForDeletion}, nil
 		}
 		return reconcile.Result{}, nil
 	}
@@ -525,10 +525,10 @@ func (r *Reconciler) processDelete(ctx context.Context, instance *lvmv1alpha1.LV
 	if controllerutil.ContainsFinalizer(instance, lvmClusterFinalizer) {
 		resourceDeletionList := []resource.Manager{
 			resource.LVMVGs(),
+			resource.VGManager(r.ClusterType),
 			resource.LVMVGNodeStatus(),
 			resource.TopoLVMStorageClass(),
 			resource.CSIDriver(),
-			resource.VGManager(r.ClusterType),
 			resource.CSINode(),
 			resource.ServiceMonitor(),
 		}

--- a/internal/controllers/lvmcluster/resource/vgmanager.go
+++ b/internal/controllers/lvmcluster/resource/vgmanager.go
@@ -149,13 +149,11 @@ func (v vgManager) EnsureDeleted(r Reconciler, ctx context.Context, lvmCluster *
 		r.GetLogPassthroughOptions().VGManager.AsArgs(),
 	)
 
-	if err := r.Delete(ctx, &ds); errors.IsNotFound(err) {
-		return nil
-	} else if err != nil {
+	if err := r.Delete(ctx, &ds); err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete %s daemonset %q: %w", v.GetName(), ds.Name, err)
+	} else if err == nil {
+		logger.Info("initiated DaemonSet deletion", "DaemonSet", ds.Name)
 	}
-
-	logger.Info("initiated DaemonSet deletion", "DaemonSet", ds.Name)
 
 	if err := r.Get(ctx, client.ObjectKeyFromObject(&ds), &ds); err == nil {
 		return fmt.Errorf("%s daemonset %q still has to be removed", v.GetName(), ds.Name)

--- a/test/e2e/device_class_removal_test.go
+++ b/test/e2e/device_class_removal_test.go
@@ -1,0 +1,289 @@
+/*
+Copyright © 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	snapapi "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	. "github.com/onsi/ginkgo/v2"
+	ginkgotypes "github.com/onsi/ginkgo/v2/types"
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/config/clusterstatus"
+	storagev1 "k8s.io/api/storage/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/lvm-operator/v4/api/v1alpha1"
+	"github.com/openshift/lvm-operator/v4/internal/controllers/lvmcluster/resource"
+)
+
+func deviceClassRemovalTest() {
+	Describe("Cleanup", Serial, func() {
+		var cluster *v1alpha1.LVMCluster
+		BeforeEach(func(ctx SpecContext) {
+			infraStatus, err := clusterstatus.GetClusterInfraStatus(ctx, config)
+			Expect(err).NotTo(HaveOccurred(), "failed to get cluster infrastructure status")
+
+			if infraStatus.ControlPlaneTopology == configv1.ExternalTopologyMode {
+				Skip("Device class removal tests are not supported on HyperShift clusters")
+			}
+			if infraStatus.InfrastructureTopology != configv1.SingleReplicaTopologyMode {
+				Skip("Device class removal tests run only on single-node (SNO) clusters")
+			}
+
+			waitForExistingClusterDeletion(ctx)
+			cluster = GetDefaultTestLVMClusterTemplate()
+		})
+		AfterEach(func(ctx SpecContext) {
+			if cluster == nil {
+				return
+			}
+			if CurrentSpecReport().State.Is(ginkgotypes.SpecStateFailureStates) {
+				skipSuiteCleanup.Store(true)
+			}
+			DeleteResource(ctx, cluster)
+			validateCSINodeInfo(ctx, cluster, false)
+		})
+
+		It("should remove a non-default device class and clean up its resources", func(ctx SpecContext) {
+			cluster = createClusterWithTwoDeviceClasses(ctx, cluster, false)
+
+			vg2SCName := resource.GetStorageClassName("vg2")
+
+			By("Removing the non-default device class (vg2) from the cluster")
+			Expect(crClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)).To(Succeed())
+			cluster.Spec.Storage.DeviceClasses = filterDeviceClasses(cluster.Spec.Storage.DeviceClasses, "vg2")
+			Expect(crClient.Update(ctx, cluster)).To(Succeed())
+
+			By("Verifying vg2 StorageClass is deleted")
+			Eventually(func(ctx SpecContext) error {
+				return crClient.Get(ctx, types.NamespacedName{Name: vg2SCName}, &storagev1.StorageClass{})
+			}, 5*timeout, interval).WithContext(ctx).Should(Satisfy(k8serrors.IsNotFound))
+
+			By("Verifying vg2 LVMVolumeGroup is deleted")
+			Eventually(func(ctx SpecContext) error {
+				return crClient.Get(ctx, types.NamespacedName{Name: "vg2", Namespace: installNamespace}, &v1alpha1.LVMVolumeGroup{})
+			}, 5*timeout, interval).WithContext(ctx).Should(Satisfy(k8serrors.IsNotFound))
+
+			By("Verifying vg2 is removed from LVMCluster status")
+			Eventually(func(ctx SpecContext) bool {
+				currentCluster := &v1alpha1.LVMCluster{}
+				if err := crClient.Get(ctx, client.ObjectKeyFromObject(cluster), currentCluster); err != nil {
+					return false
+				}
+				for _, dcs := range currentCluster.Status.DeviceClassStatuses {
+					if dcs.Name == "vg2" {
+						return false
+					}
+				}
+				return true
+			}, 5*timeout, interval).WithContext(ctx).Should(BeTrue())
+
+			By("Verifying the cluster is still Ready with vg1")
+			validateLVMCluster(ctx, cluster)
+		})
+
+		It("should also clean up VolumeSnapshotClass when removing a device class with thin pool", func(ctx SpecContext) {
+			cluster = createClusterWithTwoDeviceClasses(ctx, cluster, true)
+
+			vg2VSCName := resource.GetVolumeSnapshotClassName("vg2")
+
+			By("Verifying vg2 VolumeSnapshotClass exists")
+			if err := crClient.Get(ctx, types.NamespacedName{Name: vg2VSCName}, &snapapi.VolumeSnapshotClass{}); meta.IsNoMatchError(err) {
+				Skip("VolumeSnapshotClasses are not supported in this cluster")
+			}
+			Eventually(func(ctx SpecContext) error {
+				return crClient.Get(ctx, types.NamespacedName{Name: vg2VSCName}, &snapapi.VolumeSnapshotClass{})
+			}, timeout, interval).WithContext(ctx).Should(Succeed())
+
+			By("Removing the non-default device class (vg2)")
+			Expect(crClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)).To(Succeed())
+			cluster.Spec.Storage.DeviceClasses = filterDeviceClasses(cluster.Spec.Storage.DeviceClasses, "vg2")
+			Expect(crClient.Update(ctx, cluster)).To(Succeed())
+
+			By("Verifying vg2 StorageClass is deleted")
+			Eventually(func(ctx SpecContext) error {
+				return crClient.Get(ctx, types.NamespacedName{Name: resource.GetStorageClassName("vg2")}, &storagev1.StorageClass{})
+			}, 5*timeout, interval).WithContext(ctx).Should(Satisfy(k8serrors.IsNotFound))
+
+			By("Verifying vg2 VolumeSnapshotClass is deleted")
+			Eventually(func(ctx SpecContext) bool {
+				err := crClient.Get(ctx, types.NamespacedName{Name: vg2VSCName}, &snapapi.VolumeSnapshotClass{})
+				return k8serrors.IsNotFound(err) || meta.IsNoMatchError(err)
+			}, 5*timeout, interval).WithContext(ctx).Should(BeTrue())
+
+			By("Verifying the cluster is still Ready")
+			validateLVMCluster(ctx, cluster)
+		})
+	})
+
+	// Rejected updates don't change server state, so all webhook tests share one cluster.
+	Describe("Webhook Validation", Serial, Ordered, func() {
+		var cluster *v1alpha1.LVMCluster
+
+		BeforeAll(func(ctx SpecContext) {
+			infraStatus, err := clusterstatus.GetClusterInfraStatus(ctx, config)
+			Expect(err).NotTo(HaveOccurred(), "failed to get cluster infrastructure status")
+
+			if infraStatus.ControlPlaneTopology == configv1.ExternalTopologyMode {
+				Skip("Device class removal tests are not supported on HyperShift clusters")
+			}
+			if infraStatus.InfrastructureTopology != configv1.SingleReplicaTopologyMode {
+				Skip("Device class removal tests run only on single-node (SNO) clusters")
+			}
+
+			waitForExistingClusterDeletion(ctx)
+			cluster = GetDefaultTestLVMClusterTemplate()
+			cluster = createClusterWithTwoDeviceClasses(ctx, cluster, false)
+		})
+
+		AfterAll(func(ctx SpecContext) {
+			if cluster == nil {
+				return
+			}
+			if CurrentSpecReport().State.Is(ginkgotypes.SpecStateFailureStates) {
+				skipSuiteCleanup.Store(true)
+			}
+			DeleteResource(ctx, cluster)
+			validateCSINodeInfo(ctx, cluster, false)
+		})
+
+		It("should reject removal of the default device class", func(ctx SpecContext) {
+			Eventually(func(g Gomega, ctx SpecContext) {
+				g.Expect(crClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)).To(Succeed())
+				cluster.Spec.Storage.DeviceClasses = filterDeviceClasses(cluster.Spec.Storage.DeviceClasses, "vg1")
+				err := crClient.Update(ctx, cluster)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("cannot delete default device class"))
+			}, timeout, interval).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should reject removal of all device classes", func(ctx SpecContext) {
+			Eventually(func(g Gomega, ctx SpecContext) {
+				g.Expect(crClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)).To(Succeed())
+				cluster.Spec.Storage.DeviceClasses = []v1alpha1.DeviceClass{}
+				err := crClient.Update(ctx, cluster)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("at least one device class must remain"))
+			}, timeout, interval).WithContext(ctx).Should(Succeed())
+		})
+	})
+}
+
+// createClusterWithTwoDeviceClasses discovers available devices, deletes the initial cluster,
+// and recreates it with vg1 (default, thick) and vg2 (non-default). If vg2WithThinPool is true,
+// vg2 gets a ThinPoolConfig.
+func createClusterWithTwoDeviceClasses(ctx SpecContext, cluster *v1alpha1.LVMCluster, vg2WithThinPool bool) *v1alpha1.LVMCluster {
+	GinkgoHelper()
+
+	By("Creating cluster without device selector to discover available devices")
+	CreateResource(ctx, cluster)
+	VerifyLVMSSetup(ctx, cluster)
+
+	devices := getDiscoveredDevices(ctx, cluster)
+	Expect(len(devices)).To(BeNumerically(">=", 2), "at least 2 devices are required for device class removal test")
+	GinkgoLogr.Info("Discovered devices", "devices", devices)
+
+	smallerDevice, largerDevice := classifyDevicesBySize(devices)
+
+	By("Deleting cluster to recreate with two device classes")
+	DeleteResource(ctx, cluster)
+	validateCSINodeInfo(ctx, cluster, false)
+	waitForExistingClusterDeletion(ctx)
+
+	By("Recreating cluster with default (vg1) and non-default (vg2) device classes")
+	cluster = GetDefaultTestLVMClusterTemplate()
+	cluster.Spec.Storage.DeviceClasses[0].ThinPoolConfig = nil
+	cluster.Spec.Storage.DeviceClasses[0].DeviceSelector = &v1alpha1.DeviceSelector{
+		Paths: []v1alpha1.DevicePath{v1alpha1.DevicePath(largerDevice)},
+	}
+
+	vg2 := v1alpha1.DeviceClass{
+		Name:    "vg2",
+		Default: false,
+		DeviceSelector: &v1alpha1.DeviceSelector{
+			Paths: []v1alpha1.DevicePath{v1alpha1.DevicePath(smallerDevice)},
+		},
+	}
+	if vg2WithThinPool {
+		vg2.ThinPoolConfig = &v1alpha1.ThinPoolConfig{
+			Name:               "tp2",
+			SizePercent:        90,
+			OverprovisionRatio: 5,
+		}
+	}
+	cluster.Spec.Storage.DeviceClasses = append(cluster.Spec.Storage.DeviceClasses, vg2)
+
+	CreateResource(ctx, cluster)
+	validateLVMCluster(ctx, cluster)
+	validateCSIDriver(ctx)
+	validateCSINodeInfo(ctx, cluster, true)
+	validateVGManager(ctx)
+	validateLVMVolumeGroup(ctx)
+	validateStorageClass(ctx)
+	validateLVMVolumeGroupByName(ctx, "vg2")
+	validateStorageClassByName(ctx, resource.GetStorageClassName("vg2"))
+	if vg2WithThinPool {
+		validateVolumeSnapshotClassByName(ctx, resource.GetVolumeSnapshotClassName("vg2"))
+	}
+
+	return cluster
+}
+
+func filterDeviceClasses(classes []v1alpha1.DeviceClass, excludeName string) []v1alpha1.DeviceClass {
+	var result []v1alpha1.DeviceClass
+	for _, dc := range classes {
+		if dc.Name != excludeName {
+			result = append(result, dc)
+		}
+	}
+	return result
+}
+
+func validateLVMVolumeGroupByName(ctx context.Context, name string) bool {
+	GinkgoHelper()
+	By("validating the LVMVolumeGroup " + name)
+	return Eventually(func(ctx context.Context) error {
+		return crClient.Get(ctx, types.NamespacedName{Name: name, Namespace: installNamespace}, &v1alpha1.LVMVolumeGroup{})
+	}, timeout, interval).WithContext(ctx).Should(Succeed())
+}
+
+func validateStorageClassByName(ctx context.Context, name string) bool {
+	GinkgoHelper()
+	By("validating the StorageClass " + name)
+	return Eventually(func(ctx context.Context) error {
+		return crClient.Get(ctx, types.NamespacedName{Name: name}, &storagev1.StorageClass{})
+	}, timeout, interval).WithContext(ctx).Should(Succeed())
+}
+
+func validateVolumeSnapshotClassByName(ctx context.Context, name string) bool {
+	GinkgoHelper()
+	By("validating the VolumeSnapshotClass " + name)
+	return Eventually(func(ctx context.Context) error {
+		err := crClient.Get(ctx, types.NamespacedName{Name: name}, &snapapi.VolumeSnapshotClass{})
+		if meta.IsNoMatchError(err) {
+			GinkgoLogr.Info("VolumeSnapshotClass is ignored since VolumeSnapshotClasses are not supported in the given Cluster")
+			return nil
+		}
+		return err
+	}, timeout, interval).WithContext(ctx).Should(Succeed())
+}

--- a/test/e2e/lvm_suite_test.go
+++ b/test/e2e/lvm_suite_test.go
@@ -76,4 +76,5 @@ var _ = Describe("LVM Operator e2e tests", func() {
 		Describe("Thick", Serial, Ordered, pvcTestThickProvisioning)
 	})
 	Describe("Device Removal", Serial, deviceRemovalTest)
+	Describe("Device Class Removal", Serial, deviceClassRemovalTest)
 })

--- a/test/e2e/storage_class_options_test.go
+++ b/test/e2e/storage_class_options_test.go
@@ -347,7 +347,7 @@ func storageClassOptionsTest() {
 				By("Waiting for LVMCluster to be fully deleted")
 				Eventually(func(ctx SpecContext) error {
 					return crClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)
-				}, 5*time.Minute, interval).WithContext(ctx).Should(Satisfy(k8serrors.IsNotFound))
+				}, 10*time.Minute, interval).WithContext(ctx).Should(Satisfy(k8serrors.IsNotFound))
 			})
 		})
 

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -52,24 +52,20 @@ const (
 	vgManagerDaemonsetName  = "vg-manager"
 )
 
-// waitForExistingClusterDeletion ensures no LVMCluster is present before a new
-// test starts. This handles the case where a previous test's cleanup timed out
-// but the operator is still processing deletion in the background. Without this
-// guard, the next test would immediately fail with "duplicate LVMClusters".
 func waitForExistingClusterDeletion(ctx context.Context) {
 	GinkgoHelper()
-	By("ensuring no stale LVMCluster exists from a previous test")
+	By("ensuring no LVMCluster exists from a previous test")
 	Eventually(func(ctx context.Context) error {
-		list := &v1alpha1.LVMClusterList{}
-		if err := crClient.List(ctx, list, client.InNamespace(installNamespace)); err != nil {
+		clusterList := &v1alpha1.LVMClusterList{}
+		if err := crClient.List(ctx, clusterList, client.InNamespace(installNamespace)); err != nil {
 			return err
 		}
-		if len(list.Items) > 0 {
+		if len(clusterList.Items) > 0 {
 			return fmt.Errorf("LVMCluster %q still exists (phase: %s, deletionTimestamp: %v)",
-				list.Items[0].Name, list.Items[0].Status.State, list.Items[0].DeletionTimestamp)
+				clusterList.Items[0].Name, clusterList.Items[0].Status.State, clusterList.Items[0].DeletionTimestamp)
 		}
 		return nil
-	}, 5*time.Minute, interval).WithContext(ctx).Should(Succeed())
+	}, timeout, interval).WithContext(ctx).Should(Succeed())
 }
 
 func validateLVMCluster(ctx context.Context, cluster *v1alpha1.LVMCluster) bool {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for removing non-default device classes, including optional thin-pool snapshot scenarios and webhook validation to ensure illegal removals are rejected.
  * Ensured serial ordering and enhanced pre-test cleanup polling for deterministic, stable test execution.

* **Bug Fixes**
  * Improved deletion handling and cleanup ordering to make device-class removal and resource cleanup more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->