### PR TITLE
[release-4.14] NO-JIRA: Regenerate manifests with controller-gen v0.17.3

### DIFF
--- a/bundle/manifests/lvm.topolvm.io_lvmclusters.yaml
+++ b/bundle/manifests/lvm.topolvm.io_lvmclusters.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.17.3
   creationTimestamp: null
   name: lvmclusters.lvm.topolvm.io
 spec:
@@ -24,14 +24,19 @@ spec:
         description: LVMCluster is the Schema for the lvmclusters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -57,18 +62,18 @@ spec:
                             match for a device to be included in the LVMCluster
                           properties:
                             optionalPaths:
-                              description: A list of device paths which could be chosen
-                                for creating Volume Group. For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
-                                We discourage using the device names as they can change
-                                over node restarts.
+                              description: |-
+                                A list of device paths which could be chosen for creating Volume Group.
+                                For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
+                                We discourage using the device names as they can change over node restarts.
                               items:
                                 type: string
                               type: array
                             paths:
-                              description: A list of device paths which would be chosen
-                                for creating Volume Group. For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
-                                We discourage using the device names as they can change
-                                over node restarts.
+                              description: |-
+                                A list of device paths which would be chosen for creating Volume Group.
+                                For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
+                                We discourage using the device names as they can change over node restarts.
                               items:
                                 type: string
                               type: array
@@ -83,9 +88,10 @@ spec:
                           - ""
                           type: string
                         name:
-                          description: 'Name of the class, the VG and possibly the
-                            storageclass. Validations to confirm that this field can
-                            be used as metadata.name field in storageclass ref: https://github.com/kubernetes/apimachinery/blob/de7147/pkg/util/validation/validation.go#L209'
+                          description: |-
+                            Name of the class, the VG and possibly the storageclass.
+                            Validations to confirm that this field can be used as metadata.name field in storageclass
+                            ref: https://github.com/kubernetes/apimachinery/blob/de7147/pkg/util/validation/validation.go#L209
                           maxLength: 245
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -98,39 +104,35 @@ spec:
                               description: Required. A list of node selector terms.
                                 The terms are ORed.
                               items:
-                                description: A null or empty node selector term matches
-                                  no objects. The requirements of them are ANDed.
-                                  The TopologySelectorTerm type implements a subset
-                                  of the NodeSelectorTerm.
+                                description: |-
+                                  A null or empty node selector term matches no objects. The requirements of
+                                  them are ANDed.
+                                  The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                 properties:
                                   matchExpressions:
                                     description: A list of node selector requirements
                                       by node's labels.
                                     items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -143,30 +145,26 @@ spec:
                                     description: A list of node selector requirements
                                       by node's fields.
                                     items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -176,10 +174,12 @@ spec:
                                       type: object
                                     type: array
                                 type: object
+                                x-kubernetes-map-type: atomic
                               type: array
                           required:
                           - nodeSelectorTerms
                           type: object
+                          x-kubernetes-map-type: atomic
                         thinPoolConfig:
                           description: ThinPoolConfig contains configurations for
                             the thin-pool
@@ -188,19 +188,17 @@ spec:
                               description: Name of the thin pool to be created
                               type: string
                             overprovisionRatio:
-                              description: OverProvisionRatio is the factor by which
-                                additional storage can be provisioned compared to
+                              description: |-
+                                OverProvisionRatio is the factor by which additional storage can be provisioned compared to
                                 the available storage in the thin pool.
                               minimum: 1
                               type: integer
                             sizePercent:
                               default: 90
-                              description: SizePercent specifies the percentage of
-                                space in the LVM volume group for creating the thin
-                                pool. If the size configuration is 100, the whole
-                                disk will be used. By default, 90% of the disk is
-                                used for the thin pool to allow for data or metadata
-                                expansion later on.
+                              description: |-
+                                SizePercent specifies the percentage of space in the LVM volume group for creating the thin pool.
+                                If the size configuration is 100, the whole disk will be used.
+                                By default, 90% of the disk is used for the thin pool to allow for data or metadata expansion later on.
                               maximum: 100
                               minimum: 10
                               type: integer
@@ -216,40 +214,39 @@ spec:
               tolerations:
                 description: Tolerations to apply to nodes to act on
                 items:
-                  description: The pod this Toleration is attached to tolerates any
-                    taint that matches the triple <key,value,effect> using the matching
-                    operator <operator>.
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
                   properties:
                     effect:
-                      description: Effect indicates the taint effect to match. Empty
-                        means match all taint effects. When specified, allowed values
-                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: Key is the taint key that the toleration applies
-                        to. Empty means match all taint keys. If the key is empty,
-                        operator must be Exists; this combination means to match all
-                        values and all keys.
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                       type: string
                     operator:
-                      description: Operator represents a key's relationship to the
-                        value. Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod
-                        can tolerate all taints of a particular category.
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: TolerationSeconds represents the period of time
-                        the toleration (which must be of effect NoExecute, otherwise
-                        this field is ignored) tolerates the taint. By default, it
-                        is not set, which means tolerate the taint forever (do not
-                        evict). Zero and negative values will be treated as 0 (evict
-                        immediately) by the system.
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: Value is the taint value the toleration matches
-                        to. If the operator is Exists, the value should be empty,
-                        otherwise just a regular string.
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
                       type: string
                   type: object
                 type: array
@@ -260,8 +257,9 @@ spec:
               conditions:
                 description: Conditions describes the state of the resource.
                 items:
-                  description: Condition represents the state of the operator's reconciliation
-                    functionality.
+                  description: |-
+                    Condition represents the state of the operator's
+                    reconciliation functionality.
                   properties:
                     lastHeartbeatTime:
                       format: date-time
@@ -336,5 +334,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/lvm.topolvm.io_lvmclusters.yaml
+++ b/bundle/manifests/lvm.topolvm.io_lvmclusters.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: lvmclusters.lvm.topolvm.io
 spec:
@@ -24,19 +24,14 @@ spec:
         description: LVMCluster is the Schema for the lvmclusters API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -62,18 +57,18 @@ spec:
                             match for a device to be included in the LVMCluster
                           properties:
                             optionalPaths:
-                              description: |-
-                                A list of device paths which could be chosen for creating Volume Group.
-                                For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
-                                We discourage using the device names as they can change over node restarts.
+                              description: A list of device paths which could be chosen
+                                for creating Volume Group. For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
+                                We discourage using the device names as they can change
+                                over node restarts.
                               items:
                                 type: string
                               type: array
                             paths:
