### PR TITLE
OCPEDGE-2766: create LVMS domain glossary and concept relationship map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ This is the LVM Operator, part of LVMS (Logical Volume Manager Storage) for Open
 |----------|---------|
 | [docs/core-beliefs.md](docs/core-beliefs.md) | Non-negotiable design principles — read this first |
 | [docs/conventions/](docs/conventions/) | Implementation conventions enforced in review (split by area) |
+| [docs/domain/glossary.md](docs/domain/glossary.md) | LVMS terminology — canonical definitions matching Go types and CRD fields |
+| [docs/domain/concepts.md](docs/domain/concepts.md) | How LVMS concepts relate — resource flow, filter chain, reconciliation, deletion |
 | [docs/decisions/](docs/decisions/index.md) | Architectural Decision Records (ADRs) — why the codebase looks the way it does |
 | [docs/architecture.md](docs/architecture.md) | Design rationale, component diagram, reconciliation lifecycle, CRD relationships, finalizer hierarchy |
 | [docs/design/lvm-operator-manager.md](docs/design/lvm-operator-manager.md) | LVM Operator Manager internals |

--- a/docs/domain/concepts.md
+++ b/docs/domain/concepts.md
@@ -1,0 +1,175 @@
+# LVMS Concept Relationships
+
+How LVMS concepts relate to each other. For term definitions, see [glossary.md](glossary.md). For architecture, see [architecture.md](../architecture.md). For design principles, see [core-beliefs.md](../core-beliefs.md).
+
+## Resource Flow
+
+The path from user intent to storage on disk:
+
+```text
+LVMCluster (user creates)
+ └── DeviceClass (1:N, defined in spec)
+      ├── LVMVolumeGroup CR (1:1, operator creates)
+      │    └── LVMVolumeGroupNodeStatus CR (1 per node, VG Manager creates)
+      │         └── VGStatus (1 per VG on that node)
+      ├── StorageClass (1:1, operator creates via SSA, named lvms-{name})
+      ├── VolumeSnapshotClass (1:1, only if ThinPoolConfig set, named lvms-{name})
+      └── On each matching node (VG Manager):
+           ├── LVM VolumeGroup (tagged @lvms)
+           │    └── ThinPool LV (if ThinPoolConfig set)
+           └── LogicalVolume CRs → LVM LVs → PVs → PVCs → Pods
+```
+
+Key: LVMCluster is the only user-facing CR. Everything below it is operator-managed.
+
+## Device Filter Chain
+
+How a raw block device becomes a VG member. VG Manager runs this on each reconcile cycle (frequency depends on configuration — see [Reconciliation Flow](#reconciliation-flow)). A device must pass ALL filters to be "Available".
+
+**Note on ordering:** Filters are stored in a `map[string]Filter`, so execution order is not guaranteed and may vary across restarts. Each filter is independent — the result does not depend on which order they run.
+
+```text
+lsblk --json discovers all block devices
+         │
+         ▼
+┌─ partOfDeviceSelector ─── Does it match Paths/OptionalPaths? (skip if no DeviceSelector)
+│
+├─ notReadOnly ──────────── Is ReadOnly=false?
+│
+├─ notSuspended ─────────── Is State != "suspended"?
+│
+├─ noInvalidPartitionLabel ─ Is PartLabel not bios/boot/reserved? (case-insensitive)
+│
+├─ onlyValidFilesystemSignatures
+│    ├─ No FSType → pass
+│    ├─ LVM2_member → pass if: same VG name, OR orphaned PV with free capacity
+│    └─ Any other FSType → reject
+│
+├─ noChildren ───────────── Has no child block devices?
+│
+└─ usableDeviceType
+     ├─ ROM → reject
+     ├─ LVM partition → reject
+     └─ Loop → pass only if not used by Kubernetes
+```
+
+Devices that fail filters are reported in `VGStatus.Excluded` with the filter name and reason. Two special errors (`ErrDeviceAlreadySetupCorrectly`, `ErrLVMPartition`) are suppressed from excluded reporting since they are expected post-setup.
+
+## Reconciliation Flow
+
+Two reconciliation loops run independently:
+
+### LVMCluster Controller (Deployment, requeues every 1 min)
+
+```text
+1. Validate LVMCluster CR
+2. Create/update subordinate resources concurrently (goroutines + errors.Join):
+   - CSIDriver
+   - VG Manager DaemonSet
+   - LVMVolumeGroup CRs (one per DeviceClass)
+   - StorageClasses (via SSA)
+   - VolumeSnapshotClasses (if thin pool)
+   - SCCs (OpenShift only)
+   - ServiceMonitor
+3. Aggregate status from all LVMVolumeGroupNodeStatus CRs
+4. Set LVMCluster conditions: ResourcesAvailable, VolumeGroupsReady
+5. Compute state: Failed > Degraded > Progressing > Ready > Unknown (only Ready when ALL expected VGs on ALL valid nodes are Ready)
+```
+
+### VG Manager (DaemonSet, one per node, requeues every 30s)
+
+```text
+1. List LVMVolumeGroup CRs matching this node
+2. For each LVMVolumeGroup:
+   a. Check for deletion (DeletionTimestamp set) → run cleanup if yes
+   b. Check ForceWipeDevicesAndDestroyAllData → wipe if needed, return early
+   c. List block devices via lsblk --json
+   d. List existing VGs (filtered by @lvms tag)
+   e. Run filter chain on all discovered devices
+   f. Create VG (vgcreate) or extend VG (vgextend) with new devices
+   g. Handle thin pool: create, extend, or validate chunk size / metadata
+   h. Handle RAID: validate device count, check health, update metrics
+   i. Handle device removal: detect removed paths, call vgreduce/pvremove
+   j. Validate existing logical volumes (thin pool health, metadata %)
+   k. Update LVMVolumeGroupNodeStatus with current state
+3. Determine requeue:
+   - Explicit device paths + Static policy → no periodic requeue
+   - Dynamic policy → requeue in 30s
+   - After VG creation/extension → always requeue (verification step)
+```
+
+## CRD Relationships
+
+```text
+LVMCluster (namespace-scoped, singleton)
+ │
+ │ creates (ownerRef)
+ ▼
+LVMVolumeGroup (namespace-scoped, one per DeviceClass)
+ │
+ │ per-node finalizer: cleanup.vgmanager.node.topolvm.io/{nodeName}
+ │ non-controller ownerRef on NodeStatus
+ │
+ ▼
+LVMVolumeGroupNodeStatus (namespace-scoped, one per node)
+ │
+ │ controller ownerRef from LVMCluster (deletion propagation)
+ │ non-controller ownerRef from each LVMVolumeGroup
+ │ finalizer: delete-protection.lvm.openshift.io
+ │
+ │ contains
+ ▼
+VGStatus[] (one entry per VolumeGroup on this node)
+```
+
+Cluster-scoped resources (CSIDriver, StorageClass, VolumeSnapshotClass, SCC) use labels for ownership since OwnerReferences don't work cross-namespace. Label: `app.kubernetes.io/managed-by: lvms-operator`.
+
+## StorageClass Lifecycle
+
+How a DeviceClass becomes a Kubernetes StorageClass:
+
+1. LVMCluster controller reads `DeviceClass.StorageClassOptions`
+2. Builds StorageClass object with name `lvms-{deviceClassName}`
+3. Copies `AdditionalParameters` from user, then overwrites with LVMS-owned keys:
+   - `topolvm.io/device-class` = device class name
+   - `csi.storage.k8s.io/fstype` = filesystem type
+4. Copies `AdditionalLabels` from user, then sets managed labels
+5. Applies via Server-Side Apply with field owner `lvms-operator` and `ForceOwnership`
+6. Sets default SC annotation (`storageclass.kubernetes.io/is-default-class`) if DeviceClass is default and no other default exists
+
+The SSA field manager model ensures LVMS-owned keys cannot be overridden by user kubectl edits. Day-2 changes to AdditionalLabels reconcile automatically.
+
+## Deletion Flow
+
+When an LVMCluster is deleted:
+
+```text
+1. LVMCluster finalizer (lvmcluster.topolvm.io) blocks deletion
+2. Gate 1: Check for active PVCs using LVMS StorageClasses
+   └── If found → block, requeue
+3. Gate 2: Check for Retain-policy PVs
+   └── If found → block, requeue
+4. processDelete: delete subordinate resources
+5. For each LVMVolumeGroup:
+   a. Each VG Manager removes its per-node finalizer after cleanup:
+      - Delete thin pool LV
+      - Remove VG (vgremove)
+      - Remove PVs (pvremove)
+      - Clean lvmd config
+   b. Once all per-node finalizers are removed, LVMVolumeGroup is deleted
+6. Stale node finalizer cleaner handles nodes that disappeared
+7. LVMCluster finalizer removed → LVMCluster deleted
+```
+
+If ReclaimPolicy=Retain and user logical volumes exist, VG Manager emits `ManualCleanupRequired` event and blocks cleanup.
+
+## Capacity and Scheduling
+
+How LVMS-aware scheduling works:
+
+1. VG Manager (via embedded TopoLVM node) sets capacity annotation on each Node: `capacity.topolvm.io/{deviceClassName}` = available bytes
+2. PVC created with LVMS StorageClass (WaitForFirstConsumer binding mode)
+3. Kubernetes scheduler uses TopoLVM's topology-aware scheduling to pick a node with sufficient capacity
+4. TopoLVM controller creates LogicalVolume CR targeting that node
+5. VG Manager provisions the LVM LV via TopoLVM node plugin
+6. PVC controller checks pending PVCs — if no node has enough capacity, emits `NotEnoughCapacity` warning event on the PVC

--- a/docs/domain/glossary.md
+++ b/docs/domain/glossary.md
@@ -1,0 +1,91 @@
+# LVMS Domain Glossary
+
+Canonical LVMS terminology. Each term maps to a Go type or CRD field. For architecture, see [architecture.md](../architecture.md). For concept relationships, see [concepts.md](concepts.md). For design principles, see [core-beliefs.md](../core-beliefs.md).
+
+## LVMCluster
+
+The primary user-facing CR (`api/v1alpha1/lvmcluster_types.go`). Defines device classes, tolerations, and the desired storage configuration. Singleton — only one per cluster. Creates all subordinate resources (see [concepts.md § Resource Flow](concepts.md#resource-flow)).
+
+**Gotcha:** CRs created outside `openshift-lvm-storage` namespace bypass webhook validation and are silently ignored.
+
+## DeviceClass
+
+A named storage tier within an LVMCluster (`DeviceClass` struct). Maps 1:1 to an LVMVolumeGroup CR, a VolumeGroup on each matching node, a StorageClass (`lvms-{name}`), and optionally a VolumeSnapshotClass. Name must be a DNS-1123 label (lowercase, `[a-z0-9]([-a-z0-9]*[a-z0-9])?`).
+
+**Gotcha:** The name flows into StorageClass, VolumeSnapshotClass, VG, and capacity annotation names — renaming is a breaking change. ThinPoolConfig and RAIDConfig are mutually exclusive.
+
+## DeviceSelector
+
+Rules for discovering block devices (`DeviceSelector` struct). `Paths` = mandatory (all must resolve on each node). `OptionalPaths` = optional (at least one must resolve). `ForceWipeDevicesAndDestroyAllData` = explicit wipe opt-in (see [core-beliefs.md § Safety-First](../core-beliefs.md#safety-first-lvm-operations)).
+
+**Gotcha:** Nil DeviceSelector = "greedy mode" — permanent, cannot add explicit paths later (see [core-beliefs.md § Greedy Mode](../core-beliefs.md#greedy-mode-is-permanent)). Multi-DeviceClass always requires explicit DeviceSelector. Stable paths (`/dev/disk/by-id/` or `/dev/disk/by-path/`) recommended over kernel names (`/dev/sda`).
+
+## DeviceDiscoveryPolicy
+
+Controls whether VG Manager continuously discovers new devices or locks to install-time devices (`DeviceDiscoveryPolicySpec` at `lvmvolumegroupnodestatus_types.go`).
+
+**Spec values:** `Static` (locked after VG creation) or `Dynamic` (continuous 30s discovery).
+
+**Status values:** `Preconfigured` (explicit DeviceSelector paths override policy), `RuntimeStatic`, `RuntimeDynamic`.
+
+**Gotcha — known inconsistency:** The controller defaults nil to Dynamic (`ptr.Deref(policy, Dynamic)`), but the API godoc and webhook warning text say "new volume groups will default to Static mode." The controller behavior (Dynamic) is what actually executes; the godoc/webhook describe unimplemented or intended-but-missing logic. RAID overrides to Static regardless of spec. In Static mode, if the VG already exists, newly discovered devices are excluded. With explicit device paths, the spec policy is ignored — status always reports Preconfigured. Set the policy explicitly to avoid ambiguity.
+
+## VolumeGroup (LVM concept)
+
+The LVM volume group on a node (`lvm.VolumeGroup` struct at `lvm/lvm.go`). Created via `vgcreate`, extended via `vgextend`. Name equals the DeviceClass name. All LVMS-managed VGs are tagged with `@lvms` (see below).
+
+**Gotcha:** This is NOT a Kubernetes resource — do not confuse with LVMVolumeGroup (the CR). VG size is reported as a string in bytes with no suffix. A VG is valid even with zero physical volumes.
+
+## ThinPoolConfig
+
+Optional thin provisioning on a DeviceClass (`ThinPoolConfig` struct). `SizePercent` (default 90, range 10–100). `OverprovisionRatio` (required, range 1–100). `ChunkSizeCalculationPolicy` (Static or Host). `MetadataSize` (2Mi–16Gi). See [design/thin-provisioning.md](../design/thin-provisioning.md).
+
+**Gotcha:** Mutually exclusive with RAIDConfig. Enables VolumeSnapshotClass creation. `Host` policy means the node's lvm2 decides chunk/metadata size — the spec value is ignored.
+
+## RAIDConfig
+
+Native LVM RAID on a DeviceClass (`RAIDConfig` struct). `Type` = raid1/raid4/raid5/raid6/raid10. `Mirrors` (raid1/raid10 only). `Stripes` (raid4/5/6/10). `StripeSize` (power of 2, default 64Ki). See [design/raid-support.md](../design/raid-support.md) and [core-beliefs.md § RAID Constraints](../core-beliefs.md#raid-constraints).
+
+**Gotcha:** Entire struct is immutable after creation. Uses thick provisioning — no snapshot/clone support. Minimum device counts: raid1 = mirrors+1, raid4/5 = stripes+1, raid6 = stripes+2, raid10 = 2*(mirrors+1). Day-2 device replacement uses `optionalPaths`.
+
+## StorageClassOptions
+
+LVMS-managed StorageClass properties on a DeviceClass (`StorageClassOptions` struct). `ReclaimPolicy` (default Delete, immutable). `VolumeBindingMode` (default WaitForFirstConsumer, immutable). `AdditionalParameters` (immutable, max 16). `AdditionalLabels` (mutable, max 16). See [concepts.md § StorageClass Lifecycle](concepts.md#storageclass-lifecycle).
+
+**Gotcha:** LVMS-owned keys (`topolvm.io/device-class`, `csi.storage.k8s.io/fstype`) are silently overwritten after user values are copied (merge order matters). `AdditionalLabels` is the only mutable field. ReclaimPolicy=Retain blocks LVMCluster deletion if PVs exist.
+
+## FilesystemType
+
+Filesystem for logical volumes (`DeviceFilesystemType` string). Values: `xfs` (default) or `ext4`. Set as `csi.storage.k8s.io/fstype` on the StorageClass. Immutable after creation.
+
+## LVMVolumeGroup
+
+Internal CR created 1:1 per DeviceClass (`api/v1alpha1/lvmvolumegroup_types.go`). Mirrors DeviceClass fields. Watched by VG Manager. See [architecture.md § CRD Relationships](../architecture.md#crd-relationships).
+
+**Gotcha:** Users should never create these directly — has no admission webhook, so manual creation bypasses all LVMCluster validation. Status is NOT on this object; it's on LVMVolumeGroupNodeStatus. Per-node finalizer `cleanup.vgmanager.node.topolvm.io/{nodeName}` added by each VG Manager instance.
+
+## LVMVolumeGroupNodeStatus
+
+Per-node CR reporting actual VG state (`api/v1alpha1/lvmvolumegroupnodestatus_types.go`). Named after the node. Contains `Spec.LVMVGStatus` (JSON tag: `nodeStatus`) — a list of VGStatus entries, one per VG on that node.
+
+**Gotcha:** The real status data is in `.Spec.LVMVGStatus`, not `.Status` (which is empty). This is an API design artifact. Dual ownership: LVMCluster as controller owner (deletion propagation) + LVMVolumeGroup as non-controller owner (multi-VG support).
+
+## VGStatus
+
+Per-VG status within LVMVolumeGroupNodeStatus (`VGStatus` struct). `Status` uses `VGStatusType`: Progressing, Ready, Failed, Degraded. Includes `Devices` (active PV paths), `Excluded` (filtered devices with reasons), `RAIDStatus`.
+
+**Gotcha:** Failed automatically promotes to Degraded if the VG has existing devices — Failed is for new creations, Degraded is for existing VGs with active data.
+
+## LogicalVolume
+
+TopoLVM CR (vendored from `github.com/openshift/topolvm`). Created by TopoLVM controller when PVCs are provisioned. LVMS does not create these — only interacts during cleanup (removing stale finalizers for deleted nodes).
+
+## ForceWipeDevicesAndDestroyAllData
+
+Explicit wipe opt-in flag on DeviceSelector (`*bool`). See [core-beliefs.md § Safety-First](../core-beliefs.md#safety-first-lvm-operations) for the triple opt-in requirement.
+
+## The @lvms Tag
+
+LVM tag on every LVMS-managed VG (`lvm.DefaultTag` in `internal/controllers/vgmanager/lvm/lvm.go`). `ListVGs(ctx, true)` returns only tagged VGs.
+
+**Gotcha:** If a VG exists with the right name but no tag, VG Manager won't find it. Manual fix: `vgchange {name} --addtag @lvms` on the node.


### PR DESCRIPTION
## Summary

Adds domain documentation that captures LVMS-specific knowledge beyond what's in Go types or CRD YAML. Part of the Agentic SDLC MVP ([OCPEDGE-2508](https://redhat.atlassian.net/browse/OCPEDGE-2508)) — completing Track 1 Contextification alongside [PR #2688](https://github.com/openshift/lvm-operator/pull/2688).

Agents can read Go struct definitions but miss the relationships, constraints, and gotchas between LVMS concepts. These docs bridge that gap.

### New files

- **`docs/domain/glossary.md`** — 15 canonical LVMS terms (LVMCluster, DeviceClass, DeviceSelector, VolumeGroup, ThinPoolConfig, RAIDConfig, StorageClassOptions, FilesystemType, LVMVolumeGroup, LVMVolumeGroupNodeStatus, VGStatus, LogicalVolume, ForceWipeDevicesAndDestroyAllData, @lvms tag). Each term includes the Go type reference, relationships to other terms, constraints, and common gotchas.

- **`docs/domain/concepts.md`** — How LVMS concepts relate:
  - Resource flow: LVMCluster → DeviceClass → VG → ThinPool → LV → PV → PVC
  - Device filter chain: 7 filters with pass/reject logic
  - Reconciliation flow: LVMCluster controller (1min) and VG Manager (30s) loops
  - CRD relationships: ownership hierarchy and finalizer structure
  - StorageClass lifecycle: SSA creation with field ownership
  - Deletion flow: gates, finalizer cleanup, ManualCleanupRequired
  - Capacity and scheduling: TopoLVM topology-aware scheduling

### Modified

- **`AGENTS.md`** — Added glossary and concepts to documentation index

### Review guidance

- Are the 15 term definitions accurate? Do they match your understanding?
- Are there missing terms that agents would need?
- Do the concept relationship diagrams match the current reconciliation flow?

Jira: [OCPEDGE-2766](https://redhat.atlassian.net/browse/OCPEDGE-2766)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an LVMS domain glossary with canonical terminology and mappings to user configuration and reported status.
  * Added a concepts guide explaining how LVMS resources flow from `LVMCluster` down to node-level LVM artifacts, including the reconciliation loops and requeue behavior.
  * Documented device selection/filtering logic, including how excluded devices are reported, plus StorageClass generation and scheduling/capacity behavior.
  * Updated the documentation index to include the new domain pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->