### PR TITLE
[release-4.19] NO-JIRA: Limit go test parallelism to prevent OOM in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ verify: ## Verify go formatting and generated files.
 	hack/verify-generated.sh
 
 test: envtest godeps-update ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -v -coverprofile=coverage.out `go list ./... | grep -v -e "e2e" -e "performance"`
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -v -p 2 -coverprofile=coverage.out `go list ./... | grep -v -e "e2e" -e "performance"`
 ifeq ($(OPENSHIFT_CI), true)
 	hack/publish-codecov.sh
 endif


### PR DESCRIPTION
The Konflux integration test pipeline runs with a memory limit from the tenant LimitRange. With default parallelism, multiple packages compile heavy dependencies simultaneously, exceeding the limit and triggering OOM kills. Limit to 2 parallel packages.