### PR TITLE
NO-JIRA: fix contextification doc accuracy issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Paths []string `json:"paths,omitempty"`
 This operator manages physical storage and performs destructive LVM operations. See [docs/core-beliefs.md](docs/core-beliefs.md) for non-negotiable invariants and [docs/conventions/](docs/conventions/) for implementation patterns.
 
 - **Data loss risk**: LVM operations can wipe disks. Verify device selectors carefully in tests.
-- **Idempotency**: controllers must handle partial states and retries safely. VG Manager reconciles every 30 seconds.
+- **Idempotency**: controllers must handle partial states and retries safely. VG Manager requeue interval depends on configuration (RAID/Dynamic: 30s periodic; Static with explicit paths: no periodic requeue).
 - **Finalizers**: LVMS uses a three-level finalizer hierarchy to prevent orphaned storage. Never skip finalizer logic. See [docs/architecture.md](docs/architecture.md) for details.
 - **Privileged operations**: VG Manager runs as a privileged DaemonSet and executes LVM commands (`vgcreate`, `vgextend`, `lvcreate`, `wipefs`) directly on nodes.
 
@@ -87,7 +87,7 @@ E2E tests are in `test/e2e/` and require a live cluster with available block dev
 |------|----------|
 | `api/v1alpha1/` | CRD type definitions and webhook validation |
 | `cmd/` | Binary entrypoints (operator and vgmanager subcommands) |
-| `internal/controllers/` | Reconcilers: lvmcluster, vgmanager, persistent-volume, node removal |
+| `internal/controllers/` | Reconcilers: lvmcluster, vgmanager, persistent-volume, persistent-volume-claim, node removal |
 | `internal/controllers/lvmcluster/resource/` | Resource managers (DaemonSet, StorageClass, CSIDriver, etc.) |
 | `config/` | Kustomize overlays, CRD manifests, RBAC, samples |
 | `test/e2e/` | End-to-end test suite |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,7 +40,7 @@ When a user creates an `LVMCluster` CR, the operator drives the system through t
 2. **VG Manager** (running as a privileged DaemonSet on each matching node) watches for `LVMVolumeGroup` CRs, discovers block devices matching the device selector, creates LVM physical volumes and volume groups, and optionally provisions thin pools.
 3. **Status reporting**: each VG Manager instance creates or updates an `LVMVolumeGroupNodeStatus` CR reflecting the volume group state on its node. The LVMCluster controller aggregates these to set the cluster-level status.
 
-The VG Manager reconciles every 30 seconds, making device discovery and volume group management eventually consistent.
+VG Manager periodic reconciliation depends on the configuration: RAID device classes requeue every 30 seconds for health monitoring, Dynamic discovery policy requeues every 30 seconds for device discovery, and explicit device paths with Static policy do not periodically requeue. The LVMCluster controller requeues every 1 minute unconditionally.
 
 ## Data Flow: PVC to Logical Volume
 
@@ -57,12 +57,12 @@ When a workload requests storage via a `PersistentVolumeClaim` using an LVMS `St
 ```
 LVMCluster (user-facing, singleton per namespace)
  └── LVMVolumeGroup (internal, one per device class)
-      └── LVMVolumeGroupNodeStatus (internal, one per node per device class)
+      └── LVMVolumeGroupNodeStatus (internal, one per node, contains per-VG status entries)
 ```
 
 - **LVMCluster**: the only CR users create directly. Defines device classes, device selectors, thin pool configuration, and node selectors. Only one LVMCluster is supported per cluster.
 - **LVMVolumeGroup**: created and managed by the LVMCluster controller. Represents a single volume group definition. Users do not create these directly.
-- **LVMVolumeGroupNodeStatus**: created by VG Manager on each node. Reports the actual state of the volume group including device list, excluded devices, and (if configured) RAID health status.
+- **LVMVolumeGroupNodeStatus**: created by VG Manager on each node (named after the node). Contains a list of `VGStatus` entries — one per volume group on that node — reporting device list, excluded devices, and (if configured) RAID health status. Note: the status data is in `.Spec.LVMVGStatus`, not `.Status`.
 
 ## API Version: v1alpha1
 
@@ -95,7 +95,7 @@ Due to OLM constraints, the webhook is scoped to the operator namespace (`opensh
 
 - **DaemonSet for node operations**: VG Manager runs as a privileged DaemonSet rather than using a Job-based model. This allows continuous device monitoring and idempotent reconciliation without scheduling overhead.
 - **Thin provisioning by default**: all volume groups use thin pools to enable snapshot and clone support. This introduces the thin/RAID flag conflict that prevents native LVM RAID (see README Known Limitations).
-- **Embedded lvmd**: the lvmd gRPC daemon from TopoLVM runs in-process within VG Manager, configured via a `lvmd.yaml` ConfigMap that VG Manager watches for changes.
+- **Embedded lvmd**: the lvmd gRPC daemon from TopoLVM runs in-process within VG Manager, configured via a file-based config at `/etc/topolvm/lvmd.yaml` on the host filesystem (a ConfigMap approach was tried and reverted — see [ADR-0009](decisions/0009-configmap-for-lvmd-config.md)).
 - **Node removal controller**: a dedicated controller watches for node deletions and cleans up orphaned `LVMVolumeGroupNodeStatus` resources, preventing stale status from accumulating.
 
 ## Further Reading

