### PR TITLE
NO-ISSUE: Narrow controller-gen paths in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,13 +135,13 @@ export CATALOG_PACKAGE
 ##@ Development
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="{./cmd/...,./api/...,./internal/...}" output:crd:artifacts:config=config/crd/bases
 
 mocks: mockery ## Generate mocks for unit test code
 	$(shell $(MOCKERY) --log-level error)
 
 generate: controller-gen mocks ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations. Also retriggers mock generation
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="{./cmd/...,./api/...,./internal/...}"
 
 fmt: ## Run go fmt against code.
 	go fmt ./...


### PR DESCRIPTION
This PR removes the need to cache packages defined under test/integration when building in Konflux, which may lead to cachi2 issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined build configuration to optimize code generation targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->