### PR TITLE
NO-ISSUE: Apply ready-for-human-review label after coderabbit succeeds

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,3 +8,8 @@ tone_instructions: "Be concise"
 reviews:
   in_progress_fortune: false
   poem: false
+  request_changes_workflow: true
+  auto_apply_labels: true
+  labeling_instructions:
+    - label: "ready-for-human-review"
+      instructions: "Apply when CodeRabbit approves the PR with no outstanding comments or requested changes."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review automation configuration to enable automated workflows and labeling for pull requests. Pull requests will now automatically receive a "ready-for-human-review" label when the automated reviewer approves with no outstanding issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->