--- a/docs/conventions/reconciliation.md
+++ b/docs/conventions/reconciliation.md
@@ -11,7 +11,7 @@ For design principles, see [core-beliefs.md](../core-beliefs.md). For architectu
 - Rely on Kubernetes optimistic concurrency (`resourceVersion` conflicts) for concurrent status updates from multiple VG Manager pods. (#72)
 - Don't use `errgroup` — it cancels context on first error. Use raw goroutines with a results channel and `errors.Join`. (#391)
 - After wiping devices, return early. Let the next reconcile re-list — immediate re-listing returns stale data. (#778)
-- Both controllers currently requeue periodically on success (LVMCluster at 1min, VGManager at 30s). This was debated in PR #898 — qJkee objected to unconditional requeue but it remains as a safety net for missed watch events. (#898)
+- LVMCluster requeues every 1 minute unconditionally on success. VG Manager requeue is conditional: RAID device classes requeue every 30s (health monitoring), Dynamic discovery requeues every 30s, and explicit paths with Static policy do not periodically requeue. (#898)
 - Don't fail-fast on multi-node operations. Continue for healthy nodes, aggregate errors. Defer error checks past loops when early failure would penalize healthy nodes. (#898)
 - Platform detection (OpenShift vs K8s) runs once at startup by checking the Infrastructure API (`internal/cluster/type.go`). MicroShift is detected via the `microshift-version` ConfigMap if Infrastructure API is unavailable. `IsNotFound`/`IsNoMatchError` are non-fatal; other detection errors are fatal at startup. (#38, #399)
 - RBAC must include `watch`+`list` verbs even when not explicitly watching — controller-runtime informer cache requires them. (#45)

--- a/docs/decisions/0010-server-side-apply-for-storageclassoptions.md
+++ b/docs/decisions/0010-server-side-apply-for-storageclassoptions.md
@@ -18,7 +18,7 @@ The previous StorageClass reconciliation used `CreateOrUpdate` with a mutate fun
 
 * Users must be able to set additional StorageClass parameters and labels without LVMS overwriting them.
 * LVMS must maintain ownership of critical parameters (`topolvm.io/device-class`, `csi.storage.k8s.io/fstype`) and managed labels — user values must never override these.
-* Day-2 changes (adding/removing parameters, toggling default SC annotation) must reconcile without requiring StorageClass deletion and recreation.
+* Day-2 changes (modifying `AdditionalLabels`, toggling default SC annotation) must reconcile without requiring StorageClass deletion and recreation. Note: `AdditionalParameters` is immutable after creation (CEL); only `AdditionalLabels` can be changed day-2.
 * Immutability of critical fields (reclaimPolicy, volumeBindingMode, fstype) must be enforced at the API level.
 
 ## Considered Options

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -49,7 +49,7 @@ $ lsblk --paths --json -o NAME,ROTA,TYPE,SIZE,MODEL,VENDOR,RO,STATE,KNAME,SERIAL
 6. **Devices with Bind Mounts:**
     - *Condition:* Devices with bind mounts are unsupported.
     - *Why:* Managing logical volumes becomes more complex when dealing with devices that have bind mounts, potentially causing conflicts or difficulties in maintaining the integrity of the logical volume setup.
-    - *Filter:* `cat /proc/1/mountinfo | grep <device-name>` returns mount points for the device in the 4th or 10th field.
+    - *Note:* No automated filter exists for bind mounts in the current filter chain. Users must avoid specifying bind-mounted devices in their DeviceSelector.
 
 7. **ROM Devices:**
     - *Condition:* Devices of type `rom` are unsupported.


### PR DESCRIPTION
## Summary

Fixes 7 accuracy issues found by an external line-by-line audit of all contextification docs against current source code.

### Fixes

1. **architecture.md — lvmd ConfigMap claim**: Said "configured via a lvmd.yaml ConfigMap." Code uses file-based config at `/etc/topolvm/lvmd.yaml` (ConfigMap approach was reverted in PR #566, correctly documented in ADR-0009, but architecture.md still had the stale claim).

2. **"VG Manager reconciles every 30 seconds" — stale in 3 files**: AGENTS.md, architecture.md, reconciliation.md. VG Manager requeue is now conditional: RAID/Dynamic = 30s periodic; Static + explicit paths = no periodic requeue (`determineFinishedRequeue` in controller.go).

3. **architecture.md — NodeStatus cardinality**: Said "one per node per device class." Actually one per node (named after node), containing a list of per-VG status entries.

4. **known-limitations.md — bind-mount filter**: Described a `/proc/1/mountinfo` filter mechanism that does not exist in the filter chain (7 filters, none for bind mounts). Updated to note this is a user responsibility, not automated.

5. **AGENTS.md — missing controller**: Key Directories omitted `persistent-volume-claim` controller.

6. **[ADR-0010](https://redhat.atlassian.net/browse/ADR-0010) — additionalParameters mutability**: Decision drivers read as if additionalParameters are day-2 mutable. They are immutable after creation (CEL `oldSelf == self`). Only AdditionalLabels is mutable.

### Not fixed in this PR (needs team discussion)

**DeviceDiscoveryPolicy nil-default contradiction**: Controller defaults nil to Dynamic (`ptr.Deref(policy, Dynamic)`), but API godoc and webhook warning say "new VGs default to Static." The code, its own documentation, and the webhook text disagree. This is a code-internal contradiction that needs a Jira ticket and team decision, not a doc fix.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified reconciliation timing so users can see when updates happen automatically versus conditionally.
  * Updated storage class guidance to note which settings can be changed without recreating resources and which are fixed after creation.
  * Refined known limitations for device selection, including that bind-mounted devices must be avoided.
  * Improved architecture and safety notes to better describe status handling, retry behavior, and controller coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->