### PR TITLE
OCPEDGE-2776: feat(agents): add agentic harness foundation with safety guardrails

### DIFF
--- a/.claude/commands/modify-crd.md
+++ b/.claude/commands/modify-crd.md
@@ -1,0 +1,59 @@
+# CRD Modification Workflow
+
+Follow these steps when modifying CRD types. Do not skip steps.
+
+## 1. Edit Type Definition
+
+Edit the relevant type in `api/v1alpha1/*_types.go`:
+- Add godoc comments for all new fields
+- Use pointer types (`*StructType`) for optional structs
+- New fields must be optional with `omitempty`
+- `nil` means "upgraded from before this field existed"
+
+## 2. Add Kubebuilder Markers
+
+Add validation, default, and documentation markers:
+```go
+// +optional
+// +kubebuilder:validation:Optional
+FieldName *string `json:"fieldName,omitempty"`
+```
+
+For immutable fields, add CEL validation:
+```go
+// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="fieldName is immutable"
+```
+
+**Gotcha**: CEL transition rules are skipped when `oldSelf` doesn't exist (new field on upgrade). Add `+kubebuilder:default={}` on optional structs with immutable sub-fields.
+
+## 3. Regenerate
+
+```bash
+make generate    # updates zz_generated.deepcopy.go
+make manifests   # regenerates config/crd/bases/ and RBAC
+make bundle      # regenerates OLM bundle manifests
+make catalog     # regenerates OLM catalog
+```
+
+Never edit generated files directly.
+
+## 4. Update Controller Logic
+
+Add handling for the new field in the relevant controller under `internal/controllers/`.
+
+## 5. Add Webhook Validation
+
+If the field needs cross-field validation, add it to the webhook in `api/v1alpha1/lvmcluster_webhook.go`. Safety-critical constraints must be validated at webhook AND controller.
+
+## 6. Add Tests
+
+- Unit test: validation logic and controller behavior
+- E2E test: if the change affects user-facing workflows
+
+## 7. Verify
+
+```bash
+make test        # unit tests pass
+make verify      # formatting and generated files are clean
+make lint        # no linter violations
+```

--- a/.claude/commands/new-adr.md
+++ b/.claude/commands/new-adr.md
@@ -1,0 +1,52 @@
+# Create a New ADR
+
+## 1. Determine the Next Number
+
+```bash
+ls docs/decisions/[0-9]*.md | sort | tail -1
+```
+
+Use the next sequential number (e.g., if last is 0012, use 0013).
+
+## 2. Create the File
+
+Copy the template:
+```bash
+cp docs/decisions/adr-template.md docs/decisions/NNNN-short-slug.md
+```
+
+## 3. Fill the Frontmatter
+
+```yaml
+---
+status: proposed
+date: YYYY-MM-DD
+decision-makers: [your name]
+consulted: [team members consulted]
+informed: [stakeholders informed]
+---
+```
+
+## 4. Write the ADR
+
+Fill in all sections:
+- **Context and Problem Statement**: what decision needs to be made and why
+- **Decision Drivers**: constraints and priorities
+- **Considered Options**: at least 2 concrete alternatives
+- **Decision Outcome**: chosen option with justification
+- **Consequences**: good and bad, be honest about tradeoffs
+
+## 5. Update the Index
+
+Add a row to the table in `docs/decisions/index.md`:
+
+```markdown
+| [NNNN](NNNN-short-slug.md) | Title | Proposed | YYYY-MM-DD |
+```
+
+## 6. Commit
+
+```bash
+git add docs/decisions/NNNN-short-slug.md docs/decisions/index.md
+git commit -m "docs: add ADR NNNN — short title"
+```

--- a/.claude/commands/run-e2e.md
+++ b/.claude/commands/run-e2e.md
@@ -1,0 +1,55 @@
+# E2E Test Execution
+
+## Prerequisites
+
+1. Verify cluster access:
+```bash
+oc whoami
+oc get nodes
+```
+
+2. Check for available block devices or set up loop devices:
+```bash
+lsblk
+```
+
+If no spare block devices, see [docs/loop-devices.md](../../docs/loop-devices.md) for loop device setup.
+
+## Deploy
+
+```bash
+make deploy
+```
+
+Wait for the operator pod to be ready:
+```bash
+oc get pods -n openshift-lvm-storage -w
+```
+
+## Run Tests
+
+```bash
+make e2e
+```
+
+## Validation Order
+
+E2E tests validate in reconciliation order:
+1. LVMCluster CR created and conditions progressing
+2. CSI Driver registered
+3. CSINodeInfo populated
+4. VG Manager DaemonSet ready on target nodes
+5. LVMVolumeGroup status reflects volume groups
+6. StorageClass created with correct parameters
+7. VolumeSnapshotClass created (if snapshot testing enabled)
+
+## Cleanup
+
+```bash
+make undeploy
+```
+
+If LVMCluster is stuck deleting, check finalizers:
+```bash
+oc get lvmcluster -o yaml | grep finalizers -A 5
+```

--- a/.claude/rules/api-types.md
+++ b/.claude/rules/api-types.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "api/v1alpha1/**"
+description: CRD modification workflow and validation conventions
+---
+
+## CRD Change Workflow
+
+Use `/modify-crd` for the full step-by-step workflow. Never edit `zz_generated*.go` or `config/crd/bases/` directly.
+
+## API Rules
+
+- `v1alpha1` is the stable production API — treat as stable despite the name
+- New fields must be optional (`+optional`, pointer type, `omitempty`)
+- `nil` means "upgraded from before this field existed" — default to backward-compatible behavior
+- Use `*StructType` for optional structs to enable nil-checking
+- Required fields cannot have `omitempty`
+- Status values must be typed constants, not bare strings
+
+## Validation
+
+- Safety-critical constraints: validate at CRD schema (markers), webhook, AND controller
+- Non-safety validation: webhook only, don't duplicate in controller
+- Validation functions must not mutate or cause side effects
+- Objects in webhook handlers are guaranteed non-nil — no nil-check needed
+- Use kubebuilder markers from the start for new config structures
+
+## Gotcha: CEL XValidation Nil Bypass
+
+Transition rules (`oldSelf == self`) are silently skipped when `oldSelf` does not exist (field added in upgrade). Fix: add `+kubebuilder:default={}` on optional struct fields with immutable sub-fields, plus a webhook guard for upgrades.
+
+Full conventions: [docs/conventions/api-and-validation.md](../../docs/conventions/api-and-validation.md)

