### PR TITLE
fix: handle missing LVMVolumeGroupNodeStatus gracefully in vg-manager

### DIFF
--- a/internal/controllers/vgmanager/controller.go
+++ b/internal/controllers/vgmanager/controller.go
@@ -139,6 +139,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	nodeStatus := r.getLVMVolumeGroupNodeStatus()
 	if err := r.Get(ctx, client.ObjectKeyFromObject(nodeStatus), nodeStatus); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("LVMVolumeGroupNodeStatus not yet created by LVMCluster controller, requeueing")
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
 		return ctrl.Result{}, fmt.Errorf("could not get LVMVolumeGroupNodeStatus: %w", err)
 	}
 

--- a/internal/controllers/vgmanager/controller_test.go
+++ b/internal/controllers/vgmanager/controller_test.go
@@ -801,26 +801,19 @@ func testNodeSelector(ctx context.Context) {
 	Expect(err).ToNot(HaveOccurred(), "should not error on invalid node selector, but filter out")
 	Expect(res).To(Equal(reconcile.Result{}))
 
-	By("then verifying incorrect node resolution because nodestatus cannot be created")
-	funcs := interceptor.Funcs{Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
-		if obj.GetName() == "test-node" {
-			return fmt.Errorf("mock creation failure for LVMVolumeGroupNodeStatus")
-		}
-		return client.Create(ctx, obj, opts...)
-	}}
+	By("then verifying requeue when LVMVolumeGroupNodeStatus does not exist yet")
 	fakeClient = fake.NewClientBuilder().WithScheme(scheme.Scheme).
 		WithObjects(matchingNode, notMatchingNode, volumeGroup, invalidVolumeGroup).
-		WithInterceptorFuncs(funcs).
 		Build()
 	r = &Reconciler{
-		Client:   fakeClient,
-		Scheme:   scheme.Scheme,
-		NodeName: "test-node",
+		Client:    fakeClient,
+		Scheme:    scheme.Scheme,
+		NodeName:  "test-node",
+		Namespace: volumeGroup.GetNamespace(),
 	}
-	By("verifying incorrect node resolution because nodestatus cannot be created")
 	res, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(volumeGroup)})
-	Expect(err).To(HaveOccurred(), "should error on valid node selector due to failure of nodestatus creation")
-	Expect(res).To(Equal(reconcile.Result{}))
+	Expect(err).ToNot(HaveOccurred(), "should not error when LVMVolumeGroupNodeStatus is not found, but requeue")
+	Expect(res).To(Equal(reconcile.Result{RequeueAfter: 10 * time.Second}))
 
 	fakeClient = fake.NewClientBuilder().WithScheme(scheme.Scheme).
 		WithObjects(matchingNode, notMatchingNode, volumeGroup, invalidVolumeGroup).
@@ -834,8 +827,8 @@ func testNodeSelector(ctx context.Context) {
 	Expect(err).To(HaveOccurred(), "should error during node match resolution")
 	Expect(res).To(Equal(reconcile.Result{}))
 
-	By("then verifying incorrect node resolution because nodestatus cannot be created")
-	funcs = interceptor.Funcs{Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	By("then verifying error when LVMVolumeGroupNodeStatus get fails with non-NotFound error")
+	funcs := interceptor.Funcs{Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 		if key.Name == matchingNode.Name {
 			if nodeStatus, ok := obj.(*lvmv1alpha1.LVMVolumeGroupNodeStatus); ok {
 				return fmt.Errorf("mock get failure for LVMVolumeGroupNodeStatus %s", nodeStatus.GetName())
@@ -848,9 +841,10 @@ func testNodeSelector(ctx context.Context) {
 		WithInterceptorFuncs(funcs).
 		Build()
 	r = &Reconciler{
-		Client:   fakeClient,
-		Scheme:   scheme.Scheme,
-		NodeName: "test-node",
+		Client:    fakeClient,
+		Scheme:    scheme.Scheme,
+		NodeName:  "test-node",
+		Namespace: volumeGroup.GetNamespace(),
 	}
 	By("verifying incorrect node resolution because nodestatus cannot be fetched from cluster")
 	res, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(volumeGroup)})


### PR DESCRIPTION
The vg-manager reconciler errors hard when the LVMVolumeGroupNodeStatus for its node does not yet exist, causing a permanent stuck state on some nodes during bootstrap. This happens because the LVMCluster controller creates NodeStatus resources in parallel with other resources, and the vg-manager can start reconciling before its NodeStatus is created.

Handle the NotFound case by requeueing after 10 seconds instead of returning a hard error, giving the LVMCluster controller time to create the resource.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When a required node status is not yet present, operations now log this and automatically retry after 10 seconds instead of treating it as an error.
  * Improved handling of other status retrieval failures so they surface as errors; tests updated to reflect the new retry behavior and to separate “missing status” and “retrieval failure” cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->