### PR TITLE
OCPEDGE-2583: Update tekton pipelines to target release-4.22 branch

### DIFF
--- a/.tekton/lvm-operator-bundle-pull-request.yaml
+++ b/.tekton/lvm-operator-bundle-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/lvm-operator-bundle-pull-request.yaml".pathChanged()
+      == "release-4.22" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/lvm-operator-bundle-pull-request.yaml".pathChanged()
       || ".tekton/lvm-operator-bundle-push.yaml".pathChanged() || "release/bundle/***".pathChanged()
       || "bundle/***".pathChanged() || "release/hack/render_templates.sh".pathChanged() || "release/container-build.args".pathChanged()
       || ".tekton/images-mirror-set.yaml".pathChanged())

--- a/.tekton/lvm-operator-bundle-push.yaml
+++ b/.tekton/lvm-operator-bundle-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/lvm-operator-bundle-pull-request.yaml".pathChanged()
+      == "release-4.22" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/lvm-operator-bundle-pull-request.yaml".pathChanged()
       || ".tekton/lvm-operator-bundle-push.yaml".pathChanged() || "release/bundle/***".pathChanged()
       || "bundle/***".pathChanged() || "release/hack/render_templates.sh".pathChanged() || "release/container-build.args".pathChanged()
       || ".tekton/images-mirror-set.yaml".pathChanged())

--- a/.tekton/lvm-operator-catalog-pull-request.yaml
+++ b/.tekton/lvm-operator-catalog-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-4.22" &&
       (".tekton/lvm-operator-catalog-pull-request.yaml".pathChanged() ||
       ".tekton/lvm-operator-catalog-push.yaml".pathChanged() ||
       ".tekton/images-mirror-set.yaml".pathChanged() ||

--- a/.tekton/lvm-operator-catalog-push.yaml
+++ b/.tekton/lvm-operator-catalog-push.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-4.22" &&
       (".tekton/lvm-operator-catalog-pull-request.yaml".pathChanged() ||
       ".tekton/lvm-operator-catalog-push.yaml".pathChanged() ||
       ".tekton/images-mirror-set.yaml".pathChanged() ||

--- a/.tekton/lvm-operator-pull-request.yaml
+++ b/.tekton/lvm-operator-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/lvm-operator-pull-request.yaml".pathChanged()
+      == "release-4.22" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/lvm-operator-pull-request.yaml".pathChanged()
       || ".tekton/lvm-operator-push.yaml".pathChanged() || "release/operator/***".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "cmd/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()

--- a/.tekton/lvm-operator-push.yaml
+++ b/.tekton/lvm-operator-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/lvm-operator-pull-request.yaml".pathChanged()
+      == "release-4.22" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/lvm-operator-pull-request.yaml".pathChanged()
       || ".tekton/lvm-operator-push.yaml".pathChanged() || "release/operator/***".pathChanged()
       || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
       || "cmd/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()

--- a/.tekton/lvms-must-gather-pull-request.yaml
+++ b/.tekton/lvms-must-gather-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/lvms-must-gather-pull-request.yaml".pathChanged()
+      == "release-4.22" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/lvms-must-gather-pull-request.yaml".pathChanged()
       || ".tekton/lvms-must-gather-push.yaml".pathChanged() || "must-gather/***".pathChanged()
       || "release/must-gather/***".pathChanged() || "release/container-build.args".pathChanged())
   creationTimestamp: null

--- a/.tekton/lvms-must-gather-push.yaml
+++ b/.tekton/lvms-must-gather-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/lvms-must-gather-pull-request.yaml".pathChanged()
+      == "release-4.22" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/lvms-must-gather-pull-request.yaml".pathChanged()
       || ".tekton/lvms-must-gather-push.yaml".pathChanged() || "must-gather/***".pathChanged()
       || "release/must-gather/***".pathChanged() || "release/container-build.args".pathChanged())
   creationTimestamp: null


### PR DESCRIPTION
Change target_branch filter from "main" to "release-4.22" in all tekton pipeline CEL expressions so PR and push pipelines trigger correctly for the release branch.