--- a/.claude/rules/reconciliation.md
+++ b/.claude/rules/reconciliation.md
@@ -1,0 +1,40 @@
+---
+paths:
+  - "internal/controllers/**"
+description: Reconciliation patterns, ownership, and finalizer conventions
+---
+
+## MutateFn Convention
+
+- Construct desired resource state in the constructor
+- Use MutateFn to set mutable fields updated on both create and update paths
+- For immutable resources (CSIDriver): MutateFn body is `return nil`
+
+## Ownership and Finalizers
+
+- Three-level finalizer hierarchy: LVMCluster → LVMVolumeGroup → LVMVolumeGroupNodeStatus
+- Cluster-scoped resources use labels for ownership (OwnerReferences don't work cross-namespace)
+- `Delete` only sets `DeletionTimestamp` — finalizers gate actual deletion
+- Non-blocking delete + finalizer removal is the correct teardown pattern (`--wait=true` deadlocks)
+- Resource deletion must be idempotent
+
+## Error Handling
+
+- Don't use `errgroup` — it cancels context on first error. Use raw goroutines + `errors.Join`
+- Don't fail-fast on multi-node operations — aggregate errors, continue for healthy nodes
+- Don't check `errors.IsAlreadyExists` after `CreateOrUpdate` — that error is never returned
+- Rely on Kubernetes optimistic concurrency for concurrent status updates
+
+## Status and Conditions
+
+- Use upstream `meta/v1.Condition` and `meta.SetStatusCondition`/`meta.FindStatusCondition`
+- Initialize conditions at creation, then modify — don't recompute from scratch every reconcile
+- Recompute state from conditions, not only on failure. Add Unknown as default for in-progress
+- LVMCluster Ready: only set when all expected VGs are reconciled. Failed > Degraded > Ready
+
+## RBAC
+
+- RBAC must include `watch`+`list` verbs — controller-runtime informer cache requires them
+- Separate service accounts per workload with minimal RBAC
+
+Full conventions: [docs/conventions/reconciliation.md](../../docs/conventions/reconciliation.md)

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,43 @@
+---
+paths:
+  - "test/**"
+  - "**/*_test.go"
+description: Testing conventions for unit tests, integration tests, and E2E
+---
+
+## Test Naming
+
+- Describe reconciliation outcomes, not CRUD: "reconcile succeeds on creation" not "create LVMCluster"
+- Test names form readable sentences from Describe+It
+
+## Unit Tests
+
+- Fakeclient preferred over envtest for vgmanager tests
+- All system command execution through an Executor interface
+- Inject resolution functions alone, not full resolver objects
+- Use `go:embed` for YAML templates, not per-instance files
+- envtest has no garbage collection — verify ownerReferences, don't test cascade deletion
+
+## E2E Tests
+
+- `Eventually().WithContext(ctx).Should(Succeed())` for polling, not manual loops
+- `By()` for readable steps
+- `Consistently` for negative assertions (e.g., PVC stays Pending), not single check after sleep
+- Validate in reconciliation order: LVMCluster → CSI Driver → CSINodeInfo → VG Manager → LVMVolumeGroup → StorageClass → VolumeSnapshotClass
+- Pod images: busybox (not nginx/ubuntu). Test namespaces: `privileged` PSA enforcement
+- Assert on specific rejection reasons, not just that creation failed
+
+## Cleanup
+
+- Tests must clean up: explicit cleanup steps in test body AND defers
+- `deleteLVMClusterSafely` (strips finalizers) is acceptable in integration test defers as a safety net
+- For non-defer test steps, use `deleteSpecifiedResource` (normal operator cleanup path)
+- Stripping finalizers is never acceptable in controller/production code
+- After deleting a retained PV, clean up the underlying LogicalVolume CR
+
+## Build Integration
+
+- After `api/v1alpha1/` changes: `make generate && make manifests && make bundle && make catalog`
+- Split code changes and regenerated manifests into separate commits
+
+Full conventions: [docs/conventions/testing.md](../../docs/conventions/testing.md)

--- a/.claude/rules/vgmanager.md
+++ b/.claude/rules/vgmanager.md
@@ -1,0 +1,31 @@
+---
+paths:
+  - "internal/controllers/vgmanager/**"
+description: VG Manager safety rules, LVM command handling, and device filtering
+---
+
+## LVM Command Safety
+
+- All LVM commands accessing lvmdevices must run `AsHost` — not container-level privileges
+- Always pass `-Z y` to `lvcreate` for thin pools — never rely on host `lvm.conf` defaults
+- Always handle errors from LVM host commands — never silently swallow
+- Commands writing to both stdout and stderr must use `CombinedOutput` (`wipefs`/`dmsetup` race)
+- After wiping devices, return early — let the next reconcile re-list (immediate re-listing returns stale data)
+
+## Device Filtering
+
+- Conservative filtering: better to miss a valid device than wipe user data
+- Device wiping requires triple opt-in: DeviceSelector + `ForceWipeDevicesAndDestroyAllData` + per-node annotation
+- VG ownership determined by `@lvms` LVM tag — force-wipe eligibility is a separate check
+- Don't create PVs with `pvcreate` — pass raw devices to `vgcreate`/`vgextend`
+- Filter out VGs not created by the operator when iterating existing VGs
+- Compare symlink-resolved paths, not raw kname, for device filtering
+- Use lsblk `TYPE` field ('loop') not Major number for loop devices
+
+## Reconciliation
+
+- VG Manager reconciles every 30 seconds (poll-based, not event-driven for device changes)
+- VGManager must not report healthy until CSI driver registration is confirmed in kubelet
+- Don't fail-fast on multi-node operations — continue for healthy nodes, aggregate errors
+
+Full conventions: [docs/conventions/safety.md](../../docs/conventions/safety.md), [docs/conventions/reconciliation.md](../../docs/conventions/reconciliation.md)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,93 @@
+{
+  "permissions": {
+    "deny": [
+      "Edit(**/zz_generated*)",
+      "Write(**/zz_generated*)",
+      "Edit(config/crd/bases/**)",
+      "Write(config/crd/bases/**)",
+      "Edit(vendor/**)",
+      "Write(vendor/**)",
+      "Bash(wipefs *)",
+      "Bash(* wipefs *)",
+      "Bash(vgremove *)",
+      "Bash(* vgremove *)",
+      "Bash(pvremove *)",
+      "Bash(* pvremove *)",
+      "Bash(lvremove *)",
+      "Bash(* lvremove *)",
+      "Bash(mkfs *)",
+      "Bash(* mkfs *)",
+      "Bash(dd *)",
+      "Bash(* dd if=*)",
+      "Bash(* dd of=*)",
+      "Bash(rm -rf *)",
+      "Bash(* rm -rf *)"
+    ],
+    "allow": [
+      "Read(*)",
+      "Bash(make generate)",
+      "Bash(make manifests)",
+      "Bash(make mocks)",
+      "Bash(make bundle)",
+      "Bash(make catalog)",
+      "Bash(make build)",
+      "Bash(make test *)",
+      "Bash(make test)",
+      "Bash(make docker-test *)",
+      "Bash(make docker-test)",
+      "Bash(make e2e *)",
+      "Bash(make e2e)",
+      "Bash(make lint)",
+      "Bash(make verify)",
+      "Bash(make fmt)",
+      "Bash(make vet)",
+      "Bash(go test ./...)",
+      "Bash(go test -v ./...)",
+      "Bash(go test -count=* ./...)",
+      "Bash(go test -run * ./...)",
+      "Bash(go test -v -run * ./...)",
+      "Bash(go test -v -count=* ./...)",
+      "Bash(go test -count=* -run * ./...)",
+      "Bash(go test -v -count=* -run * ./...)",
+      "Bash(go vet ./...)",
+      "Bash(go build ./...)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.content // .tool_input.new_string // empty' < /dev/stdin | grep -qE '(sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|AKIA[A-Z0-9]{16}|-----BEGIN .*PRIVATE KEY-----)' && echo '🚫 Possible secret detected in edit. Review before proceeding.' >&2 && exit 2 || exit 0",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '⚠ API types modified. Run: make generate && make manifests && make bundle && make catalog'",
+            "if": "Edit(api/v1alpha1/*_types.go)"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FPATH=$(jq -r '.tool_input.file_path // empty' < /dev/stdin) && [ -n \"$FPATH\" ] && PKG=$(realpath --relative-to=. \"$(dirname \"$FPATH\")\" 2>/dev/null) && [ -n \"$PKG\" ] && go vet ./$PKG",
+            "if": "Edit({internal,api,cmd}/**/*.go)",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.cursor/rules/lvms.mdc
+++ b/.cursor/rules/lvms.mdc
@@ -1,0 +1,43 @@
+# Derived from AGENTS.md — keep in sync
+
+## Project
+
+LVM Operator (LVMS) — Kubernetes operator managing LVM volume groups for OpenShift.
+Single binary embedding TopoLVM CSI driver. Go, controller-runtime, OLM.
+
+## Safety Rules
+
+- Never edit generated files: `zz_generated*.go`, `config/crd/bases/`, `vendor/`
+- Never run destructive LVM commands: `wipefs`, `vgremove`, `pvremove`, `lvremove`, `mkfs`, `dd`
+- Always run `make generate && make manifests` after changing `api/v1alpha1/` types
+- Always run `make bundle && make catalog` after any change that affects CRDs, RBAC, config, or monitoring
+- Never skip finalizer logic — three-level hierarchy prevents orphaned storage
+
+## Build Commands
+
+- `make build` — compile
+- `make test` — unit tests
+- `make lint` — linters
+- `make verify` — formatting and generated file checks
+- `make generate` — update deepcopy after API changes
+- `make manifests` — regenerate CRD YAML and RBAC after API changes
+- `make bundle` — regenerate OLM bundle manifests
+- `make catalog` — regenerate OLM catalog
+
+## Key Conventions
+
+- Use MutateFn for mutable fields in CreateOrUpdate
+- Don't use errgroup — use raw goroutines with errors.Join
+- New optional fields: nil means "upgraded" — default to backward-compatible behavior
+- Conservative device filtering: better to miss a device than wipe data
+- Test descriptions describe outcomes, not CRUD operations
+
+## Key Directories
+
+- `api/v1alpha1/` — CRD types and webhook validation
+- `internal/controllers/` — reconcilers
+- `config/` — Kustomize overlays, CRD manifests, RBAC
+- `test/e2e/` — end-to-end tests
+- `docs/` — architecture, conventions, ADRs
+
+Full docs: see AGENTS.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,87 @@
+# Derived from AGENTS.md — keep in sync
+
+## Project
+
+LVM Operator (LVMS) — Kubernetes operator managing LVM volume groups for OpenShift.
+Single binary embedding TopoLVM CSI driver, optimized for edge/single-node clusters.
+
+Tech stack: Go, controller-runtime, OLM, Ginkgo/Gomega, Kustomize.
+
+## Build Commands
+
+- `make build` — compile the operator binary
+- `make test` — run unit tests
+- `make docker-test` — run unit tests inside a Linux container (useful for non-Linux hosts)
+- `make lint` — run linters
+- `make verify` — formatting and generated file checks
+- `make generate` — update deepcopy methods after API type changes
+- `make manifests` — regenerate CRD YAML and RBAC after API type changes
+- `make bundle` — regenerate OLM bundle manifests
+- `make catalog` — regenerate OLM catalog
+- `make e2e` — run end-to-end tests (requires live cluster)
+
+## Boundaries
+
+This operator manages physical storage. Mistakes destroy data.
+
+**Always do:**
+- Run `make generate && make manifests` after changing `api/v1alpha1/` types
+- Run `make bundle && make catalog` after any change that affects CRDs, RBAC, config, or monitoring
+- Run `make verify` before considering work complete
+- Use pointer types (`*StructType`) for optional API fields
+- Treat `nil` as "upgraded from before this field existed"
+
+**Ask first:**
+- Adding new dependencies to `go.mod`
+- Modifying webhook validation logic
+- Changing device selector behavior
+- Any schema migration or breaking API change
+
+**Never do:**
+- Edit generated files: `zz_generated*.go`, `config/crd/bases/`, `vendor/`
+- Run destructive LVM commands: `wipefs`, `vgremove`, `pvremove`, `lvremove`, `mkfs`, `dd`
+- Skip finalizer logic — three-level hierarchy prevents orphaned storage
+- Commit secrets, credentials, or personal registry references
+
+## CRD Modification Workflow
+
+1. Edit type definition in `api/v1alpha1/*_types.go`
+2. Add kubebuilder markers for validation, defaults, documentation
+3. Run `make generate` to update deepcopy methods
+4. Run `make manifests` to regenerate CRD YAML and RBAC
+5. Run `make bundle && make catalog` to regenerate OLM bundle and catalog
+6. Update or add controller logic
+7. Add unit tests for validation and controller behavior
+8. Add e2e tests if user-facing workflow changes
+
+## Key Directories
+
+| Path | Contents |
+|------|----------|
+| `api/v1alpha1/` | CRD type definitions and webhook validation |
+| `cmd/` | Binary entrypoints (operator and vgmanager subcommands) |
+| `internal/controllers/` | Reconcilers: lvmcluster, vgmanager, persistent-volume, node removal |
+| `internal/controllers/lvmcluster/resource/` | Resource managers (DaemonSet, StorageClass, CSIDriver, etc.) |
+| `config/` | Kustomize overlays, CRD manifests, RBAC, samples |
+| `test/e2e/` | End-to-end test suite |
+| `docs/` | Architecture, design, conventions, ADRs |
+
+## Commit Conventions
+
+```text
+component: short description
+
+Body explaining why, not what.
+
+Signed-off-by: Name <email>
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+- Type/component must not be empty
+- Max 72 characters per line
+- No full stop in header
+- Must be signed off (`-s`)
+
+## Documentation
+
+See [AGENTS.md](../AGENTS.md) for full agent guidance, documentation index, and deep links.

--- a/.github/instructions/api-types.instructions.md
+++ b/.github/instructions/api-types.instructions.md
@@ -1,0 +1,34 @@
+---
+applyTo: "api/v1alpha1/**"
+---
+# Derived from AGENTS.md — keep in sync
+
+## CRD Type Conventions
+
+- `v1alpha1` is the stable production API — name is historical
+- New fields must be optional: `+optional`, pointer type, `omitempty`
+- `nil` means "upgraded from before this field existed" — default to backward-compatible behavior
+- Use `*StructType` for optional structs to enable nil-checking
+- Required fields cannot have `omitempty`
+
+## After Editing Types
+
+Always run:
+```bash
+make generate    # updates zz_generated.deepcopy.go
+make manifests   # regenerates CRD YAML and RBAC
+make bundle      # regenerates OLM bundle manifests
+make catalog     # regenerates OLM catalog
+```
+
+Never edit `zz_generated*.go` or `config/crd/bases/` directly.
+
+## Validation
+
+- Safety-critical constraints: validate at CRD schema (markers), webhook, AND controller
+- Use kubebuilder markers from the start for new config structures
+- Validation functions must not mutate or cause side effects
+
+## CEL XValidation Gotcha
+
+Transition rules (`oldSelf == self`) are silently skipped when `oldSelf` doesn't exist. Fix: add `+kubebuilder:default={}` on optional struct fields with immutable sub-fields.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,21 +100,38 @@ This operator manages physical storage. Mistakes destroy data. See [docs/core-be
 - VG Manager requeue interval depends on configuration (RAID/Dynamic: 30s periodic; Static with explicit paths: no periodic requeue) — controllers must handle partial states and retries safely (idempotency)
 - Data loss from incorrect device selection is unrecoverable — verify device selectors carefully in tests
 
+## Path-Scoped Guidance
+
+Claude Code loads context-specific rules when you touch files in these areas:
+
+| Rule File | Triggered By | Content |
+|-----------|-------------|---------|
+| `.claude/rules/api-types.md` | `api/v1alpha1/**` | CRD workflow, validation markers, API version policy, CEL nil-bypass gotcha |
+| `.claude/rules/vgmanager.md` | `internal/controllers/vgmanager/**` | LVM command safety, filter chain, wipe eligibility |
+| `.claude/rules/reconciliation.md` | `internal/controllers/**` | MutateFn convention, ownership/finalizer rules, requeue patterns |
+| `.claude/rules/testing.md` | `test/**, **/*_test.go` | Ginkgo/Gomega conventions, E2E patterns, cleanup, envtest vs fakeclient |
+
+## Agent Skills
+
+Reusable multi-step workflows invocable as slash commands:
+
+| Skill | Command | Purpose |
+|-------|---------|---------|
+| CRD Modification | `/modify-crd` | Full CRD change workflow: types → markers → generate → manifests → bundle → controller → tests |
+| E2E Testing | `/run-e2e` | E2E test execution with cluster verification, loop devices, and cleanup |
+| New ADR | `/new-adr` | Create a new Architectural Decision Record from template |
+
+## Cross-Tool Compatibility
+
+This repo provides instruction files for multiple AI coding tools:
+
+- **Claude Code**: `CLAUDE.md` → `AGENTS.md`, `.claude/settings.json`, `.claude/rules/`, `.claude/commands/`
+- **GitHub Copilot**: `.github/copilot-instructions.md`, `.github/instructions/`
+- **Cursor**: `.cursor/rules/lvms.mdc`
+
 ## Testing
 
-Unit tests use Ginkgo/Gomega and are located alongside source files:
-
-```go
-var _ = Describe("LVMCluster Controller", func() {
-    Context("When reconciling a new LVMCluster", func() {
-        It("Should create the TopoLVM deployment", func() {
-            // Test implementation
-        })
-    })
-})
-```
-
-E2E tests are in `test/e2e/` and require a live cluster with available block devices. See [CONTRIBUTING.md](CONTRIBUTING.md) for build, deploy, and test commands. See [docs/conventions/testing.md](docs/conventions/testing.md) for testing conventions.
+Unit tests use Ginkgo/Gomega and are located alongside source files. E2E tests are in `test/e2e/` and require a live cluster with available block devices. See [CONTRIBUTING.md](CONTRIBUTING.md) for build, deploy, and test commands. See [docs/conventions/testing.md](docs/conventions/testing.md) for testing conventions.
 
 ## Key Directories
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,19 @@ This is the LVM Operator, part of LVMS (Logical Volume Manager Storage) for Open
 - [CONTRIBUTING.md](CONTRIBUTING.md) — build commands, testing, commit conventions, AI attribution
 - [Official product documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/storage/configuring-persistent-storage#persistent-storage-using-lvms)
 
+## Build Commands
+
+- `make build` — compile the operator binary
+- `make test` — run unit tests
+- `make docker-test` — run unit tests inside a Linux container (useful for non-Linux hosts)
+- `make lint` — run linters
+- `make verify` — formatting and generated file checks
+- `make generate` — update deepcopy methods after API type changes
+- `make manifests` — regenerate CRD YAML and RBAC after API type changes
+- `make bundle` — regenerate OLM bundle manifests
+- `make catalog` — regenerate OLM catalog
+- `make e2e` — run end-to-end tests (requires live cluster)
+
 ## Documentation Index
 
 | Document | Purpose |
@@ -37,9 +50,10 @@ When changing API types in `api/v1alpha1/`, follow this sequence:
 2. Add kubebuilder markers for validation, defaults, and documentation.
 3. Run `make generate` to update deepcopy methods.
 4. Run `make manifests` to regenerate CRD YAML and RBAC manifests.
-5. Update or add controller logic to handle the new field.
-6. Add unit tests for validation and controller behavior.
-7. Add e2e tests if the change affects user workflows.
+5. Run `make bundle && make catalog` to regenerate OLM bundle and catalog.
+6. Update or add controller logic to handle the new field.
+7. Add unit tests for validation and controller behavior.
+8. Add e2e tests if the change affects user workflows.
 
 ### Validation Markers
 
@@ -58,14 +72,33 @@ Paths []string `json:"paths,omitempty"`
 - New fields should be optional to maintain backward compatibility.
 - Breaking changes require migration support and careful review.
 
-## Safety Considerations
+## Boundaries
 
-This operator manages physical storage and performs destructive LVM operations. See [docs/core-beliefs.md](docs/core-beliefs.md) for non-negotiable invariants and [docs/conventions/](docs/conventions/) for implementation patterns.
+This operator manages physical storage. Mistakes destroy data. See [docs/core-beliefs.md](docs/core-beliefs.md) for non-negotiable invariants and [docs/conventions/](docs/conventions/) for implementation patterns.
 
-- **Data loss risk**: LVM operations can wipe disks. Verify device selectors carefully in tests.
-- **Idempotency**: controllers must handle partial states and retries safely. VG Manager requeue interval depends on configuration (RAID/Dynamic: 30s periodic; Static with explicit paths: no periodic requeue).
-- **Finalizers**: LVMS uses a three-level finalizer hierarchy to prevent orphaned storage. Never skip finalizer logic. See [docs/architecture.md](docs/architecture.md) for details.
-- **Privileged operations**: VG Manager runs as a privileged DaemonSet and executes LVM commands (`vgcreate`, `vgextend`, `lvcreate`, `wipefs`) directly on nodes.
+**Always do:**
+- Run `make generate && make manifests` after changing `api/v1alpha1/` types
+- Run `make bundle && make catalog` after any change that affects CRDs, RBAC, config, or monitoring
+- Run `make verify` before considering work complete
+- Use pointer types (`*StructType`) for optional API fields
+- Treat `nil` as "upgraded from before this field existed"
+
+**Ask first:**
+- Adding new dependencies to `go.mod`
+- Modifying webhook validation logic
+- Changing device selector behavior
+- Any schema migration or breaking API change
+
+**Never do:**
+- Edit generated files: `zz_generated*.go`, `config/crd/bases/`, `vendor/`
+- Run destructive LVM commands: `wipefs`, `vgremove`, `pvremove`, `lvremove`, `mkfs`, `dd`
+- Skip finalizer logic — three-level hierarchy prevents orphaned storage. See [docs/architecture.md](docs/architecture.md)
+- Commit secrets, credentials, or personal registry references
+
+**Key architecture facts:**
+- VG Manager runs as a privileged DaemonSet and executes LVM commands (`vgcreate`, `vgextend`, `lvcreate`, `wipefs`) directly on nodes
+- VG Manager requeue interval depends on configuration (RAID/Dynamic: 30s periodic; Static with explicit paths: no periodic requeue) — controllers must handle partial states and retries safely (idempotency)
+- Data loss from incorrect device selection is unrecoverable — verify device selectors carefully in tests
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,11 +260,43 @@ Signed-off-by: First_Name Last_Name <email address>
 
 We welcome contributions that use AI coding tools. The following conventions ensure transparency and maintain code quality.
 
+### Supported Tools
+
+This repo provides instruction files for multiple AI coding tools:
+
+| Tool | Instruction File | Scope |
+|------|-----------------|-------|
+| Claude Code | `CLAUDE.md` → `AGENTS.md` | Full guidance, safety rules, documentation index |
+| Claude Code | `.claude/settings.json` | Deny rules, allow rules, PostToolUse hooks |
+| Claude Code | `.claude/rules/` | Path-scoped rules (auto-loaded per file area) |
+| Claude Code | `.claude/commands/` | Reusable workflows: `/modify-crd`, `/run-e2e`, `/new-adr` |
+| GitHub Copilot | `.github/copilot-instructions.md` | Project overview, build commands, safety rules |
+| GitHub Copilot | `.github/instructions/` | Path-specific guidance for API types |
+| Cursor | `.cursor/rules/lvms.mdc` | Project overview, conventions, safety rules |
+All cross-tool files are derived from `AGENTS.md` (the single source of truth) and include a sync header.
+
+### Path-Scoped Rules (Claude Code)
+
+When you edit files in specific areas, Claude Code auto-loads relevant rules:
+
+- `api/v1alpha1/**` → CRD workflow, validation markers, CEL gotchas
+- `internal/controllers/vgmanager/**` → LVM command safety, device filtering
+- `internal/controllers/**` → MutateFn convention, ownership, finalizers
+- `test/**`, `**/*_test.go` → Ginkgo/Gomega conventions, E2E patterns
+
+### Agent Skills (Claude Code)
+
+Invoke these multi-step workflows as slash commands:
+
+- `/modify-crd` — full CRD change workflow from types through tests
+- `/run-e2e` — E2E test execution with cluster verification and cleanup
+- `/new-adr` — create a new Architectural Decision Record from template
+
 ### Attribution
 
 Commits that include AI-generated code must add a `Co-Authored-By:` trailer identifying the AI tool used:
 
-```
+```text
 component: commit title
 
 Description of the change.

--- a/docs/decisions/0001-single-binary-architecture.md
+++ b/docs/decisions/0001-single-binary-architecture.md
@@ -1,9 +1,9 @@
 ---
-status: draft
-date: Pre-2023
-decision-makers: LVMS team
-consulted:
-informed:
+status: accepted
+date: 2022-07-01
+decision-makers: Bulat Zamalutdinov
+consulted: LVMS team
+informed: OpenShift storage team
 ---
 
 # Single Binary Architecture for Edge Deployment
@@ -20,16 +20,27 @@ LVMS depends on TopoLVM and several CSI sidecar components. The standard Kuberne
 
 ## Considered Options
 
-<!-- LVMS team: please fill in the alternatives that were discussed when this decision was made. Was multi-container deployment ever seriously evaluated? What made the team rule it out? -->
-
-1. TBD — requires LVMS team input on what alternatives were discussed
-2. Single binary with embedded TopoLVM and CSI sidecars
+1. **Multi-container deployment** — run TopoLVM controller, CSI sidecars, and the operator as separate Deployments/DaemonSets, each with its own container image.
+2. **Single binary with embedded TopoLVM and CSI sidecars** — compile TopoLVM controllers directly into the operator and vg-manager binaries using Go's `replace` directive.
 
 ## Decision Outcome
 
-Chosen option: single binary. See [architecture.md](../architecture.md) for full rationale.
+Chosen option: "Single binary with embedded TopoLVM and CSI sidecars", because:
+
+- Fewer pods reduce resource overhead on constrained edge nodes.
+- Startup is faster with no inter-deployment dependency chain.
+- A single binary simplifies upgrades and rollback — one image to build, test, and ship.
+- Version skew between TopoLVM and the operator is eliminated at compile time.
+
+### Consequences
+
+* Good, because edge clusters use fewer resources and start faster.
+* Good, because there is no version skew between operator and CSI driver.
+* Bad, because upstream TopoLVM changes require a downstream fork (`github.com/openshift/topolvm`) with a `replace` directive, adding merge overhead.
+* Bad, because debugging requires understanding that `cmd/main.go` multiplexes `operator` and `vgmanager` subcommands into one cobra root.
 
 ## More Information
 
 * [docs/architecture.md](../architecture.md) — "Why LVMS Embeds TopoLVM" section
+* [docs/upstream.md](../upstream.md) — upstream contribution workflow
 * `cmd/main.go` — single cobra root with `operator` and `vgmanager` subcommands

--- a/docs/decisions/0002-v1alpha1-is-stable.md
+++ b/docs/decisions/0002-v1alpha1-is-stable.md
@@ -1,9 +1,9 @@
 ---
-status: draft
-date: Pre-2023
-decision-makers: LVMS team
-consulted:
-informed:
+status: accepted
+date: 2022-07-01
+decision-makers: Bulat Zamalutdinov
+consulted: LVMS team
+informed: OpenShift storage team
 ---
 
 # v1alpha1 as Stable Production API
@@ -20,16 +20,27 @@ LVMS ships its CRDs under `lvm.topolvm.io/v1alpha1`. The name suggests instabili
 
 ## Considered Options
 
-<!-- LVMS team: was v1beta1 or v1 ever concretely proposed? What specifically killed the idea — just cost, or other factors? -->
-
-1. TBD — requires LVMS team input on what alternatives were discussed
-2. Keep `v1alpha1` and treat as stable by convention
+1. **Promote to v1beta1 or v1** — introduce a new API version with a conversion webhook, run both versions during a migration window, then deprecate v1alpha1.
+2. **Introduce a v2 API** — redesign the API surface (formally proposed and rejected in ADR 0008).
+3. **Keep `v1alpha1` and treat as stable by convention** — document that the name is historical, enforce stability via CEL immutability markers and webhook validation.
 
 ## Decision Outcome
 
-Chosen option: keep `v1alpha1`. See [architecture.md](../architecture.md) for full rationale.
+Chosen option: "Keep `v1alpha1` and treat as stable by convention", because:
+
+- Migration to v1beta1/v1 requires conversion webhooks, storage version migration, and coordinated rollout across upstream TopoLVM and downstream OpenShift — cost not justified by any concrete need.
+- The v2 API proposal was formally rejected (ADR 0008) after analysis showed the redesign offered no user-facing benefit proportional to the migration effort.
+- CEL XValidation markers and webhook validation already enforce the immutability guarantees that a "stable" version label would imply.
+
+### Consequences
+
+* Good, because no migration effort is imposed on existing clusters.
+* Good, because immutability is enforced mechanically (CEL markers), not by version-label convention.
+* Bad, because the `v1alpha1` name confuses new contributors who expect instability.
+* Bad, because if a breaking change is ever needed, the migration path is more complex than if a versioning pattern had been established early.
 
 ## More Information
 
 * [docs/architecture.md](../architecture.md) — "API Version: v1alpha1" section
+* [ADR 0008](0008-v2-api-rejection.md) — formal rejection of v2 API proposal
 * `api/v1alpha1/lvmcluster_types.go` — immutability markers on production fields

--- a/docs/decisions/0003-finalizer-hierarchy.md
+++ b/docs/decisions/0003-finalizer-hierarchy.md
@@ -1,9 +1,9 @@
 ---
-status: draft
-date: Pre-2023
-decision-makers: LVMS team
-consulted:
-informed:
+status: accepted
+date: 2022-07-01
+decision-makers: Bulat Zamalutdinov
+consulted: LVMS team
+informed: OpenShift storage team
 ---
 
 # Three-Level Finalizer Hierarchy for Cleanup Safety
@@ -21,17 +21,28 @@ When an LVMCluster is deleted, LVMS must clean up LVM resources on every node. I
 
 ## Considered Options
 
-<!-- LVMS team: was a single finalizer on LVMCluster with a controller-driven cleanup loop considered? What problems did that approach have that led to the three-level design? -->
-
-1. TBD — requires LVMS team input on what alternatives were discussed
-2. Three-level finalizer hierarchy (LVMCluster → LVMVolumeGroup → LVMVolumeGroupNodeStatus)
+1. **Single finalizer on LVMCluster with controller-driven cleanup loop** — one finalizer on the top-level CR; the LVMCluster controller orchestrates cleanup by directly issuing LVM commands to each node (via Jobs or exec) and removing the finalizer when all nodes report clean.
+2. **Three-level finalizer hierarchy** — separate finalizers on LVMCluster, LVMVolumeGroup, and LVMVolumeGroupNodeStatus, each controller removing its own finalizer when its level of cleanup is complete.
 
 ## Decision Outcome
 
-Chosen option: three-level hierarchy. See [architecture.md](../architecture.md) for full rationale.
+Chosen option: "Three-level finalizer hierarchy", because:
+
+- A single-finalizer approach requires the central controller to have direct knowledge of every node's LVM state and the ability to execute commands on each node — violating the DaemonSet model where VG Manager owns node-local operations.
+- Per-node finalizers on LVMVolumeGroup (`cleanup.vgmanager.node.topolvm.io/{nodeName}`) let each VG Manager pod handle its own node's cleanup independently, naturally handling unreachable nodes (finalizer stays until the node comes back).
+- The LVMCluster finalizer blocks until PVCs are removed and Retain-policy PVs are cleaned up, emitting `ManualCleanupRequired` events — preventing silent data loss.
+
+### Consequences
+
+* Good, because cleanup is distributed — each node handles its own state without central coordination.
+* Good, because unreachable nodes don't block other nodes' cleanup — their finalizers remain until they recover.
+* Good, because Retain-policy PVs get explicit `ManualCleanupRequired` events instead of silent deletion.
+* Bad, because the three-level hierarchy is complex to reason about and debug when finalizers get stuck.
+* Bad, because orphaned LVMVolumeGroupNodeStatus resources required a dedicated cleanup controller (ADR 0006).
 
 ## More Information
 
 * [docs/architecture.md](../architecture.md) — "Cleanup and Finalizer Hierarchy" section
+* [ADR 0006](0006-orphaned-nodestatus-dedicated-controller.md) — dedicated controller for orphaned NodeStatus
 * `internal/controllers/lvmcluster/controller.go` — LVMCluster finalizer
 * `internal/controllers/vgmanager/controller.go` — per-node cleanup finalizer

--- a/docs/decisions/0004-conservative-device-filters.md
+++ b/docs/decisions/0004-conservative-device-filters.md
@@ -1,9 +1,9 @@
 ---
-status: draft
-date: Pre-2023
-decision-makers: LVMS team
-consulted:
-informed:
+status: accepted
+date: 2022-07-01
+decision-makers: Bulat Zamalutdinov
+consulted: LVMS team
+informed: OpenShift storage team
 ---
 
 # Conservative Device Discovery Filters
@@ -16,20 +16,30 @@ VG Manager discovers block devices on each node and decides which are safe for L
 
 * Data loss from incorrect selection is unrecoverable and can happen silently.
 * False negatives (missing a device) are recoverable via DeviceSelector. False positives (wiping data) are catastrophic.
-* `deviceMinAge` was later removed because time-based filtering gives false confidence.
+* `deviceMinAge` was later removed (ADR 0005) because time-based filtering gives false confidence.
 
 ## Considered Options
 
-<!-- LVMS team: was a permissive-by-default approach (include all, exclude known-bad) ever considered? What drove the decision toward conservative filtering? -->
-
-1. TBD — requires LVMS team input on what alternatives were discussed
-2. Conservative filtering (exclude by default, include only known-safe patterns)
+1. **Permissive-by-default (include all, exclude known-bad)** — start with all block devices visible to lsblk, then filter out devices matching known-bad patterns (mounted filesystems, partitions, read-only, already in a VG). Unknown devices are included.
+2. **Conservative filtering (exclude by default, include only known-safe)** — start with no devices, then include only devices that pass all filters in a chain: not mounted, not read-only, no filesystem signature, no partitions, not in use by Kubernetes, not already in a non-LVMS VG.
 
 ## Decision Outcome
 
-Chosen option: conservative filtering. See [known-limitations.md](../known-limitations.md) for the full filter chain documentation.
+Chosen option: "Conservative filtering", because:
+
+- With physical storage, the cost asymmetry is extreme: wiping a disk with user data is catastrophic and unrecoverable, while missing a valid device is easily fixed by adding it to DeviceSelector.
+- A permissive default would require maintaining an exhaustive blocklist of every possible "bad" device pattern across all hardware and OS versions — an open-ended problem.
+- Conservative filtering makes the safe path the default path — operators who want LVMS to consume all devices opt in explicitly via nil DeviceSelector (greedy mode), which is itself a permanent, documented commitment.
+
+### Consequences
+
+* Good, because the default is safe — new contributors and agents cannot accidentally wipe data.
+* Good, because the filter chain is auditable — each filter has a clear, testable predicate.
+* Bad, because users with unusual device layouts may need to explicitly configure DeviceSelector, adding setup friction.
+* Bad, because the filter chain has accumulated complexity (no bind mount filter exists; some filters are noted as design debt from PR #147).
 
 ## More Information
 
 * [docs/known-limitations.md](../known-limitations.md) — user-facing filter documentation
+* [ADR 0005](0005-remove-device-min-age.md) — removal of time-based filtering
 * `internal/controllers/vgmanager/filter/filter.go` — filter chain implementation

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -8,10 +8,10 @@ Format: [MADR 4.0](https://adr.github.io/madr/) short template. See [adr-templat
 
 | ADR | Title | Status | Date |
 |-----|-------|--------|------|
-| [0001](0001-single-binary-architecture.md) | Single binary architecture for edge deployment | Draft | Pre-2023 |
-| [0002](0002-v1alpha1-is-stable.md) | v1alpha1 as stable production API | Draft | Pre-2023 |
-| [0003](0003-finalizer-hierarchy.md) | Three-level finalizer hierarchy for cleanup safety | Draft | Pre-2023 |
-| [0004](0004-conservative-device-filters.md) | Conservative device discovery filters | Draft | Pre-2023 |
+| [0001](0001-single-binary-architecture.md) | Single binary architecture for edge deployment | Accepted | 2022-07-01 |
+| [0002](0002-v1alpha1-is-stable.md) | v1alpha1 as stable production API | Accepted | 2022-07-01 |
+| [0003](0003-finalizer-hierarchy.md) | Three-level finalizer hierarchy for cleanup safety | Accepted | 2022-07-01 |
+| [0004](0004-conservative-device-filters.md) | Conservative device discovery filters | Accepted | 2022-07-01 |
 | [0005](0005-remove-device-min-age.md) | Remove deviceMinAge time-based filtering | Accepted | 2023-08-10 |
 | [0006](0006-orphaned-nodestatus-dedicated-controller.md) | Dedicated controller for orphaned NodeStatus cleanup | Accepted | 2023-08-14 |
 | [0007](0007-no-errgroup-for-concurrent-reconciliation.md) | No errgroup for concurrent reconciliation | Accepted | 2023-08-23 |
@@ -20,8 +20,6 @@ Format: [MADR 4.0](https://adr.github.io/madr/) short template. See [adr-templat
 | [0010](0010-server-side-apply-for-storageclassoptions.md) | Server-side apply for StorageClassOptions | Accepted | 2026-03-03 |
 | [0011](0011-deletion-gates-pvc-pv-policy.md) | Deletion gates: PVC and PV policy checks | Accepted | 2026-03-03 |
 | [0012](0012-cel-vs-webhook-validation.md) | CEL XValidation vs webhook for validation | Accepted | 2026-06-09 |
-
-Draft ADRs (0001–0004) have the decision outcome documented but need "Considered Options" filled in by the LVMS team.
 
 ## Adding a New ADR
 


### PR DESCRIPTION
Add Claude Code permissions (deny destructive LVM commands and generated file edits, allow safe build/test commands), PostToolUse hooks (API type change warning, per-package go vet), and PreToolUse secret detection.

Add GitHub Copilot instruction file derived from AGENTS.md. Restructure AGENTS.md safety section into three-tier boundaries (Always/Ask/Never) and add explicit build commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added clearer guidance for build, test, verify, generate, and release workflows, including expanded checklists for regenerating bundles and catalogs.
  * Added step-by-step instructions for modifying CRDs safely, plus updated API authoring and reconciliation/testing conventions.
  * Expanded AI-assisted tooling guidance and contribution workflows, including commit and documentation standards.
* **Chores**
  * Added stronger tool-use guardrails to prevent unsafe operations and to flag potential secret content during edits.
  * Added automatic follow-up actions to keep generated outputs and related quality checks in sync after relevant changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->