### PR TITLE
NO-JIRA: Use local lvm-operator as dependency for integration tests

### DIFF
--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -1,24 +1,18 @@
-FROM golang:1.21 AS builder
+FROM golang:1.23 AS builder
 
-# Set working directory inside the builder container
-WORKDIR /workspace
+WORKDIR /go/src/github.com/openshift/lvm-operator
+COPY . .
 
-# Copy the integration test source code and go.mod
-COPY test/integration/ ./
+WORKDIR /go/src/github.com/openshift/lvm-operator/test/integration
 
-# Download all dependencies and verify
 RUN go mod download
 
-# Build the binary
-RUN GO_COMPLIANCE_POLICY="exempt_all" CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o integration-test .
+RUN GO_COMPLIANCE_POLICY="exempt_all" CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /tmp/integration-test .
 
-# ---- Stage 2: Runtime container ----
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 WORKDIR /
 
-# Copy the built binary from the builder stage
-COPY --from=builder /workspace/integration-test .
+COPY --from=builder /tmp/integration-test .
 
-# Run the binary
 ENTRYPOINT ["./integration-test"]

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -81,4 +81,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12
+replace (
+	github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12
+	github.com/openshift/lvm-operator => ../../
+)

--- a/test/integration/go.sum
+++ b/test/integration/go.sum
@@ -89,8 +89,6 @@ github.com/openshift/api v0.0.0-20240423014330-2cb60a113ad1 h1:qo6vX1xwLILWL69tC
 github.com/openshift/api v0.0.0-20240423014330-2cb60a113ad1/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/openshift/library-go v0.0.0-20240422143640-fad649cbbd63 h1:Cv1pmE4m2MJrytpTOk0HHJfaw7gvBOwAj8FJeGuffCg=
 github.com/openshift/library-go v0.0.0-20240422143640-fad649cbbd63/go.mod h1:m/HsttSi90vSixwoy5mPUBHcZid2YRw/QbsLErLxF9s=
-github.com/openshift/lvm-operator v0.0.0-20260605034543-7302e3d5d527 h1:44BEYOh9ybh4pzEr6TcSeqJohLdArbGC+DIzN0TB0E4=
-github.com/openshift/lvm-operator v0.0.0-20260605034543-7302e3d5d527/go.mod h1:jRjYpHwmD8GHDkHYkG+emOlzKkxzwaGeLVSFShylyrY=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12 h1:AKx/w1qpS8We43bsRgf8Nll3CGlDHpr/WAXvuedTNZI=
 github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
## Summary
- Add `replace` directive in `test/integration/go.mod` to use local operator code (`../../`) instead of a published version
- Ensures integration tests always use the same branch's operator code

## Test plan
- [ ] CI passes (verify, unit-test, images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)