-                              description: |-
-                                A list of device paths which would be chosen for creating Volume Group.
-                                For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
-                                We discourage using the device names as they can change over node restarts.
+                              description: A list of device paths which would be chosen
+                                for creating Volume Group. For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
+                                We discourage using the device names as they can change
+                                over node restarts.
                               items:
                                 type: string
                               type: array
@@ -88,10 +83,9 @@ spec:
                           - ""
                           type: string
                         name:
-                          description: |-
-                            Name of the class, the VG and possibly the storageclass.
-                            Validations to confirm that this field can be used as metadata.name field in storageclass
-                            ref: https://github.com/kubernetes/apimachinery/blob/de7147/pkg/util/validation/validation.go#L209
+                          description: 'Name of the class, the VG and possibly the
+                            storageclass. Validations to confirm that this field can
+                            be used as metadata.name field in storageclass ref: https://github.com/kubernetes/apimachinery/blob/de7147/pkg/util/validation/validation.go#L209'
                           maxLength: 245
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -104,35 +98,39 @@ spec:
                               description: Required. A list of node selector terms.
                                 The terms are ORed.
                               items:
-                                description: |-
-                                  A null or empty node selector term matches no objects. The requirements of
-                                  them are ANDed.
-                                  The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                description: A null or empty node selector term matches
+                                  no objects. The requirements of them are ANDed.
+                                  The TopologySelectorTerm type implements a subset
+                                  of the NodeSelectorTerm.
                                 properties:
                                   matchExpressions:
                                     description: A list of node selector requirements
                                       by node's labels.
                                     items:
-                                      description: |-
-                                        A node selector requirement is a selector that contains values, a key, and an operator
-                                        that relates the key and values.
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: |-
-                                            Represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
                                           type: string
                                         values:
-                                          description: |-
-                                            An array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. If the operator is Gt or Lt, the values
-                                            array must have a single element, which will be interpreted as an integer.
-                                            This array is replaced during a strategic merge patch.
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -145,26 +143,30 @@ spec:
                                     description: A list of node selector requirements
                                       by node's fields.
                                     items:
-                                      description: |-
-                                        A node selector requirement is a selector that contains values, a key, and an operator
-                                        that relates the key and values.
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: |-
-                                            Represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
                                           type: string
                                         values:
-                                          description: |-
-                                            An array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. If the operator is Gt or Lt, the values
-                                            array must have a single element, which will be interpreted as an integer.
-                                            This array is replaced during a strategic merge patch.
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -174,12 +176,10 @@ spec:
                                       type: object
                                     type: array
                                 type: object
-                                x-kubernetes-map-type: atomic
                               type: array
                           required:
                           - nodeSelectorTerms
                           type: object
-                          x-kubernetes-map-type: atomic
                         thinPoolConfig:
                           description: ThinPoolConfig contains configurations for
                             the thin-pool
@@ -188,17 +188,19 @@ spec:
                               description: Name of the thin pool to be created
                               type: string
                             overprovisionRatio:
-                              description: |-
-                                OverProvisionRatio is the factor by which additional storage can be provisioned compared to
+                              description: OverProvisionRatio is the factor by which
+                                additional storage can be provisioned compared to
                                 the available storage in the thin pool.
                               minimum: 1
                               type: integer
                             sizePercent:
                               default: 90
-                              description: |-
-                                SizePercent specifies the percentage of space in the LVM volume group for creating the thin pool.
-                                If the size configuration is 100, the whole disk will be used.
-                                By default, 90% of the disk is used for the thin pool to allow for data or metadata expansion later on.
+                              description: SizePercent specifies the percentage of
+                                space in the LVM volume group for creating the thin
+                                pool. If the size configuration is 100, the whole
+                                disk will be used. By default, 90% of the disk is
+                                used for the thin pool to allow for data or metadata
+                                expansion later on.
                               maximum: 100
                               minimum: 10
                               type: integer
@@ -214,39 +216,40 @@ spec:
               tolerations:
                 description: Tolerations to apply to nodes to act on
                 items:
-                  description: |-
-                    The pod this Toleration is attached to tolerates any taint that matches
-                    the triple <key,value,effect> using the matching operator <operator>.
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
                   properties:
                     effect:
-                      description: |-
-                        Effect indicates the taint effect to match. Empty means match all taint effects.
-                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: |-
-                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
                       type: string
                     operator:
