### PR TITLE
NO-JIRA: Fix setup-envtest 401 Unauthorized from deprecated GCS bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ENVTEST_K8S_VERSION = 1.29.0
 OPERATOR_SDK_VERSION ?= 1.34.1
 CONTROLLER_RUNTIME_VERSION := $(shell awk '/sigs\.k8s\.io\/controller-runtime/ {print substr($$2, 2)}' $(SELF_DIR)/go.mod)
 GINKGO_VERSION := $(shell awk '/github.com\/onsi\/ginkgo\/v2/ {print $$2}' $(SELF_DIR)/go.mod)
-ENVTEST_BRANCH := release-$(shell echo $(CONTROLLER_RUNTIME_VERSION) | cut -d "." -f 1-2)
+ENVTEST_BRANCH := release-0.17
 ENVTEST_KUBERNETES_VERSION := $(shell echo $(KUBERNETES_VERSION) | cut -d "." -f 1-2)
 
 MANAGER_NAME_PREFIX ?= lvms-
@@ -157,7 +157,7 @@ verify: ## Verify go formatting and generated files.
 	hack/verify-generated.sh
 
 test: envtest godeps-update ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -v -coverprofile=coverage.out `go list ./... | grep -v -e "e2e" -e "performance"`
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --use-deprecated-gcs=false -p path)" go test -v -coverprofile=coverage.out `go list ./... | grep -v -e "e2e" -e "performance"`
 ifeq ($(OPENSHIFT_CI), true)
 	hack/publish-codecov.sh
 endif


### PR DESCRIPTION
## Summary
- Pin `ENVTEST_BRANCH` to `release-0.17` and pass `--use-deprecated-gcs=false` to force GitHub releases download
- `release-0.17` is the latest setup-envtest branch compatible with Go 1.21 (this branch's Go version)
- `release-0.19+` would fix GCS by default but requires Go 1.22+
- The deprecated GCS bucket for kubebuilder-tools now returns `401 Unauthorized`

Same fix as https://github.com/openshift/lvm-operator/pull/2360 (release-4.17), adapted for Go 1.21 compatibility.
Similar fix was applied in [openshift/assisted-service#8856](https://github.com/openshift/assisted-service/pull/8856).

## Test plan
- [x] Verified `setup-envtest` from `release-0.17` with `--use-deprecated-gcs=false` successfully fetches kubebuilder assets
- [ ] CI integration tests pass with the updated configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)