### PR TITLE
NO-JIRA: Add 5.0 tekton manifests for main branch

### DIFF
--- a/.tekton/lvm-operator-5-0-pull-request.yaml
+++ b/.tekton/lvm-operator-5-0-pull-request.yaml
@@ -1,0 +1,51 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/lvm-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/lvm-operator-5-0-pull-request.yaml".pathChanged()
+      || ".tekton/lvm-operator-5-0-push.yaml".pathChanged() || "release/operator/***".pathChanged()
+      || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
+      || "cmd/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
+      || "api/***".pathChanged() || "release/container-build.args".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: lvm-operator-5-0
+    appstudio.openshift.io/component: lvm-operator-5-0
+    pipelines.appstudio.openshift.io/type: build
+  name: lvm-operator-5-0-on-pull-request
+  namespace: logical-volume-manag-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/logical-volume-manag-tenant/lvm-operator:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: release/operator/konflux.Dockerfile
+  - name: prefetch-input
+    value: '[{"type": "rpm", "path": "release/operator"},{"type": "gomod", "path": "."}]'
+  - name: build-args-file
+    value: release/container-build.args
+  - name: skip-additional-tags
+    value: "true"
+  pipelineRef:
+    name: multi-arch-build-pipeline
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-lvm-operator-5-0
+  timeouts:
+    pipeline: 1h30m0s
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/lvm-operator-5-0-push.yaml
+++ b/.tekton/lvm-operator-5-0-push.yaml
@@ -1,0 +1,46 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/lvm-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/lvm-operator-5-0-pull-request.yaml".pathChanged()
+      || ".tekton/lvm-operator-5-0-push.yaml".pathChanged() || "release/operator/***".pathChanged()
+      || "go.mod".pathChanged() || "go.sum".pathChanged() || "Makefile".pathChanged()
+      || "cmd/***".pathChanged() || "internal/***".pathChanged() || "test/***".pathChanged()
+      || "api/***".pathChanged() || "release/container-build.args".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: lvm-operator-5-0
+    appstudio.openshift.io/component: lvm-operator-5-0
+    pipelines.appstudio.openshift.io/type: build
+  name: lvm-operator-5-0-on-push
+  namespace: logical-volume-manag-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/logical-volume-manag-tenant/lvm-operator:{{revision}}
+  - name: dockerfile
+    value: release/operator/konflux.Dockerfile
+  - name: prefetch-input
+    value: '[{"type": "rpm", "path": "release/operator"},{"type": "gomod", "path": "."}]'
+  - name: build-args-file
+    value: release/container-build.args
+  pipelineRef:
+    name: multi-arch-build-pipeline
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-lvm-operator-5-0
+  timeouts:
+    pipeline: 1h30m0s
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/lvm-operator-bundle-5-0-pull-request.yaml
+++ b/.tekton/lvm-operator-bundle-5-0-pull-request.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/lvm-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/lvm-operator-bundle-5-0-pull-request.yaml".pathChanged()
+      || ".tekton/lvm-operator-bundle-5-0-push.yaml".pathChanged() || "release/bundle/***".pathChanged()
+      || "bundle/***".pathChanged() || "release/hack/render_templates.sh".pathChanged() || "release/container-build.args".pathChanged()
+      || ".tekton/images-mirror-set.yaml".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: lvm-operator-5-0
+    appstudio.openshift.io/component: lvm-operator-bundle-5-0
+    pipelines.appstudio.openshift.io/type: build
+  name: lvm-operator-bundle-5-0-on-pull-request
+  namespace: logical-volume-manag-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/logical-volume-manag-tenant/lvm-operator-bundle:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: release/bundle/bundle.konflux.Dockerfile
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}]'
+  - name: skip-preflight
+    value: "true"
+  - name: build-args-file
+    value: release/container-build.args
+  - name: skip-additional-tags
+    value: "true"
+  pipelineRef:
+    name: single-arch-build-pipeline
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-lvm-operator-bundle-5-0
+  timeouts:
+    pipeline: 1h30m0s
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/lvm-operator-bundle-5-0-push.yaml
+++ b/.tekton/lvm-operator-bundle-5-0-push.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/lvm-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && (".tekton/single-arch-build-pipeline.yaml".pathChanged() || ".tekton/lvm-operator-bundle-5-0-pull-request.yaml".pathChanged()
+      || ".tekton/lvm-operator-bundle-5-0-push.yaml".pathChanged() || "release/bundle/***".pathChanged()
+      || "bundle/***".pathChanged() || "release/hack/render_templates.sh".pathChanged() || "release/container-build.args".pathChanged()
+      || ".tekton/images-mirror-set.yaml".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: lvm-operator-5-0
+    appstudio.openshift.io/component: lvm-operator-bundle-5-0
+    pipelines.appstudio.openshift.io/type: build
+  name: lvm-operator-bundle-5-0-on-push
+  namespace: logical-volume-manag-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/logical-volume-manag-tenant/lvm-operator-bundle:{{revision}}
+  - name: dockerfile
+    value: release/bundle/bundle.konflux.Dockerfile
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}]'
+  - name: skip-preflight
+    value: "true"
+  - name: build-args-file
+    value: release/container-build.args
+  pipelineRef:
+    name: single-arch-build-pipeline
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-lvm-operator-bundle-5-0
+  timeouts:
+    pipeline: 1h30m0s
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/lvm-operator-catalog-5-0-pull-request.yaml
+++ b/.tekton/lvm-operator-catalog-5-0-pull-request.yaml
@@ -1,0 +1,70 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/lvm-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" &&
+      (".tekton/lvm-operator-catalog-5-0-pull-request.yaml".pathChanged() ||
+      ".tekton/lvm-operator-catalog-5-0-push.yaml".pathChanged() ||
+      ".tekton/images-mirror-set.yaml".pathChanged() ||
+      "release/catalog/**".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: lvm-operator-catalog-5-0
+    appstudio.openshift.io/component: lvm-operator-catalog-5-0
+    pipelines.appstudio.openshift.io/type: build
+  name: lvm-operator-catalog-5-0-on-pull-request
+  namespace: logical-volume-manag-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/logical-volume-manag-tenant/lvm-operator-catalog:v5.0-on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: release/catalog/catalog.konflux.Dockerfile
+  - name: build-args
+    value:
+    - CATALOG_VERSION=v5.0
+  - name: hermetic
+    value: "true"
+  - name: skip-additional-tags
+    value: "true"
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
+  - name: opm_args
+    value:
+    - alpha
+    - render-template
+    - semver
+    - "--migrate-level=bundle-object-to-csv-metadata"
+    - release/catalog/lvm-operator-catalog-template.yaml
+  - name: catalog-output-path
+    value: "release/catalog/lvm-operator-catalog.json"
+  - name: catalog-template-merge-script
+    value: "./release/hack/prepare-catalog.sh"
+  - name: catalog-patch-script
+    value: "./release/hack/render-catalog.sh"
+  - name: catalog-patch-image
+    value: quay.io/konflux-ci/yq@sha256:41aee71bcaa8a759073e00d6acea358fbc4013ad6e28554729451606c0c35591
+  pipelineRef:
+    name: catalog-patching-build-pipeline
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-lvm-operator-catalog-5-0
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/lvm-operator-catalog-5-0-push.yaml
+++ b/.tekton/lvm-operator-catalog-5-0-push.yaml
@@ -1,0 +1,65 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/lvm-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      (".tekton/lvm-operator-catalog-5-0-pull-request.yaml".pathChanged() ||
+      ".tekton/lvm-operator-catalog-5-0-push.yaml".pathChanged() ||
+      ".tekton/images-mirror-set.yaml".pathChanged() ||
+      "release/catalog/**".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: lvm-operator-catalog-5-0
+    appstudio.openshift.io/component: lvm-operator-catalog-5-0
+    pipelines.appstudio.openshift.io/type: build
+  name: lvm-operator-catalog-5-0-on-push
+  namespace: logical-volume-manag-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/logical-volume-manag-tenant/lvm-operator-catalog:v5.0-{{revision}}
+  - name: dockerfile
+    value: release/catalog/catalog.konflux.Dockerfile
+  - name: build-args
+    value:
+    - CATALOG_VERSION=v5.0
+  - name: hermetic
+    value: "true"
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
+  - name: opm_args
+    value:
+    - alpha
+    - render-template
+    - semver
+    - "--migrate-level=bundle-object-to-csv-metadata"
+    - release/catalog/lvm-operator-catalog-template.yaml
+  - name: catalog-output-path
+    value: "release/catalog/lvm-operator-catalog.json"
+  - name: catalog-template-merge-script
+    value: "./release/hack/prepare-catalog.sh"
+  - name: catalog-patch-script
+    value: "./release/hack/render-catalog.sh"
+  - name: catalog-patch-image
+    value: quay.io/konflux-ci/yq@sha256:41aee71bcaa8a759073e00d6acea358fbc4013ad6e28554729451606c0c35591
+  pipelineRef:
+    name: catalog-patching-build-pipeline
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-lvm-operator-catalog-5-0
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/lvms-must-gather-5-0-pull-request.yaml
+++ b/.tekton/lvms-must-gather-5-0-pull-request.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/lvm-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/lvms-must-gather-5-0-pull-request.yaml".pathChanged()
+      || ".tekton/lvms-must-gather-5-0-push.yaml".pathChanged() || "must-gather/***".pathChanged()
+      || "release/must-gather/***".pathChanged() || "release/container-build.args".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: lvm-operator-5-0
+    appstudio.openshift.io/component: lvms-must-gather-5-0
+    pipelines.appstudio.openshift.io/type: build
+  name: lvms-must-gather-5-0-on-pull-request
+  namespace: logical-volume-manag-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/logical-volume-manag-tenant/lvms-must-gather:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: dockerfile
+    value: release/must-gather/must-gather.konflux.Dockerfile
+  - name: build-args-file
+    value: release/container-build.args
+  - name: skip-additional-tags
+    value: "true"
+  pipelineRef:
+    name: multi-arch-build-pipeline
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-lvms-must-gather-5-0
+  timeouts:
+    pipeline: 1h30m0s
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/lvms-must-gather-5-0-push.yaml
+++ b/.tekton/lvms-must-gather-5-0-push.yaml
@@ -1,0 +1,42 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/lvm-operator?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && (".tekton/multi-arch-build-pipeline.yaml".pathChanged() || ".tekton/lvms-must-gather-5-0-pull-request.yaml".pathChanged()
+      || ".tekton/lvms-must-gather-5-0-push.yaml".pathChanged() || "must-gather/***".pathChanged()
+      || "release/must-gather/***".pathChanged() || "release/container-build.args".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: lvm-operator-5-0
+    appstudio.openshift.io/component: lvms-must-gather-5-0
+    pipelines.appstudio.openshift.io/type: build
+  name: lvms-must-gather-5-0-on-push
+  namespace: logical-volume-manag-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/logical-volume-manag-tenant/lvms-must-gather:{{revision}}
+  - name: dockerfile
+    value: release/must-gather/must-gather.konflux.Dockerfile
+  - name: build-args-file
+    value: release/container-build.args
+  pipelineRef:
+    name: multi-arch-build-pipeline
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-lvms-must-gather-5-0
+  timeouts:
+    pipeline: 1h30m0s
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline configurations to support automated builds and deployments triggered on both pull requests and push events for the LVM operator components, including the operator itself, bundle, catalog patching, and must-gather utilities. These configurations enable consistent and reliable build processes across multiple platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->