### PR TITLE
OCPEDGE-791: Move the disconnected cluster func to utils.go

### DIFF
--- a/test/integration/qe_tests/lvms_utils.go
+++ b/test/integration/qe_tests/lvms_utils.go
@@ -40,6 +40,39 @@ func getRandomString() string {
 	return string(b)
 }
 
+func isDisconnectedCluster() bool {
+	// Get a node name to run the network probe
+	nodeCmd := exec.Command("oc", "get", "nodes", "-o=jsonpath={.items[0].metadata.name}")
+	nodeOutput, err := nodeCmd.CombinedOutput()
+	if err != nil {
+		logf("Warning: failed to get node name: %v", err)
+		return false
+	}
+	nodeName := strings.TrimSpace(string(nodeOutput))
+	if nodeName == "" {
+		logf("Warning: no nodes found")
+		return false
+	}
+
+	// Network probe: curl an external URL from the node to check connectivity
+	probeCmd := exec.Command("oc", "debug", "node/"+nodeName, "--",
+		"chroot", "/host", "sh", "-c",
+		"curl -s --connect-timeout 5 https://fedoraproject.org/static/hotspot.txt &>/dev/null && echo Connected || echo Disconnected")
+	probeOutput, err := probeCmd.CombinedOutput()
+	if err != nil {
+		logf("Warning: network probe failed: %v", err)
+		return false
+	}
+
+	result := strings.TrimSpace(string(probeOutput))
+	if strings.Contains(result, "Disconnected") {
+		logf("Detected disconnected cluster: network probe failed to reach external URL")
+		return true
+	}
+
+	return false
+}
+
 type lvmCluster struct {
 	name             string
 	namespace        string

--- a/test/integration/qe_tests/rapidast.go
+++ b/test/integration/qe_tests/rapidast.go
@@ -67,39 +67,6 @@ func isARMCluster() bool {
 	return strings.Contains(archs, "arm64") || strings.Contains(archs, "aarch64")
 }
 
-func isDisconnectedCluster() bool {
-	// Get a node name to run the network probe
-	nodeCmd := exec.Command("oc", "get", "nodes", "-o=jsonpath={.items[0].metadata.name}")
-	nodeOutput, err := nodeCmd.CombinedOutput()
-	if err != nil {
-		logf("Warning: failed to get node name: %v", err)
-		return false
-	}
-	nodeName := strings.TrimSpace(string(nodeOutput))
-	if nodeName == "" {
-		logf("Warning: no nodes found")
-		return false
-	}
-
-	// Network probe: curl an external URL from the node to check connectivity
-	probeCmd := exec.Command("oc", "debug", "node/"+nodeName, "--",
-		"chroot", "/host", "sh", "-c",
-		"curl -s --connect-timeout 5 https://fedoraproject.org/static/hotspot.txt &>/dev/null && echo Connected || echo Disconnected")
-	probeOutput, err := probeCmd.CombinedOutput()
-	if err != nil {
-		logf("Warning: network probe failed: %v", err)
-		return false
-	}
-
-	result := strings.TrimSpace(string(probeOutput))
-	if strings.Contains(result, "Disconnected") {
-		logf("Detected disconnected cluster: network probe failed to reach external URL")
-		return true
-	}
-
-	return false
-}
-
 func createRapidastSA(ns string) error {
 	content, err := templateFS.ReadFile("testdata/rapidast_sa.yaml")
 	if err != nil {


### PR DESCRIPTION
logs: https://privatebin.corp.redhat.com/?d9d1731d6152cd29#C5SheoKMF1FEsTD4V7JqUtWUAQKBLU898MevoDTNnW5E

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disconnected-cluster detection during integration testing, helping the system better identify when external internet access is unavailable.
  * When the connectivity check can’t be completed or returns unexpected results, the test now logs a warning and safely falls back to a non-disconnected state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->