### PR TITLE
NO-JIRA: Fix flake in OCP-88798 testcase

### DIFF
--- a/test/integration/qe_tests/lvms.go
+++ b/test/integration/qe_tests/lvms.go
@@ -5247,7 +5247,10 @@ spec:
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		defer func() {
-			pvName := getPVCVolumeName(testNamespace, pvcName)
+			// Get PV name before deleting PVC (only if PVC still exists)
+			cmd := exec.Command("oc", "get", "pvc", pvcName, "-n", testNamespace, "-o=jsonpath={.spec.volumeName}", "--ignore-not-found")
+			output, _ := cmd.CombinedOutput()
+			pvName := strings.TrimSpace(string(output))
 			deleteSpecifiedResource("pvc", pvcName, testNamespace)
 			if pvName != "" {
 				cleanupLogicalVolumeByName(pvName)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test cleanup reliability for StorageClassOptions scenario to safely handle cases where PVC has already been deleted, preventing cleanup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->