### PR TITLE
OCPBUGS-92832: Fix test 60835 cascading failures by adding thinPoolConfig to vg2

### DIFF
--- a/test/integration/qe_tests/lvms_utils.go
+++ b/test/integration/qe_tests/lvms_utils.go
@@ -199,9 +199,6 @@ func (lvm *lvmCluster) deleteSafely() {
 }
 
 func (lvm *lvmCluster) createWithMultiDeviceClasses() error {
-	// Creates LVMCluster with vg1 as thin provisioning and vg2 as thick provisioning
-	// vg1: has thinPoolConfig (supports snapshots)
-	// vg2: NO thinPoolConfig (thick provisioning, no snapshot support)
 	lvmClusterYAML := fmt.Sprintf(`apiVersion: lvm.topolvm.io/v1alpha1
 kind: LVMCluster
 metadata:
@@ -222,6 +219,10 @@ spec:
         forceWipeDevicesAndDestroyAllData: true
     - name: %s
       fstype: %s
+      thinPoolConfig:
+        name: thin-pool-2
+        sizePercent: 90
+        overprovisionRatio: 10
       deviceSelector:
         paths:
         - %s


### PR DESCRIPTION
## Summary
- Test 60835 (`createWithMultiDeviceClasses`) creates an LVMCluster with two device classes but omits `thinPoolConfig` on vg2
- On release-4.14, `thinPoolConfig` is a **required** field (`+kubebuilder:validation:Required`), so the webhook rejects the create with: `spec.storage.deviceClasses[1].thinPoolConfig: Required value`
- Because test 60835 is `[Disruptive]` and deletes the original LVMCluster first, the failed create leaves no LVMCluster on the cluster, causing all subsequent tests to skip with "LVMS Operator is not installed"
- This fix adds `thinPoolConfig` with `thin-pool-2` to the vg2 device class, matching the template used in `openshift-tests-private` (`lvmcluster-with-multi-thinpool-template.yaml`) for the same test

## Root Cause
- On `main`/4.16+, `thinPoolConfig` is `+optional` (thick provisioning is supported)
- On `release-4.14`, it is `+required` — the test was written for the newer API but the manifest is invalid on 4.14

## Test plan
- [ ] Verify BM MNO integration tests pass without cascading skips after test 60835
- [ ] Confirm both storage classes (`lvms-vg1`, `lvms-vg2`) are created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)