### PR TITLE
NO-JIRA: Fix setup-envtest 401 Unauthorized from deprecated GCS bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ OPERATOR_SDK_VERSION ?= 1.34.1
 
 CONTROLLER_RUNTIME_VERSION := $(shell awk '/sigs\.k8s\.io\/controller-runtime/ {print substr($$2, 2)}' $(SELF_DIR)/go.mod)
 GINKGO_VERSION := $(shell awk '/github.com\/onsi\/ginkgo\/v2/ {print $$2}' $(SELF_DIR)/go.mod)
-ENVTEST_BRANCH := release-$(shell echo $(CONTROLLER_RUNTIME_VERSION) | cut -d "." -f 1-2)
+ENVTEST_BRANCH := release-0.19
 ENVTEST_KUBERNETES_VERSION := $(shell echo $(KUBERNETES_VERSION) | cut -d "." -f 1-2)
 
 MANAGER_NAME_PREFIX ?= lvms-


### PR DESCRIPTION
## Summary

Integration tests CI was failing in this branch with `unable to fetch hash for requested version: unable fetch metadata for kubebuilder-tools-1.30.0-linux-amd64.tar.gz -- got status "401 Unauthorized" from GCS` (e.g. https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/logical-volume-manag-tenant/applications/lvm-operator-4-17/pipelineruns/lvm-operator-integration-tests-4-17-xxh5b/logs?task=test).

- Pin `ENVTEST_BRANCH` to `release-0.19` instead of deriving it from the controller-runtime version (`release-0.18`)
- Older `setup-envtest` versions download kubebuilder-tools from a GCS bucket that now returns `401 Unauthorized`
- `release-0.19+` fetches from GitHub releases instead, fixing the CI failure

Similar fix was applied in [openshift/assisted-service#8856](https://github.com/openshift/assisted-service/pull/8856).

## Test plan
- [x] Verified `setup-envtest` from `release-0.19` successfully fetches kubebuilder assets
- [ ] CI integration tests pass with the updated `ENVTEST_BRANCH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)