### PR TITLE
OCPEDGE-2765: capture LVMS implicit knowledge — core beliefs, conventions, and ADRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,9 @@ This is the LVM Operator, part of LVMS (Logical Volume Manager Storage) for Open
 
 | Document | Purpose |
 |----------|---------|
+| [docs/core-beliefs.md](docs/core-beliefs.md) | Non-negotiable design principles — read this first |
+| [docs/conventions/](docs/conventions/) | Implementation conventions enforced in review (split by area) |
+| [docs/decisions/](docs/decisions/index.md) | Architectural Decision Records (ADRs) — why the codebase looks the way it does |
 | [docs/architecture.md](docs/architecture.md) | Design rationale, component diagram, reconciliation lifecycle, CRD relationships, finalizer hierarchy |
 | [docs/design/lvm-operator-manager.md](docs/design/lvm-operator-manager.md) | LVM Operator Manager internals |
 | [docs/design/vg-manager.md](docs/design/vg-manager.md) | Volume Group Manager design |
@@ -55,7 +58,7 @@ Paths []string `json:"paths,omitempty"`
 
 ## Safety Considerations
 
-This operator manages physical storage and performs destructive LVM operations. Keep these in mind:
+This operator manages physical storage and performs destructive LVM operations. See [docs/core-beliefs.md](docs/core-beliefs.md) for non-negotiable invariants and [docs/conventions/](docs/conventions/) for implementation patterns.
 
 - **Data loss risk**: LVM operations can wipe disks. Verify device selectors carefully in tests.
 - **Idempotency**: controllers must handle partial states and retries safely. VG Manager reconciles every 30 seconds.