-                      description: |-
-                        Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod can
-                        tolerate all taints of a particular category.
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: |-
-                        TolerationSeconds represents the period of time the toleration (which must be
-                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                        it is not set, which means tolerate the taint forever (do not evict). Zero and
-                        negative values will be treated as 0 (evict immediately) by the system.
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: |-
-                        Value is the taint value the toleration matches to.
-                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
                       type: string
                   type: object
                 type: array
@@ -257,9 +260,8 @@ spec:
               conditions:
                 description: Conditions describes the state of the resource.
                 items:
-                  description: |-
-                    Condition represents the state of the operator's
-                    reconciliation functionality.
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
                   properties:
                     lastHeartbeatTime:
                       format: date-time

--- a/bundle/manifests/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
+++ b/bundle/manifests/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.17.3
   creationTimestamp: null
   name: lvmvolumegroupnodestatuses.lvm.topolvm.io
 spec:
@@ -21,14 +21,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -71,5 +76,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
+++ b/bundle/manifests/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: lvmvolumegroupnodestatuses.lvm.topolvm.io
 spec:
@@ -21,19 +21,14 @@ spec:
           API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object

--- a/bundle/manifests/lvm.topolvm.io_lvmvolumegroups.yaml
+++ b/bundle/manifests/lvm.topolvm.io_lvmvolumegroups.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.17.3
   creationTimestamp: null
   name: lvmvolumegroups.lvm.topolvm.io
 spec:
@@ -20,14 +20,19 @@ spec:
         description: LVMVolumeGroup is the Schema for the lvmvolumegroups API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -43,18 +48,18 @@ spec:
                   a device to be included in this TopoLVMCluster
                 properties:
                   optionalPaths:
-                    description: A list of device paths which could be chosen for
-                      creating Volume Group. For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
-                      We discourage using the device names as they can change over
-                      node restarts.
+                    description: |-
+                      A list of device paths which could be chosen for creating Volume Group.
+                      For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
+                      We discourage using the device names as they can change over node restarts.
                     items:
                       type: string
                     type: array
                   paths:
-                    description: A list of device paths which would be chosen for
-                      creating Volume Group. For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
-                      We discourage using the device names as they can change over
-                      node restarts.
+                    description: |-
+                      A list of device paths which would be chosen for creating Volume Group.
+                      For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
+                      We discourage using the device names as they can change over node restarts.
                     items:
                       type: string
                     type: array
@@ -66,35 +71,35 @@ spec:
                     description: Required. A list of node selector terms. The terms
                       are ORed.
                     items:
-                      description: A null or empty node selector term matches no objects.
-                        The requirements of them are ANDed. The TopologySelectorTerm
-                        type implements a subset of the NodeSelectorTerm.
+                      description: |-
+                        A null or empty node selector term matches no objects. The requirements of
+                        them are ANDed.
+                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                       properties:
                         matchExpressions:
                           description: A list of node selector requirements by node's
                             labels.
                           items:
-                            description: A node selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: |-
+                              A node selector requirement is a selector that contains values, a key, and an operator
+                              that relates the key and values.
                             properties:
                               key:
                                 description: The label key that the selector applies
                                   to.
                                 type: string
                               operator:
-                                description: Represents a key's relationship to a
-                                  set of values. Valid operators are In, NotIn, Exists,
-                                  DoesNotExist. Gt, and Lt.
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                 type: string
                               values:
-                                description: An array of string values. If the operator
-                                  is In or NotIn, the values array must be non-empty.
-                                  If the operator is Exists or DoesNotExist, the values
-                                  array must be empty. If the operator is Gt or Lt,
-                                  the values array must have a single element, which
-                                  will be interpreted as an integer. This array is
-                                  replaced during a strategic merge patch.
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -107,27 +112,26 @@ spec:
                           description: A list of node selector requirements by node's
                             fields.
                           items:
-                            description: A node selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: |-
+                              A node selector requirement is a selector that contains values, a key, and an operator
+                              that relates the key and values.
                             properties:
                               key:
                                 description: The label key that the selector applies
                                   to.
                                 type: string
                               operator:
-                                description: Represents a key's relationship to a
-                                  set of values. Valid operators are In, NotIn, Exists,
-                                  DoesNotExist. Gt, and Lt.
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                 type: string
                               values:
-                                description: An array of string values. If the operator
-                                  is In or NotIn, the values array must be non-empty.
-                                  If the operator is Exists or DoesNotExist, the values
-                                  array must be empty. If the operator is Gt or Lt,
-                                  the values array must have a single element, which
-                                  will be interpreted as an integer. This array is
-                                  replaced during a strategic merge patch.
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -137,10 +141,12 @@ spec:
                             type: object
                           type: array
                       type: object
+                      x-kubernetes-map-type: atomic
                     type: array
                 required:
                 - nodeSelectorTerms
                 type: object
+                x-kubernetes-map-type: atomic
               thinPoolConfig:
                 description: ThinPoolConfig contains configurations for the thin-pool
                 properties:
@@ -148,18 +154,17 @@ spec:
                     description: Name of the thin pool to be created
                     type: string
                   overprovisionRatio:
-                    description: OverProvisionRatio is the factor by which additional
-                      storage can be provisioned compared to the available storage
-                      in the thin pool.
+                    description: |-
+                      OverProvisionRatio is the factor by which additional storage can be provisioned compared to
+                      the available storage in the thin pool.
                     minimum: 1
                     type: integer
                   sizePercent:
                     default: 90
-                    description: SizePercent specifies the percentage of space in
-                      the LVM volume group for creating the thin pool. If the size
-                      configuration is 100, the whole disk will be used. By default,
-                      90% of the disk is used for the thin pool to allow for data
-                      or metadata expansion later on.
+                    description: |-
+                      SizePercent specifies the percentage of space in the LVM volume group for creating the thin pool.
+                      If the size configuration is 100, the whole disk will be used.
+                      By default, 90% of the disk is used for the thin pool to allow for data or metadata expansion later on.
                     maximum: 100
                     minimum: 10
                     type: integer
@@ -182,5 +187,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/lvm.topolvm.io_lvmvolumegroups.yaml
+++ b/bundle/manifests/lvm.topolvm.io_lvmvolumegroups.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: lvmvolumegroups.lvm.topolvm.io
 spec:
@@ -20,19 +20,14 @@ spec:
         description: LVMVolumeGroup is the Schema for the lvmvolumegroups API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -48,18 +43,18 @@ spec:
                   a device to be included in this TopoLVMCluster
                 properties:
                   optionalPaths:
-                    description: |-
-                      A list of device paths which could be chosen for creating Volume Group.
-                      For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
-                      We discourage using the device names as they can change over node restarts.
+                    description: A list of device paths which could be chosen for
+                      creating Volume Group. For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
+                      We discourage using the device names as they can change over
+                      node restarts.
                     items:
                       type: string
                     type: array
                   paths:
-                    description: |-
-                      A list of device paths which would be chosen for creating Volume Group.
-                      For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
-                      We discourage using the device names as they can change over node restarts.
+                    description: A list of device paths which would be chosen for
+                      creating Volume Group. For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
+                      We discourage using the device names as they can change over
+                      node restarts.
                     items:
                       type: string
                     type: array
@@ -71,35 +66,35 @@ spec:
                     description: Required. A list of node selector terms. The terms
                       are ORed.
                     items:
-                      description: |-
-                        A null or empty node selector term matches no objects. The requirements of
-                        them are ANDed.
-                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                      description: A null or empty node selector term matches no objects.
+                        The requirements of them are ANDed. The TopologySelectorTerm
+                        type implements a subset of the NodeSelectorTerm.
                       properties:
                         matchExpressions:
                           description: A list of node selector requirements by node's
                             labels.
                           items:
-                            description: |-
-                              A node selector requirement is a selector that contains values, a key, and an operator
-                              that relates the key and values.
+                            description: A node selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
                             properties:
                               key:
                                 description: The label key that the selector applies
                                   to.
                                 type: string
                               operator:
-                                description: |-
-                                  Represents a key's relationship to a set of values.
-                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                description: Represents a key's relationship to a
+                                  set of values. Valid operators are In, NotIn, Exists,
+                                  DoesNotExist. Gt, and Lt.
                                 type: string
                               values:
-                                description: |-
-                                  An array of string values. If the operator is In or NotIn,
-                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                  array must have a single element, which will be interpreted as an integer.
-                                  This array is replaced during a strategic merge patch.
+                                description: An array of string values. If the operator
+                                  is In or NotIn, the values array must be non-empty.
+                                  If the operator is Exists or DoesNotExist, the values
+                                  array must be empty. If the operator is Gt or Lt,
+                                  the values array must have a single element, which
+                                  will be interpreted as an integer. This array is
+                                  replaced during a strategic merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -112,26 +107,27 @@ spec:
                           description: A list of node selector requirements by node's
                             fields.
                           items:
-                            description: |-
-                              A node selector requirement is a selector that contains values, a key, and an operator
-                              that relates the key and values.
+                            description: A node selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
                             properties:
                               key:
                                 description: The label key that the selector applies
                                   to.
                                 type: string
                               operator:
-                                description: |-
-                                  Represents a key's relationship to a set of values.
-                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                description: Represents a key's relationship to a
+                                  set of values. Valid operators are In, NotIn, Exists,
+                                  DoesNotExist. Gt, and Lt.
                                 type: string
                               values:
-                                description: |-
-                                  An array of string values. If the operator is In or NotIn,
-                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                  array must have a single element, which will be interpreted as an integer.
-                                  This array is replaced during a strategic merge patch.
+                                description: An array of string values. If the operator
+                                  is In or NotIn, the values array must be non-empty.
+                                  If the operator is Exists or DoesNotExist, the values
+                                  array must be empty. If the operator is Gt or Lt,
+                                  the values array must have a single element, which
+                                  will be interpreted as an integer. This array is
+                                  replaced during a strategic merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -141,12 +137,10 @@ spec:
                             type: object
                           type: array
                       type: object
-                      x-kubernetes-map-type: atomic
                     type: array
                 required:
                 - nodeSelectorTerms
                 type: object
-                x-kubernetes-map-type: atomic
               thinPoolConfig:
                 description: ThinPoolConfig contains configurations for the thin-pool
                 properties:
@@ -154,17 +148,18 @@ spec:
                     description: Name of the thin pool to be created
                     type: string
                   overprovisionRatio:
-                    description: |-
-                      OverProvisionRatio is the factor by which additional storage can be provisioned compared to
-                      the available storage in the thin pool.
+                    description: OverProvisionRatio is the factor by which additional
+                      storage can be provisioned compared to the available storage
+                      in the thin pool.
                     minimum: 1
                     type: integer
                   sizePercent:
                     default: 90
-                    description: |-
-                      SizePercent specifies the percentage of space in the LVM volume group for creating the thin pool.
-                      If the size configuration is 100, the whole disk will be used.
-                      By default, 90% of the disk is used for the thin pool to allow for data or metadata expansion later on.
+                    description: SizePercent specifies the percentage of space in
+                      the LVM volume group for creating the thin pool. If the size
+                      configuration is 100, the whole disk will be used. By default,
+                      90% of the disk is used for the thin pool to allow for data
+                      or metadata expansion later on.
                     maximum: 100
                     minimum: 10
                     type: integer

--- a/bundle/manifests/lvms-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvms-operator.clusterserviceversion.yaml
@@ -123,6 +123,34 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - node
+          - nodes
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          - persistentvolumes
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - apps
           resources:
           - daemonsets
@@ -146,110 +174,10 @@ spec:
           - update
           - watch
         - apiGroups:
-          - ""
-          resources:
-          - events
-          verbs:
-          - create
-          - patch
-          - update
-        - apiGroups:
-          - ""
-          resources:
-          - node
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - nodes
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - persistentvolumeclaims
-          verbs:
-          - get
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - persistentvolumes
-          verbs:
-          - get
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
           - lvm.topolvm.io
           resources:
           - lvmclusters
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - lvm.topolvm.io
-          resources:
-          - lvmclusters/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - lvm.topolvm.io
-          resources:
-          - lvmclusters/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - lvm.topolvm.io
-          resources:
           - lvmvolumegroupnodestatuses
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - lvm.topolvm.io
-          resources:
-          - lvmvolumegroupnodestatuses/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - lvm.topolvm.io
-          resources:
-          - lvmvolumegroupnodestatuses/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
-          - lvm.topolvm.io
-          resources:
           - lvmvolumegroups
           verbs:
           - create
@@ -262,12 +190,16 @@ spec:
         - apiGroups:
           - lvm.topolvm.io
           resources:
+          - lvmclusters/finalizers
+          - lvmvolumegroupnodestatuses/finalizers
           - lvmvolumegroups/finalizers
           verbs:
           - update
         - apiGroups:
           - lvm.topolvm.io
           resources:
+          - lvmclusters/status
+          - lvmvolumegroupnodestatuses/status
           - lvmvolumegroups/status
           verbs:
           - get
@@ -301,17 +233,6 @@ spec:
           - storage.k8s.io
           resources:
           - csidrivers
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - storage.k8s.io
-          resources:
           - storageclasses
           verbs:
           - create

--- a/bundle/manifests/lvms-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/lvms-operator.clusterserviceversion.yaml
@@ -123,34 +123,6 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
-          - ""
-          resources:
-          - events
-          verbs:
-          - create
-          - patch
-          - update
-        - apiGroups:
-          - ""
-          resources:
-          - node
-          - nodes
-          - pods
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - persistentvolumeclaims
-          - persistentvolumes
-          verbs:
-          - get
-          - list
-          - update
-          - watch
-        - apiGroups:
           - apps
           resources:
           - daemonsets
@@ -174,11 +146,59 @@ spec:
           - update
           - watch
         - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - node
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - lvm.topolvm.io
           resources:
           - lvmclusters
-          - lvmvolumegroupnodestatuses
-          - lvmvolumegroups
           verbs:
           - create
           - delete
@@ -191,15 +211,63 @@ spec:
           - lvm.topolvm.io
           resources:
           - lvmclusters/finalizers
-          - lvmvolumegroupnodestatuses/finalizers
-          - lvmvolumegroups/finalizers
           verbs:
           - update
         - apiGroups:
           - lvm.topolvm.io
           resources:
           - lvmclusters/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - lvm.topolvm.io
+          resources:
+          - lvmvolumegroupnodestatuses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - lvm.topolvm.io
+          resources:
+          - lvmvolumegroupnodestatuses/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - lvm.topolvm.io
+          resources:
           - lvmvolumegroupnodestatuses/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - lvm.topolvm.io
+          resources:
+          - lvmvolumegroups
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - lvm.topolvm.io
+          resources:
+          - lvmvolumegroups/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - lvm.topolvm.io
+          resources:
           - lvmvolumegroups/status
           verbs:
           - get
@@ -233,6 +301,17 @@ spec:
           - storage.k8s.io
           resources:
           - csidrivers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - storage.k8s.io
+          resources:
           - storageclasses
           verbs:
           - create

--- a/config/crd/bases/lvm.topolvm.io_lvmclusters.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmclusters.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: lvmclusters.lvm.topolvm.io
 spec:
   group: lvm.topolvm.io
@@ -22,14 +20,19 @@ spec:
         description: LVMCluster is the Schema for the lvmclusters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -55,18 +58,18 @@ spec:
                             match for a device to be included in the LVMCluster
                           properties:
                             optionalPaths:
-                              description: A list of device paths which could be chosen
-                                for creating Volume Group. For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
-                                We discourage using the device names as they can change
-                                over node restarts.
+                              description: |-
+                                A list of device paths which could be chosen for creating Volume Group.
+                                For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
+                                We discourage using the device names as they can change over node restarts.
                               items:
                                 type: string
                               type: array
                             paths:
-                              description: A list of device paths which would be chosen
-                                for creating Volume Group. For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
-                                We discourage using the device names as they can change
-                                over node restarts.
+                              description: |-
+                                A list of device paths which would be chosen for creating Volume Group.
+                                For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
+                                We discourage using the device names as they can change over node restarts.
                               items:
                                 type: string
                               type: array
@@ -81,9 +84,10 @@ spec:
                           - ""
                           type: string
                         name:
-                          description: 'Name of the class, the VG and possibly the
-                            storageclass. Validations to confirm that this field can
-                            be used as metadata.name field in storageclass ref: https://github.com/kubernetes/apimachinery/blob/de7147/pkg/util/validation/validation.go#L209'
+                          description: |-
+                            Name of the class, the VG and possibly the storageclass.
+                            Validations to confirm that this field can be used as metadata.name field in storageclass
+                            ref: https://github.com/kubernetes/apimachinery/blob/de7147/pkg/util/validation/validation.go#L209
                           maxLength: 245
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -96,39 +100,35 @@ spec:
                               description: Required. A list of node selector terms.
                                 The terms are ORed.
                               items:
-                                description: A null or empty node selector term matches
-                                  no objects. The requirements of them are ANDed.
-                                  The TopologySelectorTerm type implements a subset
-                                  of the NodeSelectorTerm.
+                                description: |-
+                                  A null or empty node selector term matches no objects. The requirements of
+                                  them are ANDed.
+                                  The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                 properties:
                                   matchExpressions:
                                     description: A list of node selector requirements
                                       by node's labels.
                                     items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -141,30 +141,26 @@ spec:
                                     description: A list of node selector requirements
                                       by node's fields.
                                     items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -174,10 +170,12 @@ spec:
                                       type: object
                                     type: array
                                 type: object
+                                x-kubernetes-map-type: atomic
                               type: array
                           required:
                           - nodeSelectorTerms
                           type: object
+                          x-kubernetes-map-type: atomic
                         thinPoolConfig:
                           description: ThinPoolConfig contains configurations for
                             the thin-pool
@@ -186,19 +184,17 @@ spec:
                               description: Name of the thin pool to be created
                               type: string
                             overprovisionRatio:
-                              description: OverProvisionRatio is the factor by which
-                                additional storage can be provisioned compared to
+                              description: |-
+                                OverProvisionRatio is the factor by which additional storage can be provisioned compared to
                                 the available storage in the thin pool.
                               minimum: 1
                               type: integer
                             sizePercent:
                               default: 90
-                              description: SizePercent specifies the percentage of
-                                space in the LVM volume group for creating the thin
-                                pool. If the size configuration is 100, the whole
-                                disk will be used. By default, 90% of the disk is
-                                used for the thin pool to allow for data or metadata
-                                expansion later on.
+                              description: |-
+                                SizePercent specifies the percentage of space in the LVM volume group for creating the thin pool.
+                                If the size configuration is 100, the whole disk will be used.
+                                By default, 90% of the disk is used for the thin pool to allow for data or metadata expansion later on.
                               maximum: 100
                               minimum: 10
                               type: integer
@@ -214,40 +210,39 @@ spec:
               tolerations:
                 description: Tolerations to apply to nodes to act on
                 items:
-                  description: The pod this Toleration is attached to tolerates any
-                    taint that matches the triple <key,value,effect> using the matching
-                    operator <operator>.
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
                   properties:
                     effect:
-                      description: Effect indicates the taint effect to match. Empty
-                        means match all taint effects. When specified, allowed values
-                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: Key is the taint key that the toleration applies
-                        to. Empty means match all taint keys. If the key is empty,
-                        operator must be Exists; this combination means to match all
-                        values and all keys.
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                       type: string
                     operator:
-                      description: Operator represents a key's relationship to the
-                        value. Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod
-                        can tolerate all taints of a particular category.
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: TolerationSeconds represents the period of time
-                        the toleration (which must be of effect NoExecute, otherwise
-                        this field is ignored) tolerates the taint. By default, it
-                        is not set, which means tolerate the taint forever (do not
-                        evict). Zero and negative values will be treated as 0 (evict
-                        immediately) by the system.
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: Value is the taint value the toleration matches
-                        to. If the operator is Exists, the value should be empty,
-                        otherwise just a regular string.
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
                       type: string
                   type: object
                 type: array
@@ -258,8 +253,9 @@ spec:
               conditions:
                 description: Conditions describes the state of the resource.
                 items:
-                  description: Condition represents the state of the operator's reconciliation
-                    functionality.
+                  description: |-
+                    Condition represents the state of the operator's
+                    reconciliation functionality.
                   properties:
                     lastHeartbeatTime:
                       format: date-time
@@ -330,9 +326,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/lvm.topolvm.io_lvmclusters.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmclusters.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
   name: lvmclusters.lvm.topolvm.io
 spec:
   group: lvm.topolvm.io
@@ -20,19 +21,14 @@ spec:
         description: LVMCluster is the Schema for the lvmclusters API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -58,18 +54,18 @@ spec:
                             match for a device to be included in the LVMCluster
                           properties:
                             optionalPaths:
-                              description: |-
-                                A list of device paths which could be chosen for creating Volume Group.
-                                For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
-                                We discourage using the device names as they can change over node restarts.
+                              description: A list of device paths which could be chosen
+                                for creating Volume Group. For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
+                                We discourage using the device names as they can change
+                                over node restarts.
                               items:
                                 type: string
                               type: array
                             paths:
-                              description: |-
-                                A list of device paths which would be chosen for creating Volume Group.
-                                For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
-                                We discourage using the device names as they can change over node restarts.
+                              description: A list of device paths which would be chosen
+                                for creating Volume Group. For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
+                                We discourage using the device names as they can change
+                                over node restarts.
                               items:
                                 type: string
                               type: array
@@ -84,10 +80,9 @@ spec:
                           - ""
                           type: string
                         name:
-                          description: |-
-                            Name of the class, the VG and possibly the storageclass.
-                            Validations to confirm that this field can be used as metadata.name field in storageclass
-                            ref: https://github.com/kubernetes/apimachinery/blob/de7147/pkg/util/validation/validation.go#L209
+                          description: 'Name of the class, the VG and possibly the
+                            storageclass. Validations to confirm that this field can
+                            be used as metadata.name field in storageclass ref: https://github.com/kubernetes/apimachinery/blob/de7147/pkg/util/validation/validation.go#L209'
                           maxLength: 245
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -100,35 +95,39 @@ spec:
                               description: Required. A list of node selector terms.
                                 The terms are ORed.
                               items:
-                                description: |-
-                                  A null or empty node selector term matches no objects. The requirements of
-                                  them are ANDed.
-                                  The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                description: A null or empty node selector term matches
+                                  no objects. The requirements of them are ANDed.
+                                  The TopologySelectorTerm type implements a subset
+                                  of the NodeSelectorTerm.
                                 properties:
                                   matchExpressions:
                                     description: A list of node selector requirements
                                       by node's labels.
                                     items:
-                                      description: |-
-                                        A node selector requirement is a selector that contains values, a key, and an operator
-                                        that relates the key and values.
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: |-
-                                            Represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
                                           type: string
                                         values:
-                                          description: |-
-                                            An array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. If the operator is Gt or Lt, the values
-                                            array must have a single element, which will be interpreted as an integer.
-                                            This array is replaced during a strategic merge patch.
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -141,26 +140,30 @@ spec:
                                     description: A list of node selector requirements
                                       by node's fields.
                                     items:
-                                      description: |-
-                                        A node selector requirement is a selector that contains values, a key, and an operator
-                                        that relates the key and values.
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: |-
-                                            Represents a key's relationship to a set of values.
-                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
                                           type: string
                                         values:
-                                          description: |-
-                                            An array of string values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                            the values array must be empty. If the operator is Gt or Lt, the values
-                                            array must have a single element, which will be interpreted as an integer.
-                                            This array is replaced during a strategic merge patch.
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -170,12 +173,10 @@ spec:
                                       type: object
                                     type: array
                                 type: object
-                                x-kubernetes-map-type: atomic
                               type: array
                           required:
                           - nodeSelectorTerms
                           type: object
-                          x-kubernetes-map-type: atomic
                         thinPoolConfig:
                           description: ThinPoolConfig contains configurations for
                             the thin-pool
@@ -184,17 +185,19 @@ spec:
                               description: Name of the thin pool to be created
                               type: string
                             overprovisionRatio:
-                              description: |-
-                                OverProvisionRatio is the factor by which additional storage can be provisioned compared to
+                              description: OverProvisionRatio is the factor by which
+                                additional storage can be provisioned compared to
                                 the available storage in the thin pool.
                               minimum: 1
                               type: integer
                             sizePercent:
                               default: 90
-                              description: |-
-                                SizePercent specifies the percentage of space in the LVM volume group for creating the thin pool.
-                                If the size configuration is 100, the whole disk will be used.
-                                By default, 90% of the disk is used for the thin pool to allow for data or metadata expansion later on.
+                              description: SizePercent specifies the percentage of
+                                space in the LVM volume group for creating the thin
+                                pool. If the size configuration is 100, the whole
+                                disk will be used. By default, 90% of the disk is
+                                used for the thin pool to allow for data or metadata
+                                expansion later on.
                               maximum: 100
                               minimum: 10
                               type: integer
@@ -210,39 +213,40 @@ spec:
               tolerations:
                 description: Tolerations to apply to nodes to act on
                 items:
-                  description: |-
-                    The pod this Toleration is attached to tolerates any taint that matches
-                    the triple <key,value,effect> using the matching operator <operator>.
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
                   properties:
                     effect:
-                      description: |-
-                        Effect indicates the taint effect to match. Empty means match all taint effects.
-                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: |-
-                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
                       type: string
                     operator:
-                      description: |-
-                        Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod can
-                        tolerate all taints of a particular category.
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: |-
-                        TolerationSeconds represents the period of time the toleration (which must be
-                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                        it is not set, which means tolerate the taint forever (do not evict). Zero and
-                        negative values will be treated as 0 (evict immediately) by the system.
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: |-
-                        Value is the taint value the toleration matches to.
-                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
                       type: string
                   type: object
                 type: array
@@ -253,9 +257,8 @@ spec:
               conditions:
                 description: Conditions describes the state of the resource.
                 items:
-                  description: |-
-                    Condition represents the state of the operator's
-                    reconciliation functionality.
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
                   properties:
                     lastHeartbeatTime:
                       format: date-time

--- a/config/crd/bases/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: lvmvolumegroupnodestatuses.lvm.topolvm.io
 spec:
   group: lvm.topolvm.io
@@ -23,14 +21,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -69,9 +72,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmvolumegroupnodestatuses.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
   name: lvmvolumegroupnodestatuses.lvm.topolvm.io
 spec:
   group: lvm.topolvm.io
@@ -21,19 +22,14 @@ spec:
           API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object

--- a/config/crd/bases/lvm.topolvm.io_lvmvolumegroups.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmvolumegroups.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: lvmvolumegroups.lvm.topolvm.io
 spec:
   group: lvm.topolvm.io
@@ -22,14 +20,19 @@ spec:
         description: LVMVolumeGroup is the Schema for the lvmvolumegroups API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -45,18 +48,18 @@ spec:
                   a device to be included in this TopoLVMCluster
                 properties:
                   optionalPaths:
-                    description: A list of device paths which could be chosen for
-                      creating Volume Group. For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
-                      We discourage using the device names as they can change over
-                      node restarts.
+                    description: |-
+                      A list of device paths which could be chosen for creating Volume Group.
+                      For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
+                      We discourage using the device names as they can change over node restarts.
                     items:
                       type: string
                     type: array
                   paths:
-                    description: A list of device paths which would be chosen for
-                      creating Volume Group. For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
-                      We discourage using the device names as they can change over
-                      node restarts.
+                    description: |-
+                      A list of device paths which would be chosen for creating Volume Group.
+                      For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
+                      We discourage using the device names as they can change over node restarts.
                     items:
                       type: string
                     type: array
@@ -68,35 +71,35 @@ spec:
                     description: Required. A list of node selector terms. The terms
                       are ORed.
                     items:
-                      description: A null or empty node selector term matches no objects.
-                        The requirements of them are ANDed. The TopologySelectorTerm
-                        type implements a subset of the NodeSelectorTerm.
+                      description: |-
+                        A null or empty node selector term matches no objects. The requirements of
+                        them are ANDed.
+                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                       properties:
                         matchExpressions:
                           description: A list of node selector requirements by node's
                             labels.
                           items:
-                            description: A node selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: |-
+                              A node selector requirement is a selector that contains values, a key, and an operator
+                              that relates the key and values.
                             properties:
                               key:
                                 description: The label key that the selector applies
                                   to.
                                 type: string
                               operator:
-                                description: Represents a key's relationship to a
-                                  set of values. Valid operators are In, NotIn, Exists,
-                                  DoesNotExist. Gt, and Lt.
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                 type: string
                               values:
-                                description: An array of string values. If the operator
-                                  is In or NotIn, the values array must be non-empty.
-                                  If the operator is Exists or DoesNotExist, the values
-                                  array must be empty. If the operator is Gt or Lt,
-                                  the values array must have a single element, which
-                                  will be interpreted as an integer. This array is
-                                  replaced during a strategic merge patch.
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -109,27 +112,26 @@ spec:
                           description: A list of node selector requirements by node's
                             fields.
                           items:
-                            description: A node selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: |-
+                              A node selector requirement is a selector that contains values, a key, and an operator
+                              that relates the key and values.
                             properties:
                               key:
                                 description: The label key that the selector applies
                                   to.
                                 type: string
                               operator:
-                                description: Represents a key's relationship to a
-                                  set of values. Valid operators are In, NotIn, Exists,
-                                  DoesNotExist. Gt, and Lt.
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                 type: string
                               values:
-                                description: An array of string values. If the operator
-                                  is In or NotIn, the values array must be non-empty.
-                                  If the operator is Exists or DoesNotExist, the values
-                                  array must be empty. If the operator is Gt or Lt,
-                                  the values array must have a single element, which
-                                  will be interpreted as an integer. This array is
-                                  replaced during a strategic merge patch.
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -139,10 +141,12 @@ spec:
                             type: object
                           type: array
                       type: object
+                      x-kubernetes-map-type: atomic
                     type: array
                 required:
                 - nodeSelectorTerms
                 type: object
+                x-kubernetes-map-type: atomic
               thinPoolConfig:
                 description: ThinPoolConfig contains configurations for the thin-pool
                 properties:
@@ -150,18 +154,17 @@ spec:
                     description: Name of the thin pool to be created
                     type: string
                   overprovisionRatio:
-                    description: OverProvisionRatio is the factor by which additional
-                      storage can be provisioned compared to the available storage
-                      in the thin pool.
+                    description: |-
+                      OverProvisionRatio is the factor by which additional storage can be provisioned compared to
+                      the available storage in the thin pool.
                     minimum: 1
                     type: integer
                   sizePercent:
                     default: 90
-                    description: SizePercent specifies the percentage of space in
-                      the LVM volume group for creating the thin pool. If the size
-                      configuration is 100, the whole disk will be used. By default,
-                      90% of the disk is used for the thin pool to allow for data
-                      or metadata expansion later on.
+                    description: |-
+                      SizePercent specifies the percentage of space in the LVM volume group for creating the thin pool.
+                      If the size configuration is 100, the whole disk will be used.
+                      By default, 90% of the disk is used for the thin pool to allow for data or metadata expansion later on.
                     maximum: 100
                     minimum: 10
                     type: integer
@@ -180,9 +183,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/lvm.topolvm.io_lvmvolumegroups.yaml
+++ b/config/crd/bases/lvm.topolvm.io_lvmvolumegroups.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
   name: lvmvolumegroups.lvm.topolvm.io
 spec:
   group: lvm.topolvm.io
@@ -20,19 +21,14 @@ spec:
         description: LVMVolumeGroup is the Schema for the lvmvolumegroups API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -48,18 +44,18 @@ spec:
                   a device to be included in this TopoLVMCluster
                 properties:
                   optionalPaths:
-                    description: |-
-                      A list of device paths which could be chosen for creating Volume Group.
-                      For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
-                      We discourage using the device names as they can change over node restarts.
+                    description: A list of device paths which could be chosen for
+                      creating Volume Group. For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
+                      We discourage using the device names as they can change over
+                      node restarts.
                     items:
                       type: string
                     type: array
                   paths:
-                    description: |-
-                      A list of device paths which would be chosen for creating Volume Group.
-                      For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
-                      We discourage using the device names as they can change over node restarts.
+                    description: A list of device paths which would be chosen for
+                      creating Volume Group. For example "/dev/disk/by-path/pci-0000:04:00.0-nvme-1"
+                      We discourage using the device names as they can change over
+                      node restarts.
                     items:
                       type: string
                     type: array
@@ -71,35 +67,35 @@ spec:
                     description: Required. A list of node selector terms. The terms
                       are ORed.
                     items:
-                      description: |-
-                        A null or empty node selector term matches no objects. The requirements of
-                        them are ANDed.
-                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                      description: A null or empty node selector term matches no objects.
+                        The requirements of them are ANDed. The TopologySelectorTerm
+                        type implements a subset of the NodeSelectorTerm.
                       properties:
                         matchExpressions:
                           description: A list of node selector requirements by node's
                             labels.
                           items:
-                            description: |-
-                              A node selector requirement is a selector that contains values, a key, and an operator
-                              that relates the key and values.
+                            description: A node selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
                             properties:
                               key:
                                 description: The label key that the selector applies
                                   to.
                                 type: string
                               operator:
-                                description: |-
-                                  Represents a key's relationship to a set of values.
-                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                description: Represents a key's relationship to a
+                                  set of values. Valid operators are In, NotIn, Exists,
+                                  DoesNotExist. Gt, and Lt.
                                 type: string
                               values:
-                                description: |-
-                                  An array of string values. If the operator is In or NotIn,
-                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                  array must have a single element, which will be interpreted as an integer.
-                                  This array is replaced during a strategic merge patch.
+                                description: An array of string values. If the operator
+                                  is In or NotIn, the values array must be non-empty.
+                                  If the operator is Exists or DoesNotExist, the values
+                                  array must be empty. If the operator is Gt or Lt,
+                                  the values array must have a single element, which
+                                  will be interpreted as an integer. This array is
+                                  replaced during a strategic merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -112,26 +108,27 @@ spec:
                           description: A list of node selector requirements by node's
                             fields.
                           items:
-                            description: |-
-                              A node selector requirement is a selector that contains values, a key, and an operator
-                              that relates the key and values.
+                            description: A node selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
                             properties:
                               key:
                                 description: The label key that the selector applies
                                   to.
                                 type: string
                               operator:
-                                description: |-
-                                  Represents a key's relationship to a set of values.
-                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                description: Represents a key's relationship to a
+                                  set of values. Valid operators are In, NotIn, Exists,
+                                  DoesNotExist. Gt, and Lt.
                                 type: string
                               values:
-                                description: |-
-                                  An array of string values. If the operator is In or NotIn,
-                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                  the values array must be empty. If the operator is Gt or Lt, the values
-                                  array must have a single element, which will be interpreted as an integer.
-                                  This array is replaced during a strategic merge patch.
+                                description: An array of string values. If the operator
+                                  is In or NotIn, the values array must be non-empty.
+                                  If the operator is Exists or DoesNotExist, the values
+                                  array must be empty. If the operator is Gt or Lt,
+                                  the values array must have a single element, which
+                                  will be interpreted as an integer. This array is
+                                  replaced during a strategic merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -141,12 +138,10 @@ spec:
                             type: object
                           type: array
                       type: object
-                      x-kubernetes-map-type: atomic
                     type: array
                 required:
                 - nodeSelectorTerms
                 type: object
-                x-kubernetes-map-type: atomic
               thinPoolConfig:
                 description: ThinPoolConfig contains configurations for the thin-pool
                 properties:
@@ -154,17 +149,18 @@ spec:
                     description: Name of the thin pool to be created
                     type: string
                   overprovisionRatio:
-                    description: |-
-                      OverProvisionRatio is the factor by which additional storage can be provisioned compared to
-                      the available storage in the thin pool.
+                    description: OverProvisionRatio is the factor by which additional
+                      storage can be provisioned compared to the available storage
+                      in the thin pool.
                     minimum: 1
                     type: integer
                   sizePercent:
                     default: 90
-                    description: |-
-                      SizePercent specifies the percentage of space in the LVM volume group for creating the thin pool.
-                      If the size configuration is 100, the whole disk will be used.
-                      By default, 90% of the disk is used for the thin pool to allow for data or metadata expansion later on.
+                    description: SizePercent specifies the percentage of space in
+                      the LVM volume group for creating the thin pool. If the size
+                      configuration is 100, the whole disk will be used. By default,
+                      90% of the disk is used for the thin pool to allow for data
+                      or metadata expansion later on.
                     maximum: 100
                     minimum: 10
                     type: integer

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -50,6 +50,6 @@ resources:
 - ../prometheus
 - ../webhook
 images:
-- digest: sha256:6a9e10a4aad59f7e01dac0407641e9cb5cd5b8ed21f62ea4b2271f8aede4cbec
+- digest: sha256:6ba961c2c2a29750c0132fe6dd6fa9f6001010afbc5f19b98add87b31b54bcf6
   name: rbac-proxy
   newName: registry.redhat.io/openshift4/ose-kube-rbac-proxy

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,11 +1,37 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - node
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -30,110 +56,10 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - node
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumeclaims
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumes
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - lvm.topolvm.io
   resources:
   - lvmclusters
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - lvm.topolvm.io
-  resources:
-  - lvmclusters/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - lvm.topolvm.io
-  resources:
-  - lvmclusters/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - lvm.topolvm.io
-  resources:
   - lvmvolumegroupnodestatuses
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - lvm.topolvm.io
-  resources:
-  - lvmvolumegroupnodestatuses/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - lvm.topolvm.io
-  resources:
-  - lvmvolumegroupnodestatuses/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - lvm.topolvm.io
-  resources:
   - lvmvolumegroups
   verbs:
   - create
@@ -146,12 +72,16 @@ rules:
 - apiGroups:
   - lvm.topolvm.io
   resources:
+  - lvmclusters/finalizers
+  - lvmvolumegroupnodestatuses/finalizers
   - lvmvolumegroups/finalizers
   verbs:
   - update
 - apiGroups:
   - lvm.topolvm.io
   resources:
+  - lvmclusters/status
+  - lvmvolumegroupnodestatuses/status
   - lvmvolumegroups/status
   verbs:
   - get
@@ -185,17 +115,6 @@ rules:
   - storage.k8s.io
   resources:
   - csidrivers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - storage.k8s.io
-  resources:
   - storageclasses
   verbs:
   - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,36 +2,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   name: manager-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - node
-  - nodes
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumeclaims
-  - persistentvolumes
-  verbs:
-  - get
-  - list
-  - update
-  - watch
 - apiGroups:
   - apps
   resources:
@@ -56,11 +29,59 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - node
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - lvm.topolvm.io
   resources:
   - lvmclusters
-  - lvmvolumegroupnodestatuses
-  - lvmvolumegroups
   verbs:
   - create
   - delete
@@ -73,15 +94,63 @@ rules:
   - lvm.topolvm.io
   resources:
   - lvmclusters/finalizers
-  - lvmvolumegroupnodestatuses/finalizers
-  - lvmvolumegroups/finalizers
   verbs:
   - update
 - apiGroups:
   - lvm.topolvm.io
   resources:
   - lvmclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lvm.topolvm.io
+  resources:
+  - lvmvolumegroupnodestatuses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lvm.topolvm.io
+  resources:
+  - lvmvolumegroupnodestatuses/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lvm.topolvm.io
+  resources:
   - lvmvolumegroupnodestatuses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - lvm.topolvm.io
+  resources:
+  - lvmvolumegroups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lvm.topolvm.io
+  resources:
+  - lvmvolumegroups/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - lvm.topolvm.io
+  resources:
   - lvmvolumegroups/status
   verbs:
   - get
@@ -115,6 +184,17 @@ rules:
   - storage.k8s.io
   resources:
   - csidrivers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
   - storageclasses
   verbs:
   - create

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -2,6 +2,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,9 +1,7 @@
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:


### PR DESCRIPTION
Update controller-gen from v0.7.0 to v0.17.3 and regenerate CRDs, RBAC roles, webhook manifests, and the CSV. This consolidates duplicate RBAC rules, reformats CRD descriptions to block scalar style, removes stale creationTimestamp fields, and bumps the kube-rbac-proxy image digest.