### PR TITLE
OCPEDGE-2626: Limit go test parallelism to prevent OOM in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ verify: ## Verify go formatting and generated files.
 	hack/verify-generated.sh
 
 test: envtest godeps-update ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -v -coverprofile=coverage.out `go list ./... | grep -v -e "e2e" -e "performance"`
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -v -p 2 -coverprofile=coverage.out `go list ./... | grep -v -e "e2e" -e "performance"`
 ifeq ($(OPENSHIFT_CI), true)
 	hack/publish-codecov.sh
 endif


### PR DESCRIPTION
The Konflux integration test pipeline runs with a 2Gi memory limit (from the tenant LimitRange). With default parallelism, multiple packages compile heavy dependencies (client-go, controller-runtime) simultaneously, exceeding the limit and triggering OOM kills.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized test execution configuration for improved build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->