@@ -76,7 +79,7 @@ var _ = Describe("LVMCluster Controller", func() {
 })
 ```
 
-E2E tests are in `test/e2e/` and require a live cluster with available block devices. See [CONTRIBUTING.md](CONTRIBUTING.md) for build, deploy, and test commands.
+E2E tests are in `test/e2e/` and require a live cluster with available block devices. See [CONTRIBUTING.md](CONTRIBUTING.md) for build, deploy, and test commands. See [docs/conventions/testing.md](docs/conventions/testing.md) for testing conventions.
 
 ## Key Directories
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,10 @@ Ideally the system should run for long periods of time in advance and then have 
 The test report will be generated in the working directory of the performance tests and will be a `.toml` file with broken down metrics on Pod and Container level.
 We include 90/95/99 Quantiles for Memory and CPU as our main metrics. Other metrics are not included in the tool and have to be manually fetched via prometheus.
 
+## Code Conventions
+
+See [docs/conventions/](docs/conventions/) for the full set of implementation conventions enforced in review, covering code style, reconciliation patterns, testing, device management, and build/CI.
+
 ## Commits Per Pull Request
 
 Pull requests should always represent a complete logical change. Where possible, pull requests should be composed of multiple commits that each make small but meaningful changes. Striking a balance between minimal commits and logically complete changes is an art as much as a science, but when it is possible and reasonable, divide your pull request into more commits.

--- a/docs/conventions/api-and-validation.md
+++ b/docs/conventions/api-and-validation.md
@@ -1,0 +1,46 @@
+# API Design and Validation Conventions
+
+For design principles, see [core-beliefs.md](../core-beliefs.md). For architecture, see [architecture.md](../architecture.md). These conventions were extracted from PR review threads and may not all reflect current practice — verify against current code when in doubt.
+
+## API Design
+
+- Use "DeviceClass" in user-facing API types, "VG" in internal code. DeviceClass names must follow DNS-1123 label format since they flow into StorageClass names. (#76, #45, #47)
+- Use pointer types (`*ThinPoolConfig`) for optional structs — enables nil-checking. Required fields cannot have `omitempty`. (#143)
+- API field defaults belong in kubebuilder markers on the type, not in controller logic. (#728)
+- New optional fields: `nil` means "upgraded from before this field existed" — runtime must default to backward-compatible behavior. (#2038)
+- Status values should be typed constants (enums), not bare strings. (#72)
+- `LVMVolumeGroup.Status.Node` represents intent — includes nodes where VG creation was attempted but failed, not just successes. (#71)
+- Use upstream `meta/v1.Condition` and `meta.SetStatusCondition`/`meta.FindStatusCondition` helpers. Initialize conditions at creation, then modify — don't recompute from scratch every reconcile. Status condition messages are capitalized sentences. (#628)
+- LVMCluster Ready status must only be set when all expected VGs are reconciled. Hierarchy: Failed > Degraded > Ready. (#262)
+- Do not add labels that assume a single-instance CR — could break in multi-CR scenario. (#34)
+- Auto-generated StorageClass names are intentional for 1-click install. StorageClass name changes are breaking — K8s requires delete-and-recreate. (#101, #114)
+- One thin pool per device class. Thin-pools have a 1:1 relationship with VGs. Multiple TopoLVM instances can coexist but lvmd instances race on locks. (#143, #432)
+- Device paths: any `/dev/` prefix is accepted by the webhook. Official docs recommend stable naming (`/dev/disk/by-path/` or `/dev/disk/by-id/`) over symbolic names (`/dev/sdX`) which may change across reboots. Status reports resolved PV names from LVM, not user-specified paths. Device path overlap validation must consider nodeSelector. (#229)
+- Nil DeviceSelector (dynamic discovery) is single-deviceClass only; multi-deviceClass requires explicit DeviceSelector. (#615)
+- Rejected designs are documented in the repo for historical reference (v2 API proposal: #432).
+- Feature annotations in CSV must be version-accurate per release branch. (#602)
+- Resource manager name constants are distinct from Kubernetes resource names — renaming a resource doesn't require changing the manager's identifier. (#114)
+- Consolidate redundant namespace env vars when functionally identical. (#56)
+- User-visible default changes (e.g., making LVMS StorageClass the default) need documentation. (#210)
+
+## Validation
+
+- Safety-critical constraints must be validated at multiple layers (webhook + controller runtime) — see [core-beliefs.md](../core-beliefs.md). For non-safety validation (field format, optional defaults), avoid duplicating between webhook and controller. Webhook validation functions should not be exported unless the controller needs them. (#229, #2549)
+- ThinPool SizePercent: `default=90, min=10, max=100`. Required fields cannot have `omitempty`. (#131)
+- Validation functions should only validate — never perform mutations or side effects. (#728)
+- Move non-safety validation checks (field format, optional defaults, duplicate-path detection) into admission webhooks, not the reconcile loop. Safety-critical constraints must remain in both — see line above. (#426)
+- Cannot delete the default device class or the last device class. (#1657)
+- Missing capacity annotations should be skipped (continue), not treated as errors. Use per-device-class capacity annotation (`capacity.topolvm.io/<deviceClass>`). (#385)
+- Objects in webhook handlers are guaranteed non-nil by the API server — no nil-check needed. (#2339)
+- Default DeviceClass validation must handle three distinct cases: zero, one, and multiple defaults. A single DeviceClass is implicitly default. (#307)
+- Webhook update validation can block users from correcting wrong device paths — manual workaround required (scale down operator, edit CR). (#255)
+- Use kubebuilder CRD validation markers from the start when introducing new config structures. (#131)
+- Don't check `errors.IsAlreadyExists` after `CreateOrUpdate` calls — the error is never returned. (#139)
+
+## Gotchas
+
+- **CEL XValidation nil-to-non-nil bypass**: transition rules (`oldSelf == self`) are silently skipped when `oldSelf` does not exist. Fix: add `+kubebuilder:default={}` on optional struct fields with immutable sub-fields, plus a webhook guard for upgrades. (#2494)
+- **Managed field merge order**: when merging user-provided parameters/labels with operator-managed ones, copy user values first, then overwrite with operator-managed keys. Naive `maps.Copy()` lets users override LVMS-owned keys. (#2066)
+- **Never list all PVCs/PVs cluster-wide**: use `client.MatchingFields{"spec.storageClassName": scName}` with field indexers. Unfiltered listing hangs in large clusters. (#2066)
+- **Multi-node readiness bug** (historical, fixed): `expectedVGCount` double-counting caused LVMCluster to stay "Progressing" when all nodes were Ready. The readiness logic was rewritten to use `validateDeviceClassSetup` which iterates per-device-class per-valid-node. (#383)
+- **Reducing overprovisionRatio below already-consumed capacity**: unclear upstream TopoLVM behavior — may not be properly enforced. (#708)

--- a/docs/conventions/code-style.md
+++ b/docs/conventions/code-style.md
@@ -1,0 +1,26 @@
+# Code Style and Observability Conventions
+
+These conventions were extracted from PR review threads and may not all reflect current practice — verify against current code when in doubt.
+
+## Code Style
+
+- Error log messages should start with `"failed to..."` (not consistently enforced — some use "could not" or context-prefix patterns). Errors should be wrapped with `fmt.Errorf("context: %w", err)` where possible (32 bare `return err` exist in production code). Use `errors.New()` for static error strings. (#12, #2494, #386)
+- Go filenames are lowercase; use underscores for multi-word names (e.g., `wipe_devices.go`, `lv_attr.go`). Directory names use hyphens (`persistent-volume`, not `persistent_volume` or `pv`) to avoid LVM physical volume ambiguity. (#49, #356)
+- Import ordering: Go stdlib → GitHub → k8s, blank lines between groups. controller-runtime zap logger only — no logrus. (#690, #49)
+- Prefer small named functions over inlining. Functions without receiver state should be package-level, not methods. Prefer early-return over nesting. No function-local type definitions. Prefer stdlib `slices.Contains` over hand-rolled helpers. (#133, #643, #1380, #1823)
+- Error as last return value. Function comments must end with a period (godot linter). Exported fields required when tests live in a separate `_test` package. (#130, #369)
+- Check `internal/controllers/constants/constants.go` and `api/v1alpha1/` before defining new constants. Reuse CSI driver name constants across StorageClass and VolumeSnapshotClass. (#2066, #183)
+- Typed event-reason constants should not repeat the type name as prefix. (#403)
+- Avoid package-level variables — prefer function receivers or passed contexts. (#229)
+- Webhook error messages should not be prefixed with `"Error:"` — the framework already conveys it. (#349)
+- Copyright header: "Copyright © 20XX Red Hat, Inc." (uses the Unicode © symbol, not `(c)`). CRD YAML must exactly match upstream TopoLVM definitions and begin with `---`. (#248, #224)
+- V(2) log level was broken with `--zap-log-level=debug` as of PR #631 — V(1) was used for debug logs instead. This may have been fixed in newer controller-runtime versions. (#631, #1150)
+
+## Observability
+
+- Static YAML for alert rules over jsonnet/mixin. All alerts include VG name (device_class label) and node name. RAID alerts: one per deviceClass, not per PVC. (#103, #2337)
+- Metrics through kube-rbac-proxy over TLS, not separate HTTP endpoints. `diagnostics-address` naming aligns with cluster-api convention. (#425, #431)
+- Avoid redundant error logging at call site AND execution site. Include resource identifiers (name, SCC name, pod name) in log messages. Detailed logging: no duplicate fields, uniform capitalization. (#137)
+- Must-gather: direct LVM commands (`lvs`, not `lvm lvs` — bare `lvm` opens interactive shell). `-a` flag for thin pool metadata. `oc debug` with script files and `-q` flag. VolumeSnapshots in PVC namespace, not operator namespace. Discover install namespace from CSV. Upload actual must-gather output for reviewer verification. (#142, #145, #1843)
+- Event messages must include actionable diagnostics — per-node free storage, safe units. (#356)
+- Namespace changes require upgrade testing validation before merge. Consider VolumeGroup status on deletion failure — failure status should reflect whether the requested operation succeeded. (#955, #1380)

--- a/docs/conventions/reconciliation.md
+++ b/docs/conventions/reconciliation.md
@@ -1,0 +1,50 @@
+# Reconciliation and Device Management Conventions
+
+For design principles, see [core-beliefs.md](../core-beliefs.md). For architecture, see [architecture.md](../architecture.md). These conventions were extracted from PR review threads and may not all reflect current practice — verify against current code when in doubt.
+
+## Reconciliation Patterns
+
+- Construct the desired resource state in the constructor, then use the MutateFn to set mutable fields that need updating on both create and update paths (e.g., container specs, labels). The constructor defines the initial shape; the MutateFn ensures mutable fields stay current. (#26, #34)
+- For immutable resources (CSIDriver), the MutateFn body is `return nil`. (#18)
+- `SetControllerReference` placement is inconsistent in the codebase — some resources set it inside the mutate function, others outside. The convention from PR #402 was to set it inside for consistency, but not all resource managers follow this. (#402)
+- Cluster-scoped resources (CSIDriver, VolumeSnapshotClass, SCC, StorageClass) use labels for ownership since OwnerReferences don't work cross-namespace. LVMVolumeGroupNodeStatus has dual ownership: LVMCluster as controller owner (for deletion propagation) and LVMVolumeGroup as non-controller owner (to prevent multi-VG conflicts). (#405, #631)
+- Rely on Kubernetes optimistic concurrency (`resourceVersion` conflicts) for concurrent status updates from multiple VG Manager pods. (#72)
+- Don't use `errgroup` — it cancels context on first error. Use raw goroutines with a results channel and `errors.Join`. (#391)
+- After wiping devices, return early. Let the next reconcile re-list — immediate re-listing returns stale data. (#778)
+- Both controllers currently requeue periodically on success (LVMCluster at 1min, VGManager at 30s). This was debated in PR #898 — qJkee objected to unconditional requeue but it remains as a safety net for missed watch events. (#898)
+- Don't fail-fast on multi-node operations. Continue for healthy nodes, aggregate errors. Defer error checks past loops when early failure would penalize healthy nodes. (#898)
+- Platform detection (OpenShift vs K8s) runs once at startup by checking the Infrastructure API (`internal/cluster/type.go`). MicroShift is detected via the `microshift-version` ConfigMap if Infrastructure API is unavailable. `IsNotFound`/`IsNoMatchError` are non-fatal; other detection errors are fatal at startup. (#38, #399)
+- RBAC must include `watch`+`list` verbs even when not explicitly watching — controller-runtime informer cache requires them. (#45)
+- Check for existing LogicalVolumes before deleting VG. Query the host directly, not lvmd config (which may be stale from a failed file write). (#146)
+- VolumeSnapshotClass RBAC belongs as kubebuilder annotations on the controller file. Never bundle the VolumeSnapshotClass CRD — it's part of the K8s cluster. (#183)
+- Default StorageClass logic must check all existing SCs (including non-LVMS). Only set default if no other default exists. (#210)
+- StorageClass and other subordinate resources are created concurrently via goroutines. If any resource (e.g., VG Manager DaemonSet) isn't ready, the error is aggregated with `errors.Join` and triggers a retry on the next reconcile cycle. (#38, #391)
+- Always recompute state from conditions, not only on failure. Add Unknown state as default for in-progress. (#628)
+- `Delete` only sets `DeletionTimestamp` — finalizers gate actual deletion. Non-blocking delete + finalizer removal is the correct teardown pattern; `--wait=true` would deadlock. (#1657, #2271)
+- ConfigMap data assignment (`cm.Data = map[string]string{...}`) overwrites all existing data — no extra clearing needed. (#480)
+- Use conditions (not plain status fields) for communicating CR validity. Always set status for both success and failure. (#229)
+- Filter out VGs not created by the operator when iterating existing VGs. (#229)
+- LVM command errors propagate naturally — no post-creation PV count validation needed in RAID scenarios. (#2549)
+- Device-event reconciliation is poll-based — re-read CRs on event, don't mutate CRs to trigger reconcile. (#72)
+- VG existence check must not require non-empty PV list — a VG is valid even with zero physical volumes. (#448)
+- LVMVolumeGroupNodeStatus has LVMCluster as its controller owner for proper deletion propagation (see also line above for dual ownership). (#631)
+- Status logic must handle the MicroShift zero-deviceClass edge case (valid, not Failed). (#636)
+- The `found` boolean toggle must always be set to prevent duplicate status entries. (#110)
+- Resource deletion should be idempotent and guard against future concurrent deletion. (#617)
+- Orphaned LVMVolumeGroupNodeStatus cleanup uses a dedicated controller with finalizer. (#372)
+
+## Device Management
+
+- Don't create PVs with `pvcreate`. Pass raw devices to `vgcreate`/`vgextend` — LVM handles PV initialization. Devices already in the VG must be filtered out before `vgextend`. (#73)
+- List all VGs and filter in Go — don't interpret LVM exit codes. `vgs` returns exit code 5 for non-existent VGs, which is fragile to parse. (#73)
+- Use lsblk `TYPE` field ('loop') instead of Major number to identify loop devices. Each K8s loop device always backs exactly one file. Use `lsblk --json` and match Go struct field names to JSON keys. (#113, #27)
+- VG ownership during reconciliation is determined by the `@lvms` LVM tag (`lvm.go:53`, used by `ListVGs(taggedByLVMS=true)`). Force-wipe eligibility is a separate check: `ForceWipeDevicesAndDestroyAllData` in DeviceSelector must be true, and a per-node annotation (`constants.DevicesWipedAnnotationPrefix`) prevents re-wiping. (#423)
+- Device deletion is per-device (not batch) for clear error messages. `pvmove` is the user's responsibility — LVMS does not auto-migrate data. (#1380)
+- lvmd uses file-based config (`/etc/topolvm/lvmd.yaml`) on the host filesystem. A ConfigMap approach was tried (PR #480) but reverted (PR #566) because a single ConfigMap can't represent per-node configuration differences. (#14, #480, #566)
+- Use `--force` flag on `dmsetup remove` for previously unremovable device-mapper references. (#778)
+- TopoLVM removed the Containerized flag because nsenter is a no-op outside containers. (#634)
+- `vgreduce --removemissing` is best-effort recovery, not officially supported. (#692)
+- Device filtering must compare symlink-resolved paths, not raw kname, to handle symlinked block devices. (#571)
+- Loop devices in use by Kubernetes must be skipped during VG creation/extension. `losetup` is already available via util-linux. (#113)
+- Device filters were noted as design debt in PR #147 — composable per-type filters were suggested for future dynamic configuration but may not have been pursued. (#147)
+- lsblk output format changes between RHEL versions (string vs boolean for `rota`/`ro`). Bool zero-values are acceptable defaults since lsblk always provides a value. (#361)

--- a/docs/conventions/safety.md
+++ b/docs/conventions/safety.md
@@ -1,0 +1,23 @@
+# Safety and Security Conventions
+
+For design principles, see [core-beliefs.md](../core-beliefs.md). These conventions were extracted from PR review threads and may not all reflect current practice — verify against current code when in doubt.
+
+- Separate service accounts per workload with minimal RBAC. VG Manager RBAC files are prefixed with `vg_manager_`; operator RBAC files use generic names. (#14, #21)
+- SCC permissions should have comments explaining why they are required (convention from PR #35, not currently followed in code). HostPID is needed because lvmd uses nsenter. Topolvm node requires OpenShift `privileged` SCC — custom SCCs derived from PSPs are insufficient. (#35, #14)
+- SCCs were historically preferred as static definitions; operator-managed SCCs were an OCP/OLM workaround. This may have changed with newer OLM versions. (#101)
+- Socket/config file paths must use shared constants from the controllers package — a mismatch between vgmanager and topolvm-node caused a real bug. (#27)
+- Always handle errors from LVM host commands. Never silently swallow with `if err == nil` guards and no else-branch. All LVM commands accessing lvmdevices must run AsHost. (#79, #459)
+- Always nil-check annotation/label maps before key access on Kubernetes objects. (#683)
+- Structs with pointer fields cannot be deep-copied by simple dereference — use generated DeepCopy methods. (#708)
+- Commands writing to both stdout and stderr must use `CombinedOutput`. `wipefs`/`dmsetup` can issue stderr after stdout closes, causing race conditions. (#687)
+- VGManager must not report healthy until CSI driver registration is confirmed in kubelet. (#642)
+- Changing `spec.selector` on Deployments/DaemonSets is an immutable field change that breaks upgrades. Add labels to pod templates only. (#148)
+- Personal registry references must never be committed to kustomization.yaml or manager.env. (#293)
+- Verify dependency upgrades with local deployment — certain logr + controller-runtime version combinations break. (#136)
+- DevicePath type wraps string — symlink resolution must happen at-most-once per reconcile. (#690)
+- No bind mount filter exists in the current filter chain. Bind mounts are documented as unsupported in known-limitations.md. (#533)
+- VG tagging uses `--addtag` as part of the `vgcreate` command (atomic with VG creation). `AddTagToVG` for existing VGs returns a hard error on failure. (#447)
+- Feature APIs must wait for release branch cut before landing on main. (#2339)
+- Stale string literals survive refactoring when forking upstream projects — audit during fork operations. (#8)
+- Namespace changes require upgrade testing validation before merge. Use `/hold` to gate. (#955)
+- Resource leak on command output failure: if `io.ReadAll` fails, the stderr pipe remains open. Pipe-based execution requires careful close ordering. (#778)

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -1,0 +1,31 @@
+# Testing and Build Conventions
+
+These conventions were extracted from PR review threads and may not all reflect current practice — verify against current code when in doubt.
+
+## Testing
+
+- Test descriptions describe reconciliation outcomes, not CRUD ("reconcile succeeds on creation", not "create LVMCluster"). Test names form readable sentences from Describe+It. Strip author tags. (#17, #1870, #2271)
+- E2E: `Eventually().WithContext(ctx).Should(Succeed())` instead of manual polling. `By()` for readable steps. Current timeouts are 4min/1s (`test/e2e/validation_test.go`). Validate in reconciliation order: LVMCluster → CSI Driver → CSINodeInfo → VG Manager → LVMVolumeGroup → StorageClass → VolumeSnapshotClass. DaemonSet readiness checks compare `DesiredNumberScheduled` vs `NumberReady` accounting for `maxUnavailable`. (#378, #149)
+- Integration tests use `oc` CLI, not Go API client, to mirror user patterns. `echo $(command)` is intentional in test utilities — collapses multi-line jq output for `strings.Fields()`. (#2383, #2294)
+- `Consistently` for negative assertions (e.g., PVC stays Pending), not `Eventually` or single check after sleep. Assert on specific rejection reasons, not just that creation failed. (#2383, #2410)
+- Tests must clean up. After deleting a retained PV, clean up the underlying LogicalVolume CR. Explicit cleanup steps in test body AND defers — defers handle early failure, explicit steps verify restored state. `deleteLVMClusterSafely` (which strips finalizers) is intentionally used in integration test defers as a safety net when LVMCluster gets stuck — this is the established pattern from openshift-test-private. For non-defer test steps, prefer `deleteSpecifiedResource` which uses the normal operator cleanup path. Stripping finalizers is never acceptable in controller/production code. (#130, #2383, #2416, #2260)
+- Fakeclient was preferred over envtest for vgmanager tests as of PR #426. Inject the resolution function alone, not full resolver objects. go:embed YAML templates, not per-instance files. Reuse test fixtures. All system command execution through an Executor interface. (#426, #690, #237, #252, #59)
+- E2E pod images: busybox (not nginx/ubuntu). Test namespaces: `privileged` PSA enforcement. VolumeSnapshotClass CRD is a cluster prerequisite — unit tests need a disable flag. (#401, #278, #183)
+- Unit tests require Linux (LVM commands, loop devices). Non-blocking delete + finalizer removal is the correct teardown pattern; `--wait=true` deadlocks. (#2262, #2346, #2271)
+- envtest has no garbage collection — verify ownerReferences instead of testing cascade deletion. SCC creation IS testable in envtest (confirmed in `controller_integration_test.go`). (#17, #18, #26)
+- Cross-PR review consolidation: team reviews related PRs together and centralizes shared patterns. CI override (`/override`) accepted for known-flaky pipelines on critical bugfixes. Performance tests require coordinated openshift/release config changes. (#2410, #369, #445)
+
+## Build System and CI
+
+- Split code changes and regenerated manifests into separate commits. Keep PRs focused. After `api/v1alpha1/` changes: `make generate && make manifests && make bundle` and commit the diff. Bundle manifest changes must be audited line-by-line for unintended drift. (#18, #187, #2494, #283)
+- All commits signed (`-s`) + precommit hooks, regardless of change size. Document upstream dependency changes that cause code removals, with links. (#1843, #727)
+- Runtime pod introspection (`getRunningPodImage`) over env vars for container image. Cache the image string in the reconciler struct. (#52, #94)
+- Pin operator-sdk version in Makefile. Download checks if binary exists first. (#230)
+- Generated files (kustomization.yaml namespace) should be committed, not .gitignored. (#167)
+- CI should fail fast on auth — move login before expensive build steps. (#290)
+- Pin base image versions in Dockerfiles for external images. Exception: bundle manifests use `:latest` tags as placeholders — the render-templates script substitutes actual versions at build time. Current base images: main Dockerfile uses `fedora:latest`, must-gather uses `origin-cli`. (#533, #19, #305, #1341)
+- Makefile has cross-platform `sed` handling (separate macOS/Linux paths). Docker builds use buildx platform args. (#392, #442)
+- When bumping k8s dependencies, update all CSI sidecars simultaneously. Go version in `go.mod` must match the development stream. (#1898, #1123)
+- Build targets must declare tool dependencies for clean environments. (#144)
+- Verify PRs trigger correct Konflux/CI jobs for the target version. (#2038)
+- Release-branch files should reference main branch canonical sources, not duplicate content. (#1823)

--- a/docs/core-beliefs.md
+++ b/docs/core-beliefs.md
@@ -1,0 +1,42 @@
+# LVMS Core Beliefs
+
+Key design principles that guide LVMS development. For architecture and component design, see [architecture.md](architecture.md). For implementation conventions, see [conventions/](conventions/). For agent-specific guidance, see [AGENTS.md](../AGENTS.md).
+
+## Safety-First LVM Operations
+
+LVMS manages physical storage. A bug can destroy user data. The codebase errs on the side of caution at every layer.
+
+- **Device wiping requires triple opt-in**: DeviceSelector configured, `ForceWipeDevicesAndDestroyAllData` set to `true`, and a per-node annotation preventing repeat wipes.
+- **Device filtering is conservative**: better to miss a valid device than wipe user data. Time-based filtering (`deviceMinAge`) was removed because it gives false confidence — LVM's own system lock is the real guard.
+- **Deletion blocks on active storage**: the LVMCluster finalizer blocks until PVCs are removed and Retain-policy PVs are cleaned up, emitting `ManualCleanupRequired` if user logical volumes exist.
+- **Never force-remove corrupt LVs**: set state to Degraded with explanation. Failed is for new creations; Degraded is for existing VGs with active data.
+- **All LVM commands accessing lvmdevices must run AsHost** — not container-level privileges.
+- **Always pass `-Z y` to lvcreate for thin pools** — do not rely on host `lvm.conf` defaults.
+
+## Defense-in-Depth Validation
+
+Critical constraints are validated at CRD schema (kubebuilder markers), admission webhook, AND controller runtime. The webhook can be deleted.
+
+LVMVolumeGroup has no webhook. Manual creation bypasses LVMCluster validation entirely. Invariants should be enforced in vg-manager, not just the webhook.
+
+CEL XValidation for simple invariants (immutability). Webhook for cross-field logic.
+
+## Features Ship Complete
+
+New features should include observability from day one where possible. If a feature can degrade, it should surface that at launch. Alerts are typically scoped to one per deviceClass, not per PVC, to avoid flooding. (Established during RAID design review, PR #2337.)
+
+## Greedy Mode Is Permanent
+
+No device paths specified = LVMS takes all devices. Switching to explicit paths later requires cluster recreation. Nil DeviceSelector (dynamic discovery) is single-deviceClass only; multi-deviceClass requires explicit DeviceSelector.
+
+## RAID Constraints
+
+Immutable after creation. Mutually exclusive with thin provisioning. Requires explicit device paths — dynamic discovery is fundamentally incompatible. Day-2 device replacement uses `optionalPaths`. Manual VG recovery with `vgreduce --removemissing` is documented in troubleshooting.md as a manual workaround, not an automated LVMS operation.
+
+## New Optional Fields: Nil Means Upgraded
+
+When adding optional fields, `nil` means "CR was created before this field existed." Runtime should default nil to behavior preserving backward compatibility to avoid breaking existing clusters on upgrade.
+
+## Separate Service Accounts per Workload
+
+Each workload (operator Deployment, vg-manager DaemonSet) gets its own service account with minimal RBAC. Due to the single-binary architecture, topolvm-controller shares the operator SA and topolvm-node shares the vg-manager SA. VG Manager requires OpenShift `privileged` SCC.

--- a/docs/decisions/0001-single-binary-architecture.md
+++ b/docs/decisions/0001-single-binary-architecture.md
@@ -1,0 +1,35 @@
+---
+status: draft
+date: Pre-2023
+decision-makers: LVMS team
+consulted:
+informed:
+---
+
+# Single Binary Architecture for Edge Deployment
+
+## Context and Problem Statement
+
+LVMS depends on TopoLVM and several CSI sidecar components. The standard Kubernetes model runs each as separate containers. A decision was needed on how to package these for edge and single-node clusters where resources are constrained.
+
+## Decision Drivers
+
+* Edge/SNO clusters have limited CPU and memory.
+* Startup time matters for edge recovery.
+* Upgrade complexity scales with independently versioned components.
+
+## Considered Options
+
+<!-- LVMS team: please fill in the alternatives that were discussed when this decision was made. Was multi-container deployment ever seriously evaluated? What made the team rule it out? -->
+
+1. TBD — requires LVMS team input on what alternatives were discussed
+2. Single binary with embedded TopoLVM and CSI sidecars
+
+## Decision Outcome
+
+Chosen option: single binary. See [architecture.md](../architecture.md) for full rationale.
+
+## More Information
+
+* [docs/architecture.md](../architecture.md) — "Why LVMS Embeds TopoLVM" section
+* `cmd/main.go` — single cobra root with `operator` and `vgmanager` subcommands

--- a/docs/decisions/0002-v1alpha1-is-stable.md
+++ b/docs/decisions/0002-v1alpha1-is-stable.md
@@ -1,0 +1,35 @@
+---
+status: draft
+date: Pre-2023
+decision-makers: LVMS team
+consulted:
+informed:
+---
+
+# v1alpha1 as Stable Production API
+
+## Context and Problem Statement
+
+LVMS ships its CRDs under `lvm.topolvm.io/v1alpha1`. The name suggests instability, but the API has been production-stable for multiple releases. The question is whether to promote the version.
+
+## Decision Drivers
+
+* Migration cost: conversion webhooks, storage version migration, coordinated rollout.
+* The API is effectively stable — immutability enforced via CEL markers.
+* No customer or engineering request has justified the cost.
+
+## Considered Options
+
+<!-- LVMS team: was v1beta1 or v1 ever concretely proposed? What specifically killed the idea — just cost, or other factors? -->
+
+1. TBD — requires LVMS team input on what alternatives were discussed
+2. Keep `v1alpha1` and treat as stable by convention
+
+## Decision Outcome
+
+Chosen option: keep `v1alpha1`. See [architecture.md](../architecture.md) for full rationale.
+
+## More Information
+
+* [docs/architecture.md](../architecture.md) — "API Version: v1alpha1" section
+* `api/v1alpha1/lvmcluster_types.go` — immutability markers on production fields

--- a/docs/decisions/0003-finalizer-hierarchy.md
+++ b/docs/decisions/0003-finalizer-hierarchy.md
@@ -1,0 +1,37 @@
+---
+status: draft
+date: Pre-2023
+decision-makers: LVMS team
+consulted:
+informed:
+---
+
+# Three-Level Finalizer Hierarchy for Cleanup Safety
+
+## Context and Problem Statement
+
+When an LVMCluster is deleted, LVMS must clean up LVM resources on every node. If cleanup is incomplete, storage is orphaned with no API-level recovery. A decision was needed on how to coordinate distributed cleanup.
+
+## Decision Drivers
+
+* Storage orphaning is unrecoverable without SSH access to nodes.
+* Nodes may be unreachable during deletion.
+* Cleanup has ordering requirements: LVs before VGs before PVs.
+* Retain-policy PVs should not be silently deleted.
+
+## Considered Options
+
+<!-- LVMS team: was a single finalizer on LVMCluster with a controller-driven cleanup loop considered? What problems did that approach have that led to the three-level design? -->
+
+1. TBD — requires LVMS team input on what alternatives were discussed
+2. Three-level finalizer hierarchy (LVMCluster → LVMVolumeGroup → LVMVolumeGroupNodeStatus)
+
+## Decision Outcome
+
+Chosen option: three-level hierarchy. See [architecture.md](../architecture.md) for full rationale.
+
+## More Information
+
+* [docs/architecture.md](../architecture.md) — "Cleanup and Finalizer Hierarchy" section
+* `internal/controllers/lvmcluster/controller.go` — LVMCluster finalizer
+* `internal/controllers/vgmanager/controller.go` — per-node cleanup finalizer

--- a/docs/decisions/0004-conservative-device-filters.md
+++ b/docs/decisions/0004-conservative-device-filters.md
@@ -1,0 +1,35 @@
+---
+status: draft
+date: Pre-2023
+decision-makers: LVMS team
+consulted:
+informed:
+---
+
+# Conservative Device Discovery Filters
+
+## Context and Problem Statement
+
+VG Manager discovers block devices on each node and decides which are safe for LVM volume groups. A wrong decision destroys user data. The filter chain must balance discovering all legitimate devices against never touching a device with data the user wants to keep.
+
+## Decision Drivers
+
+* Data loss from incorrect selection is unrecoverable and can happen silently.
+* False negatives (missing a device) are recoverable via DeviceSelector. False positives (wiping data) are catastrophic.
+* `deviceMinAge` was later removed because time-based filtering gives false confidence.
+
+## Considered Options
+
+<!-- LVMS team: was a permissive-by-default approach (include all, exclude known-bad) ever considered? What drove the decision toward conservative filtering? -->
+
+1. TBD — requires LVMS team input on what alternatives were discussed
+2. Conservative filtering (exclude by default, include only known-safe patterns)
+
+## Decision Outcome
+
+Chosen option: conservative filtering. See [known-limitations.md](../known-limitations.md) for the full filter chain documentation.
+
+## More Information
+
+* [docs/known-limitations.md](../known-limitations.md) — user-facing filter documentation
+* `internal/controllers/vgmanager/filter/filter.go` — filter chain implementation

--- a/docs/decisions/0005-remove-device-min-age.md
+++ b/docs/decisions/0005-remove-device-min-age.md
@@ -1,0 +1,38 @@
+---
+status: accepted
+date: 2023-08-10
+decision-makers: LVMS team
+consulted: LVMS team
+informed:
+---
+
+# Remove deviceMinAge Time-Based Device Filtering
+
+## Context and Problem Statement
+
+LVMS had a `deviceMinAge` parameter that required devices to exist for a minimum duration before being claimed for a volume group. The intent was to prevent LVMS from grabbing a device that another system was about to claim.
+
+## Decision Drivers
+
+* The race condition it tries to prevent is fundamentally unsolvable with time: device attached at t0, LVMS checks at t1, external entity doesn't claim within the window, LVMS grabs it anyway.
+* LVM's own system lock prevents concurrent LVM calls, making the age check redundant for LVM-level races.
+* Time-based guards give users false confidence that their devices are protected.
+
+## Considered Options
+
+1. Keep `deviceMinAge` with a longer default window
+2. Remove `deviceMinAge` entirely — rely on DeviceSelector for explicit device management
+
+## Decision Outcome
+
+Chosen option: "Remove `deviceMinAge` entirely", because time-based filtering is fundamentally unreliable and gives false confidence. Users who need control over which devices LVMS claims should use explicit `DeviceSelector` paths.
+
+### Consequences
+
+* Good, because false-confidence safety mechanism is removed — users must make explicit choices.
+* Good, because reconciliation is simplified with one fewer timing-dependent check.
+* Bad, because users relying on the delay for ad-hoc device management lose that (unsound) safety net.
+
+## More Information
+
+* [PR #380](https://github.com/openshift/lvm-operator/pull/380) — deviceMinAge removal

--- a/docs/decisions/0006-orphaned-nodestatus-dedicated-controller.md
+++ b/docs/decisions/0006-orphaned-nodestatus-dedicated-controller.md
@@ -1,0 +1,41 @@
+---
+status: accepted
+date: 2023-08-14
+decision-makers: LVMS team (jakobmoellerdev)
+consulted: LVMS team
+informed:
+---
+
+# Dedicated Controller for Orphaned NodeStatus Cleanup
+
+## Context and Problem Statement
+
+When a node is removed from the cluster, its `LVMVolumeGroupNodeStatus` CR becomes orphaned. These stale status CRs accumulate and can confuse operators and agents reading cluster state. A mechanism was needed to clean them up.
+
+## Decision Drivers
+
+* Orphaned NodeStatus CRs must be removed without manual intervention.
+* The cleanup mechanism must handle nodes that disappear without graceful shutdown.
+* The approach must not break the existing reconciliation model.
+
+## Considered Options
+
+1. Clean up orphaned NodeStatus during LVMCluster status update — check all nodes on every status reconcile and delete stale entries
+2. Dedicated node-removal controller with finalizer — watches node changes and cleans up on node deletion
+
+## Decision Outcome
+
+Chosen option: "Dedicated node-removal controller with finalizer", because it separates concerns cleanly and avoids expensive all-node comparisons on every status update. The tradeoff is that if the finalizer is not removed (e.g., controller bug), the Node object blocks deletion — but this is preferable to silent accumulation of stale status.
+
+A stale-finalizer cleaner on LVMVolumeGroup removes finalizers for nodes that no longer exist, handling the edge case of nodes deleted while the operator was down.
+
+### Consequences
+
+* Good, because cleanup is event-driven (node deletion) rather than polling-based.
+* Good, because the LVMCluster status update path stays simple.
+* Bad, because a stuck finalizer on the Node object blocks node deletion until the operator fixes it.
+
+## More Information
+
+* [PR #372](https://github.com/openshift/lvm-operator/pull/372) — orphaned NodeStatus cleanup controller
+* `internal/controllers/lvmcluster/controller.go` — stale finalizer cleaner (`checkStaleNodeFinalizers`)

--- a/docs/decisions/0007-no-errgroup-for-concurrent-reconciliation.md
+++ b/docs/decisions/0007-no-errgroup-for-concurrent-reconciliation.md
@@ -1,0 +1,38 @@
+---
+status: accepted
+date: 2023-08-23
+decision-makers: LVMS team
+consulted: LVMS team
+informed:
+---
+
+# No errgroup for Concurrent Reconciliation
+
+## Context and Problem Statement
+
+The LVMCluster controller creates multiple subordinate resources concurrently. When one creation fails, the question is whether to cancel all in-flight operations or let them all attempt and aggregate errors.
+
+## Decision Drivers
+
+* Resource creation is idempotent — a failed attempt doesn't corrupt state.
+* Cancelling successful in-flight operations wastes work and forces a full retry next cycle.
+* A critical deadlock bug was discovered when using errgroup: if `ensureCreated` returned nil, the context was never cancelled, blocking the group indefinitely.
+
+## Considered Options
+
+1. `golang.org/x/sync/errgroup` — cancels context on first error
+2. Raw goroutines with results channel and `errors.Join`
+
+## Decision Outcome
+
+Chosen option: "Raw goroutines with `errors.Join`", because errgroup's cancel-on-first-error semantic is wrong for resource creation where you want all operations to attempt regardless of individual failures.
+
+### Consequences
+
+* Good, because all resources are attempted even when some fail — reducing reconcile cycles to converge.
+* Good, because the deadlock bug from errgroup's context cancellation is eliminated.
+* Bad, because raw goroutine management requires more boilerplate than errgroup.
+
+## More Information
+
+* [PR #391](https://github.com/openshift/lvm-operator/pull/391) — concurrent apply/status checks, deadlock discovery

--- a/docs/decisions/0008-v2-api-rejection.md
+++ b/docs/decisions/0008-v2-api-rejection.md
@@ -1,0 +1,41 @@
+---
+status: rejected
+date: 2023-10-17
+decision-makers: LVMS team (jakobmoellerdev)
+consulted: LVMS team
+informed:
+---
+
+# V2 API Proposal (Rejected)
+
+## Context and Problem Statement
+
+A v2 API was proposed to address limitations of the current v1alpha1 API. The proposal explored whether LVMCluster should remain the single user-facing CR or whether users should be able to create LVMVolumeGroup CRs directly, and whether the API should support multiple volume groups per device class.
+
+## Decision Drivers
+
+* The current API couples all device classes into a single LVMCluster CR — modifying one device class risks affecting others.
+* Direct LVMVolumeGroup creation would eliminate the indirection but lose the pre-validation guarantee.
+* Multiple TopoLVM instances can run but lvmd instances race on locks.
+
+## Considered Options
+
+1. V2 API — users create LVMVolumeGroup directly, DeviceClass maps to N volume groups, thin and thick VGs coexist
+2. Keep v1alpha1 — LVMCluster remains the single entry point, operator creates child CRs
+
+## Decision Outcome
+
+Chosen option: "Keep v1alpha1", because the pre-validation benefit of the LVMCluster → LVMVolumeGroup → LVMVolumeGroupNodeStatus hierarchy outweighs the flexibility of direct VG creation. Without the operator-mediated layer, simultaneous CRs on hundreds of nodes could create inconsistent VG-to-node mappings and dangling PVs.
+
+The proposal was explicitly rejected but merged as documentation for historical reference — team convention is to preserve rejected designs in the repo.
+
+### Consequences
+
+* Good, because the safety guarantees of operator-mediated CR creation are preserved.
+* Good, because the rejected design is documented for future reference.
+* Bad, because modifying a single device class still requires editing the full LVMCluster CR.
+
+## More Information
+
+* [PR #432](https://github.com/openshift/lvm-operator/pull/432) — v2 API proposal (merged as documentation, rejected for implementation)
+* [PR #72](https://github.com/openshift/lvm-operator/pull/72), [PR #100](https://github.com/openshift/lvm-operator/pull/100) — original discussions on why LVMCluster is the single entry point

--- a/docs/decisions/0009-configmap-for-lvmd-config.md
+++ b/docs/decisions/0009-configmap-for-lvmd-config.md
@@ -1,0 +1,32 @@
+---
+status: superseded
+date: 2023-11-09
+decision-makers: LVMS team (jakobmoellerdev)
+consulted: LVMS team
+informed:
+---
+
+# ConfigMap for lvmd Configuration (Superseded)
+
+**This decision was reverted in [PR #566](https://github.com/openshift/lvm-operator/pull/566).** The ConfigMap approach was replaced back to file-based configuration because a single ConfigMap cannot represent per-node configuration differences. The current implementation uses `FileConfig` reading/writing `/etc/topolvm/lvmd.yaml` on the host filesystem (see `internal/controllers/vgmanager/lvmd/lvmd.go`).
+
+## Context and Problem Statement
+
+lvmd needs per-node configuration specifying which volume groups and device classes to manage. Originally this was a host file. PR #480 migrated to a ConfigMap for observability, but this was reverted because a single ConfigMap can't hold different configs for different nodes.
+
+## Considered Options
+
+1. Host filesystem file (`/etc/topolvm/lvmd.yaml`) written by VG Manager
+2. Kubernetes ConfigMap in the operator namespace
+
+## Decision Outcome
+
+Option 2 was chosen in PR #480 but **reverted in PR #566** back to option 1 because per-node config differences cannot be expressed in a single ConfigMap.
+
+The convention from this experience: when querying VG state, always query the host directly rather than relying on config files, because file writes can fail silently and leave stale config (#146).
+
+## More Information
+
+* [PR #480](https://github.com/openshift/lvm-operator/pull/480) — ConfigMap migration (superseded)
+* [PR #566](https://github.com/openshift/lvm-operator/pull/566) — revert to file-based config
+* [PR #14](https://github.com/openshift/lvm-operator/pull/14) — original multi-node config concern

--- a/docs/decisions/0010-server-side-apply-for-storageclassoptions.md
+++ b/docs/decisions/0010-server-side-apply-for-storageclassoptions.md
@@ -1,0 +1,62 @@
+---
+status: accepted
+date: 2026-03-03
+decision-makers: LVMS team (qJkee, Neilhamza)
+consulted: LVMS team
+informed: OpenShift Edge team, QE
+---
+
+# Server-Side Apply for StorageClassOptions
+
+## Context and Problem Statement
+
+LVMS needed to allow users to configure StorageClass properties (reclaimPolicy, volumeBindingMode, additional parameters, additional labels) via the LVMCluster CR. The challenge was managing field ownership: LVMS controls certain keys (device-class name, filesystem type, managed labels) while users provide additional parameters and labels. The two sets must not conflict, and day-2 changes to either must reconcile cleanly.
+
+The previous StorageClass reconciliation used `CreateOrUpdate` with a mutate function, which overwrites the entire object and cannot distinguish between LVMS-owned and user-owned fields.
+
+## Decision Drivers
+
+* Users must be able to set additional StorageClass parameters and labels without LVMS overwriting them.
+* LVMS must maintain ownership of critical parameters (`topolvm.io/device-class`, `csi.storage.k8s.io/fstype`) and managed labels — user values must never override these.
+* Day-2 changes (adding/removing parameters, toggling default SC annotation) must reconcile without requiring StorageClass deletion and recreation.
+* Immutability of critical fields (reclaimPolicy, volumeBindingMode, fstype) must be enforced at the API level.
+
+## Considered Options
+
+1. `CreateOrUpdate` with mutate function (existing approach)
+2. Kubernetes Server-Side Apply (SSA) with field ownership
+
+## Decision Outcome
+
+Chosen option: "Server-Side Apply with field ownership", because SSA's field manager model natively handles the LVMS-owned vs. user-owned key distinction, and day-2 annotation changes reconcile automatically without object recreation.
+
+Implementation details:
+
+* StorageClasses are patched with `client.Apply`, `client.FieldOwner("lvms-operator")`, and `client.ForceOwnership`.
+* User-provided `AdditionalParameters` and `AdditionalLabels` are copied first, then LVMS-owned keys are set afterward to prevent user override (PR #2066: qJkee caught that naive `maps.Copy()` of user values would silently override managed keys).
+* Immutability is enforced via CEL markers: `reclaimPolicy`, `volumeBindingMode`, and `fstype` use `XValidation: rule="oldSelf == self"`.
+* A follow-up fix (PR #2494) addressed a CEL bypass where `+kubebuilder:default={}` was needed on the optional `StorageClassOptions` struct to ensure `oldSelf` always exists on UPDATE.
+
+### Why additionalParameters Exists
+
+`additionalParameters` is a forward-compatibility passthrough. TopoLVM only reads two StorageClass parameters (`topolvm.io/device-class` and `csi.storage.k8s.io/fstype`) — any other parameter is passed through to the CSI `CreateVolume` call but ignored. The use case is extensibility: if TopoLVM or a future CSI sidecar adds support for new parameters, customers can set them without waiting for an LVMS API change. Custom parameters landing on the StorageClass object are visible to any component that reads SC parameters.
+
+Immutable fields (reclaimPolicy, volumeBindingMode, fstype) require delete-and-recreate to change — there is no patch mechanism by design.
+
+**Known gap**: LVMS-owned keys passed via additionalParameters are silently overridden by the operator (user values copied first, then managed keys set). The webhook does not currently warn about this. Discussed but not yet implemented.
+
+### Consequences
+
+* Good, because SSA handles field ownership natively — LVMS-owned keys cannot be overridden by users.
+* Good, because day-2 changes to the default SC annotation reconcile automatically.
+* Good, because the SSA patch is declarative and idempotent, fitting the operator's reconciliation model.
+* Good, because additionalParameters provides forward-compatibility without API changes.
+* Bad, because SSA is more complex to reason about than `CreateOrUpdate` for contributors unfamiliar with field managers.
+* Bad, because the webhook does not warn when users pass LVMS-owned keys via additionalParameters — they are silently overridden.
+
+## More Information
+
+* [PR #2066](https://github.com/openshift/lvm-operator/pull/2066) — original implementation
+* [PR #2494](https://github.com/openshift/lvm-operator/pull/2494) — CEL immutability bypass fix
+* `internal/controllers/lvmcluster/resource/topolvm_storageclass.go` — SSA patch and key ordering
+* `api/v1alpha1/lvmcluster_types.go` — `StorageClassOptions` struct with immutability markers

--- a/docs/decisions/0011-deletion-gates-pvc-pv-policy.md
+++ b/docs/decisions/0011-deletion-gates-pvc-pv-policy.md
@@ -1,0 +1,51 @@
+---
+status: accepted
+date: 2026-03-03
+decision-makers: LVMS team (qJkee, Neilhamza)
+consulted: LVMS team
+informed: OpenShift Edge team
+---
+
+# Deletion Gates: PVC and PV Policy Checks Before LVMCluster Deletion
+
+## Context and Problem Statement
+
+When an LVMCluster is deleted, LVMS must decide whether to proceed with VG cleanup or block. If PVCs still reference LVMS StorageClasses, deleting the VG underneath them silently destroys user data. If PVs with Retain policy exist, the user expects the data to survive — deleting the VG violates that contract.
+
+## Decision Drivers
+
+* Silent data loss on deletion is unacceptable.
+* Retain-policy PVs explicitly signal the user wants data preserved.
+* Large clusters may have thousands of PVCs — checking all of them is expensive.
+* Device class removal on day-2 must follow the same safety rules as full cluster deletion.
+
+## Considered Options
+
+1. Delete everything unconditionally — fast but destroys user data without warning
+2. Cascade via OwnerReferences — clean but OwnerReferences on cluster-scoped resources (StorageClass) don't work cross-namespace
+3. Block deletion with explicit PVC/PV gates and emit events for manual cleanup
+
+## Decision Outcome
+
+Chosen option: "Block deletion with explicit PVC/PV gates", because data safety trumps deletion speed, and users must be told exactly what to clean up.
+
+Implementation:
+
+* LVMCluster finalizer checks for active PVCs using LVMS StorageClasses via `client.MatchingFields{"spec.storageClassName": scName}` with field indexers (never unfiltered `List()` — hangs in large clusters, PR #2066).
+* Retain-policy PVs are checked separately. If user logical volumes exist with Retain policy, cleanup is blocked and a `ManualCleanupRequired` event is emitted.
+* Device class removal on day-2 follows the same gates — users must delete PVCs first (PR #1657).
+* `deleteSpecifiedResource` waits for the CR to disappear but not for VG cleanup on disk — `waitForLVMClusterReady` on the new cluster detects VG conflicts (PR #2410).
+
+### Consequences
+
+* Good, because data loss on deletion is prevented.
+* Good, because the `ManualCleanupRequired` event tells users exactly what to do.
+* Good, because field indexers make PVC/PV lookup fast even in large clusters.
+* Bad, because deletion can block indefinitely if users don't clean up their PVCs/PVs.
+
+## More Information
+
+* [PR #2066](https://github.com/openshift/lvm-operator/pull/2066) — filtered PVC/PV listing with field indexers
+* [PR #1657](https://github.com/openshift/lvm-operator/pull/1657) — device class removal on day-2
+* [PR #402](https://github.com/openshift/lvm-operator/pull/402) — ownerref alignment and deletion logic
+* `internal/controllers/lvmcluster/controller.go` — finalizer and PVC/PV gate logic

--- a/docs/decisions/0012-cel-vs-webhook-validation.md
+++ b/docs/decisions/0012-cel-vs-webhook-validation.md
@@ -1,0 +1,53 @@
+---
+status: accepted
+date: 2026-06-09
+decision-makers: LVMS team (qJkee, Neilhamza)
+consulted: LVMS team
+informed: OpenShift Edge team
+---
+
+# CEL XValidation vs Webhook for Field Validation
+
+## Context and Problem Statement
+
+LVMS needs to validate field constraints (immutability, cross-field rules, conditional logic). Kubernetes offers two mechanisms: CEL XValidation rules embedded in the CRD schema, and admission webhooks. The team needed a consistent policy on when to use which.
+
+A CEL bypass was discovered (PR #2494) where transition rules (`oldSelf == self`) are silently skipped when the field doesn't exist on the old object — revealing that CEL alone is insufficient for some safety-critical validations.
+
+## Decision Drivers
+
+* CEL rules are evaluated by the API server with no extra deployment — they survive webhook deletion.
+* Complex CEL expressions are hard to read and maintain.
+* The webhook can be deleted — safety-critical constraints cannot rely solely on it.
+* Some constraints (e.g., RAID mirrors-only-for-raid1/raid10) span multiple fields and are painful to express in CEL.
+
+## Considered Options
+
+1. All-CEL — every validation as XValidation markers on the CRD
+2. All-webhook — centralize validation in the admission webhook
+3. Hybrid — CEL for simple invariants, webhook for complex cross-field logic
+
+## Decision Outcome
+
+Chosen option: "Hybrid", because CEL readability degrades sharply for cross-field rules, and the webhook provides a single place for complex logic — but CEL provides a safety net when the webhook is deleted.
+
+Rules:
+
+* **CEL**: simple immutability (`oldSelf == self`), basic format validation, enum-like constraints. Add `+kubebuilder:default={}` on optional struct fields with immutable sub-fields to prevent the nil-bypass (PR #2494).
+* **Webhook**: cross-field validation (RAID/ThinPool mutual exclusion, device count per RAID level, mirrors-only constraints), conditional logic, anything that would hurt readability as CEL.
+* **Controller runtime**: defense-in-depth for safety-critical constraints — LVMVolumeGroup has no webhook, so vg-manager must enforce its own invariants.
+
+### Consequences
+
+* Good, because simple rules are enforced even without the webhook.
+* Good, because complex cross-field logic stays readable and maintainable in Go.
+* Bad, because contributors must decide which layer to use — three places to look for validation.
+* Bad, because the CEL nil-bypass requires the `+kubebuilder:default={}` workaround on every optional immutable struct.
+
+## More Information
+
+* [PR #2549](https://github.com/openshift/lvm-operator/pull/2549) — qJkee: "writing such complex CEL rule will be hard to read and manage in the future"
+* [PR #2494](https://github.com/openshift/lvm-operator/pull/2494) — CEL nil-to-non-nil bypass discovery and fix
+* [PR #131](https://github.com/openshift/lvm-operator/pull/131) — first CRD validation discussion
+* `api/v1alpha1/lvmcluster_webhook.go` — webhook validation
+* `api/v1alpha1/lvmcluster_types.go` — CEL XValidation markers

--- a/docs/decisions/adr-template.md
+++ b/docs/decisions/adr-template.md
@@ -1,0 +1,36 @@
+---
+status: "{proposed | accepted | deprecated | superseded by [ADR-NNNN](NNNN-title.md)}"
+date: YYYY-MM-DD
+decision-makers:
+consulted:
+informed:
+---
+
+# Title
+
+## Context and Problem Statement
+
+{Describe the context and the problem or decision that needs to be made.}
+
+## Decision Drivers
+
+* {Driver 1}
+* {Driver 2}
+
+## Considered Options
+
+1. {Option 1}
+2. {Option 2}
+
+## Decision Outcome
+
+Chosen option: "{Option N}", because {justification}.
+
+### Consequences
+
+* Good, because {positive consequence}
+* Bad, because {negative consequence}
+
+## More Information
+
+{Links to related documents, PRs, or discussions.}

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -1,0 +1,31 @@
+# LVMS Architectural Decision Records
+
+ADRs document key design decisions with context, alternatives considered, and consequences. Foundational architecture is documented in [architecture.md](../architecture.md). Implementation conventions are in [conventions/](../conventions/).
+
+Format: [MADR 4.0](https://adr.github.io/madr/) short template. See [adr-template.md](adr-template.md).
+
+## Decision Log
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [0001](0001-single-binary-architecture.md) | Single binary architecture for edge deployment | Draft | Pre-2023 |
+| [0002](0002-v1alpha1-is-stable.md) | v1alpha1 as stable production API | Draft | Pre-2023 |
+| [0003](0003-finalizer-hierarchy.md) | Three-level finalizer hierarchy for cleanup safety | Draft | Pre-2023 |
+| [0004](0004-conservative-device-filters.md) | Conservative device discovery filters | Draft | Pre-2023 |
+| [0005](0005-remove-device-min-age.md) | Remove deviceMinAge time-based filtering | Accepted | 2023-08-10 |
+| [0006](0006-orphaned-nodestatus-dedicated-controller.md) | Dedicated controller for orphaned NodeStatus cleanup | Accepted | 2023-08-14 |
+| [0007](0007-no-errgroup-for-concurrent-reconciliation.md) | No errgroup for concurrent reconciliation | Accepted | 2023-08-23 |
+| [0008](0008-v2-api-rejection.md) | V2 API proposal | Rejected | 2023-10-17 |
+| [0009](0009-configmap-for-lvmd-config.md) | ConfigMap for lvmd configuration | Superseded | 2023-11-09 |
+| [0010](0010-server-side-apply-for-storageclassoptions.md) | Server-side apply for StorageClassOptions | Accepted | 2026-03-03 |
+| [0011](0011-deletion-gates-pvc-pv-policy.md) | Deletion gates: PVC and PV policy checks | Accepted | 2026-03-03 |
+| [0012](0012-cel-vs-webhook-validation.md) | CEL XValidation vs webhook for validation | Accepted | 2026-06-09 |
+
+Draft ADRs (0001–0004) have the decision outcome documented but need "Considered Options" filled in by the LVMS team.
+
+## Adding a New ADR
+
+1. Copy [adr-template.md](adr-template.md).
+2. Name it `NNNN-short-slug.md` (next sequential number).
+3. Fill in status, date, and decision-makers in the YAML frontmatter.
+4. Add an entry to the table above.


### PR DESCRIPTION
## Summary

Captures implicit LVMS team knowledge that previously existed only in team memory and PR review threads. This is part of the Agentic SDLC MVP ([OCPEDGE-2508](https://redhat.atlassian.net/browse/OCPEDGE-2508)) — Track 1 Contextification.

Knowledge was mined from **197 PR review threads** spanning the full repo history (2021–2026), extracting conventions, design decisions, gotchas, and invariants that are enforced in review but not written down anywhere.

### New files

- **`docs/core-beliefs.md`** — 7 non-negotiable design invariants (safety-first ops, defense-in-depth, features ship complete, greedy mode, RAID constraints, nil-means-upgraded, separate service accounts)
- **`docs/conventions.md`** — 215 implementation conventions organized by topic (API design, reconciliation patterns, validation, device management, safety, gotchas, code style, testing, build/CI, observability). Each convention includes the PR number where it was established.
- **`docs/decisions/`** — 12 Architectural Decision Records in MADR 4.0 format:
  - 7 accepted (SSA for StorageClass, deletion gates, CEL vs webhook, no-errgroup, deviceMinAge removal, orphaned NodeStatus cleanup, ConfigMap for lvmd)
  - 4 draft — foundational decisions (single binary, v1alpha1 stable, finalizer hierarchy, conservative filters) with decision outcome documented but **"Considered Options" needs LVMS team input**
  - 1 rejected (v2 API proposal — preserved for historical reference)

### Modified files

- **`AGENTS.md`** — added core-beliefs, conventions, and decisions to the documentation index
- **`CONTRIBUTING.md`** — added link to conventions.md

### Review guidance

- **`docs/core-beliefs.md`**: Are these 7 invariants correct and complete? Anything missing?
- **`docs/conventions.md`**: Are any of the 215 findings outdated or wrong? These were extracted from PR threads — some may have been superseded.
- **`docs/decisions/0002–0005`** (draft ADRs): These need the "Considered Options" section filled in — what alternatives were discussed when these foundational decisions were made? Comments with `<!-- LVMS team: ... -->` mark exactly where input is needed.
- **`docs/decisions/0001, 0006–0012`** (accepted/rejected ADRs): Are the alternatives and consequences accurate?

Jira: [OCPEDGE-2765](https://redhat.atlassian.net/browse/OCPEDGE-2765)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new **Code Conventions** section to contributor guidance to improve navigation across conventions, core beliefs, and architectural decision records.
  * Published new convention pages for **API & validation**, **code style & observability**, **reconciliation & device management**, **safety & security**, and **testing/CI**.
  * Added **core beliefs** documentation, an **ADR template**, and a new **decision log** with cross-links.
  * Introduced new ADRs (**0001–0012**) covering architecture, API stability, cleanup safety, conservative device discovery, deletion gating, and validation approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->