### PR TITLE
NO-JIRA: Add renovate config validation workflow and make target

### DIFF
--- a/.github/workflows/renovate-config-validation.yaml
+++ b/.github/workflows/renovate-config-validation.yaml
@@ -1,0 +1,26 @@
+# This utilizes konflux-ci's github workflow for validating the renovate configuration
+name: "Validate renovate.json config file"
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "renovate.json"
+
+  push:
+    branches:
+      - main
+    paths:
+      - "renovate.json"
+
+jobs:
+  renovate-config-file-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: konflux-ci/renovate-config-validator-action@main
+        with:
+          config_file: renovate.json

--- a/release/konflux.make
+++ b/release/konflux.make
@@ -44,6 +44,13 @@ catalog-source: opm
 
 IMAGE_BUILD_CMD ?= $(shell command -v podman 2>&1 >/dev/null && echo podman || echo docker)
 
+.PHONY: validate-renovate-config
+validate-renovate-config:
+	$(IMAGE_BUILD_CMD) run --rm \
+	-v $(shell pwd)/renovate.json:/workspace/renovate.json:ro,Z \
+	quay.io/konflux-ci/mintmaker-renovate-image:latest \
+	renovate-config-validator /workspace/renovate.json
+
 .PHONY: catalog-container
 catalog-container:
 	$(IMAGE_BUILD_CMD) build --build-arg=CATALOG_VERSION=$(Y_STREAM) -t lvm-operator-catalog:$(Y_STREAM) -f release/catalog/catalog.konflux.Dockerfile .

--- a/renovate.json
+++ b/renovate.json
@@ -1,57 +1,39 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>konflux-ci/mintmaker//config/renovate/renovate.json"
+    "github>konflux-ci/mintmaker//config/renovate/renovate.json",
+    "github>konflux-ci/mintmaker-presets:refresh-rpm-lockfiles",
+    "github>konflux-ci/mintmaker-presets:disable-minor-updates"
   ],
   "customManagers": [
     {
       "customType": "regex",
       "datasourceTemplate": "docker",
-      "managerFilePatterns": [
-        "/.*\\-catalog\\-template\\.yaml$/"
-      ],
+      "managerFilePatterns": ["/.*\\-catalog\\-template\\.yaml$/"],
       "matchStrings": [
         "(?<depName>quay\\.io[\\w\\-\\.\\/]+)(?<currentValue>)?@(?<currentDigest>sha256:[a-f0-9]+)"
       ],
       "versioningTemplate": "docker"
     }
   ],
-  "gomod": {
-    "enabled": false
-  },
-  "pre-commit": {
-    "enabled": false
-  },
+  "gomod": { "enabled": false },
+  "pre-commit": { "enabled": false },
   "commitBody": "Signed-off-by: {{{gitAuthor}}}",
   "commitMessagePrefix": "NO-JIRA:",
   "packageRules": [
     {
-      "addLabels": [
-        "approved",
-        "lgtm"
-      ],
+      "addLabels": ["approved", "lgtm"],
       "autoApprove": true,
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "rebase",
       "enabled": true,
-      "includePaths": [
-        "release/**"
-      ],
-      "matchManagers": [
-        "custom.regex"
-      ],
-      "matchUpdateTypes": [
-        "digest"
-      ],
+      "includePaths": ["release/**"],
+      "matchManagers": ["custom.regex"],
+      "matchUpdateTypes": ["digest"],
       "platformAutomerge": true
     },
-    {
-      "matchUpdateTypes": [
-        "minor"
-      ],
-      "enabled": false
-    }
+    { "matchUpdateTypes": ["minor"], "enabled": false }
   ],
   "prConcurrentLimit": 0,
   "pruneBranchAfterAutomerge": true,
@@ -62,38 +44,23 @@
     "automerge": true,
     "automergeType": "pr",
     "automergeStrategy": "rebase",
-    "addLabels": [
-      "approved",
-      "lgtm"
-    ],
+    "addLabels": ["approved", "lgtm"],
     "enabled": true,
-    "managerFilePatterns": [
-      "/\\.yaml$/",
-      "/\\.yml$/"
-    ],
+    "managerFilePatterns": ["/\\.yaml$/", "/\\.yml$/"],
     "ignoreTests": true,
-    "includePaths": [
-      ".tekton/**",
-      "release/**"
-    ],
+    "includePaths": [".tekton/**", "release/**"],
     "platformAutomerge": true
   },
   "lockFileMaintenance": {
     "enabled": true,
     "recreateWhen": "auto",
     "rebaseWhen": "behind-base-branch",
-    "rebaseStalePrs": true,
     "branchTopic": "lock-file-maintenance",
-    "schedule": [
-      "before 5am"
-    ],
+    "schedule": ["before 5am"],
     "automerge": true,
     "automergeType": "pr",
     "automergeStrategy": "rebase",
-    "addLabels": [
-      "approved",
-      "lgtm"
-    ],
+    "addLabels": ["approved", "lgtm"],
     "platformAutomerge": true
   }
 }


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow to validate `renovate.json` on PRs and pushes to main
- Add a `validate-renovate-config` make target in `release/konflux.make` for local validation using the `quay.io/konflux-ci/mintmaker-renovate-image` container
- Update `renovate.json` to extend `mintmaker-presets` for rpm-lockfile refresh and disable-minor-updates

### Important Note
I don't actually know if this will work as intended. The addition to the extends should trigger the PR to do container and RPMs together but I don't know if our other configs override that functionality. I will monitor after merge and open follow up PRs if it overlaps. There is no way to test this prior to merge unfortunately. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to validate the repository's Renovate configuration on PRs and pushes to main (runs when the config changes).
  * Added a local make target to run Renovate configuration validation in a container.
  * Updated Renovate configuration to add two preset extensions and remove a deprecated lockfile option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->