### PR TITLE
NO-JIRA: Fix integration test Dockerfile for replace directive

### DIFF
--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -1,24 +1,19 @@
 FROM golang:1.23 AS builder
 
-# Set working directory inside the builder container
-WORKDIR /workspace
+WORKDIR /go/src/github.com/openshift/lvm-operator
+COPY . .
 
-# Copy the integration test source code and go.mod
-COPY test/integration/ ./
+WORKDIR /go/src/github.com/openshift/lvm-operator/test/integration
 
-# Download all dependencies and verify
 RUN go mod download
 
-# Build the binary
-RUN GO_COMPLIANCE_POLICY="exempt_all" CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o integration-test .
+RUN GO_COMPLIANCE_POLICY="exempt_all" CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /tmp/integration-test .
 
-# ---- Stage 2: Runtime container ----
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 WORKDIR /
 
-# Copy the built binary from the builder stage
-COPY --from=builder /workspace/integration-test .
+COPY --from=builder /tmp/integration-test .
 
-# Run the binary
 ENTRYPOINT ["./integration-test"]
+

--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -16,4 +16,3 @@ WORKDIR /
 COPY --from=builder /tmp/integration-test .
 
 ENTRYPOINT ["./integration-test"]
-


### PR DESCRIPTION
## Summary
- Copy full repo instead of just `test/integration/` so the `go.mod` replace directive (`github.com/openshift/lvm-operator/v4 => ../../`) resolves correctly during Docker build
- Keeps Go 1.23 (already correct for this branch)

## Test plan
- [ ] CI passes (images, precommit-check, unit-test)
- [ ] Nightly job Docker build succeeds