### PR TITLE
OCPEDGE-2530: Add dedicated RAID health monitor controller

### DIFF
--- a/cmd/vgmanager/vgmanager.go
+++ b/cmd/vgmanager/vgmanager.go
@@ -280,6 +280,17 @@ func run(cmd *cobra.Command, _ []string, opts *Options) error {
 		return fmt.Errorf("unable to create controller VGManager: %w", err)
 	}
 
+	if err = (&vgmanager.RAIDMonitorReconciler{
+		Client:        mgr.GetClient(),
+		EventRecorder: mgr.GetEventRecorder(vgmanager.RAIDMonitorName),
+		Scheme:        mgr.GetScheme(),
+		LVM:           lvm.NewDefaultHostLVM(),
+		NodeName:      nodeName,
+		Namespace:     operatorNamespace,
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create controller RAIDMonitor: %w", err)
+	}
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		return fmt.Errorf("unable to set up health check: %w", err)
 	}

--- a/internal/controllers/vgmanager/controller.go
+++ b/internal/controllers/vgmanager/controller.go
@@ -39,11 +39,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	corev1helper "k8s.io/component-helpers/scheduling/corev1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -75,7 +72,6 @@ const (
 	EventReasonErrorVGCreateOrExtendFailed       EventReasonError = "VGCreateOrExtendFailed"
 	EventReasonErrorThinPoolCreateOrExtendFailed EventReasonError = "ThinPoolCreateOrExtendFailed"
 	EventReasonErrorDevicePathCheckFailed        EventReasonError = "DevicePathCheckFailed"
-	EventReasonErrorRAIDHealthCheckFailed        EventReasonError = "RAIDHealthCheckFailed"
 	EventReasonErrorDeviceRemovalFailed          EventReasonError = "DeviceRemovalFailed"
 	EventReasonLVMDConfigMissing                 EventReasonInfo  = "LVMDConfigMissing"
 	EventReasonLVMDConfigUpdated                 EventReasonInfo  = "LVMDConfigUpdated"
@@ -170,14 +166,6 @@ func (r *Reconciler) reconcile(
 	vgs, err := r.ListVGs(ctx, true)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to list volume groups: %w", err)
-	}
-
-	if err := r.checkRAIDVGHealth(vgs, volumeGroup); err != nil {
-		r.WarningEvent(ctx, volumeGroup, EventReasonErrorRAIDHealthCheckFailed, err)
-		if _, statusErr := r.setVolumeGroupFailedStatus(ctx, volumeGroup, vgs, FilteredBlockDevices{}, err); statusErr != nil {
-			logger.Error(statusErr, "failed to set status to failed")
-		}
-		return reconcileAgain, nil
 	}
 
 	logger.V(1).Info("block devices", "blockDevices", blockDevices)
@@ -391,12 +379,6 @@ func (r *Reconciler) reconcile(
 }
 
 func (r *Reconciler) determineFinishedRequeue(volumeGroup *lvmv1alpha1.LVMVolumeGroup, effectivePolicy lvmv1alpha1.DeviceDiscoveryPolicySpec) ctrl.Result {
-	// RAID device classes need periodic reconciliation to monitor health status,
-	// since disk failures are node-side events with no Kubernetes object change.
-	if volumeGroup.Spec.RAIDConfig != nil {
-		return reconcileAgain
-	}
-
 	// With explicit paths, no periodic requeue is needed — the paths define
 	// the exact set of devices. Changes to paths trigger reconciliation via
 	// the LVMVolumeGroup watch.
@@ -790,28 +772,6 @@ func (r *Reconciler) addThinPoolToVG(ctx context.Context, vgName string, config 
 	return nil
 }
 
-// checkRAIDVGHealth returns an error if a RAID-configured volume group has missing physical volumes.
-func (r *Reconciler) checkRAIDVGHealth(
-	vgs []lvm.VolumeGroup,
-	volumeGroup *lvmv1alpha1.LVMVolumeGroup,
-) error {
-	if volumeGroup.Spec.RAIDConfig == nil {
-		return nil
-	}
-
-	for _, vg := range vgs {
-		if vg.Name == volumeGroup.Name && vg.IsMissingDevices() {
-			return fmt.Errorf("RAID VG %s on node %s has missing physical volumes. "+
-				"Repair the volume group on the node (replace the failed device, run 'pvcreate' and 'vgextend' "+
-				"with the new device, then 'lvconvert --repair' for each degraded LV, and 'vgreduce --removemissing' "+
-				"to clean up), and update the LVMCluster CR with the correct device paths",
-				volumeGroup.Name, r.NodeName)
-		}
-	}
-
-	return nil
-}
-
 func (r *Reconciler) deleteRemovedDevices(
 	ctx context.Context,
 	currentVG *lvm.VolumeGroup,
@@ -980,66 +940,20 @@ func (r *Reconciler) verifyMetadataSize(ctx context.Context, vgName, lvName stri
 }
 
 func (r *Reconciler) matchesThisNode(ctx context.Context, selector *corev1.NodeSelector) (bool, error) {
-	node := &corev1.Node{}
-	err := r.Get(ctx, types.NamespacedName{Name: r.NodeName}, node)
-	if err != nil {
-		return false, err
-	}
-	if selector == nil {
-		return true, nil
-	}
-
-	matches, err := corev1helper.MatchNodeSelectorTerms(node, selector)
-	return matches, err
+	return matchesNode(ctx, r.Client, r.NodeName, selector)
 }
 
-// WarningEvent sends an event to both the nodeStatus, and the affected processed volumeGroup as well as the owning LVMCluster if present
 func (r *Reconciler) WarningEvent(ctx context.Context, obj *lvmv1alpha1.LVMVolumeGroup, reason EventReasonError, errMsg error) {
-	nodeStatus := &lvmv1alpha1.LVMVolumeGroupNodeStatus{}
-	nodeStatus.SetName(r.NodeName)
-	nodeStatus.SetNamespace(r.Namespace)
-	// even if the get does not succeed we can still issue an event, just without UUID / resourceVersion
-	if err := r.Get(ctx, client.ObjectKeyFromObject(nodeStatus), nodeStatus); err == nil {
-		r.Eventf(nodeStatus, nil, corev1.EventTypeWarning, string(reason), "ReconcileVolumeGroup", errMsg.Error())
-	}
-	for _, ref := range obj.GetOwnerReferences() {
-		owner := &v1.PartialObjectMetadata{}
-		owner.SetName(ref.Name)
-		owner.SetNamespace(obj.GetNamespace())
-		owner.SetUID(ref.UID)
-		owner.SetGroupVersionKind(schema.FromAPIVersionAndKind(ref.APIVersion, ref.Kind))
-		r.Eventf(owner, nil, corev1.EventTypeWarning, string(reason), "ReconcileVolumeGroup",
-			fmt.Errorf("error on node %s in volume group %s: %w",
-				client.ObjectKeyFromObject(nodeStatus), client.ObjectKeyFromObject(obj), errMsg).Error())
-	}
-	r.Eventf(obj, nil, corev1.EventTypeWarning, string(reason), "ReconcileVolumeGroup",
-		fmt.Errorf("error on node %s: %w", client.ObjectKeyFromObject(nodeStatus), errMsg).Error())
+	emitEventToVGAndOwners(ctx, r.Client, r.EventRecorder, r.NodeName, r.Namespace, obj,
+		corev1.EventTypeWarning, string(reason), "ReconcileVolumeGroup", errMsg.Error())
 }
 
-// NormalEvent sends an event to both the nodeStatus, and the affected processed volumeGroup as well as the owning LVMCluster if present
 func (r *Reconciler) NormalEvent(ctx context.Context, obj *lvmv1alpha1.LVMVolumeGroup, reason EventReasonInfo, message string) {
 	if !log.FromContext(ctx).V(1).Enabled() {
 		return
 	}
-	nodeStatus := &lvmv1alpha1.LVMVolumeGroupNodeStatus{}
-	nodeStatus.SetName(r.NodeName)
-	nodeStatus.SetNamespace(r.Namespace)
-	// even if the get does not succeed we can still issue an event, just without UUID / resourceVersion
-	if err := r.Get(ctx, client.ObjectKeyFromObject(nodeStatus), nodeStatus); err == nil {
-		r.Eventf(nodeStatus, nil, corev1.EventTypeNormal, string(reason), "ReconcileVolumeGroup", message)
-	}
-	for _, ref := range obj.GetOwnerReferences() {
-		owner := &v1.PartialObjectMetadata{}
-		owner.SetName(ref.Name)
-		owner.SetNamespace(obj.GetNamespace())
-		owner.SetUID(ref.UID)
-		owner.SetGroupVersionKind(schema.FromAPIVersionAndKind(ref.APIVersion, ref.Kind))
-		r.Eventf(owner, nil, corev1.EventTypeNormal, string(reason), "ReconcileVolumeGroup",
-			fmt.Sprintf("update on node %s in volume group %s: %s",
-				client.ObjectKeyFromObject(nodeStatus), client.ObjectKeyFromObject(obj), message))
-	}
-	r.Eventf(obj, nil, corev1.EventTypeNormal, string(reason), "ReconcileVolumeGroup",
-		fmt.Sprintf("update on node %s: %s", client.ObjectKeyFromObject(nodeStatus), message))
+	emitEventToVGAndOwners(ctx, r.Client, r.EventRecorder, r.NodeName, r.Namespace, obj,
+		corev1.EventTypeNormal, string(reason), "ReconcileVolumeGroup", message)
 }
 
 func verifyChunkSizeForPolicy(config *lvmv1alpha1.ThinPoolConfig, lv lvm.LogicalVolume) error {

--- a/internal/controllers/vgmanager/controller_test.go
+++ b/internal/controllers/vgmanager/controller_test.go
@@ -81,14 +81,8 @@ var _ = Describe("vgmanager controller", func() {
 		It("RAID volume group with insufficient devices", func(ctx SpecContext) {
 			testRAIDVGInsufficientDevices(ctx)
 		})
-		It("RAID volume group should error when VG has missing PVs", func(ctx SpecContext) {
-			testRAIDMissingPVsReturnsError(ctx)
-		})
-		It("RAID volume group should reconcile to Ready after admin repair", func(ctx SpecContext) {
-			testRAIDHealthyAfterRepair(ctx)
-		})
-		It("RAID volume group should periodically requeue for health monitoring", func(ctx SpecContext) {
-			testRAIDRequeuesForHealthMonitoring(ctx)
+		It("RAID volume group should not requeue for health monitoring", func(ctx SpecContext) {
+			testRAIDNoLongerRequeuesForHealthMonitoring(ctx)
 		})
 		Context("edge cases during reconciliation", func() {
 			Context("failure in LVM or LSBLK", func() {
@@ -1260,7 +1254,7 @@ func testLVMDConfigChange(ctx context.Context) {
 	Expect(cfg.DeviceClasses[0].ThinPoolConfig.OverprovisionRatio).To(Equal(float64(1)))
 }
 
-func testRAIDRequeuesForHealthMonitoring(ctx context.Context) {
+func testRAIDNoLongerRequeuesForHealthMonitoring(ctx context.Context) {
 	logger := zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
 	ctx = log.IntoContext(ctx, logger)
 
@@ -1330,11 +1324,10 @@ func testRAIDRequeuesForHealthMonitoring(ctx context.Context) {
 		blockDevice1.KName: {IsUsableLoopDev: false},
 		blockDevice2.KName: {IsUsableLoopDev: false},
 	}, nil).Once()
-	instances.LVM.EXPECT().ListLVs(ctx, vg.GetName()).Return(&lvm.LVReport{Report: []lvm.LVReportItem{}}, nil).Once()
 
 	res, err := instances.Reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(vg)})
 	Expect(err).ToNot(HaveOccurred(), "reconciliation of healthy RAID VG should not return an error")
-	Expect(res).To(Equal(reconcileAgain), "RAID VG should requeue periodically for health monitoring")
+	Expect(res).To(Equal(ctrl.Result{}), "RAID VG with explicit paths should not requeue since RAID monitor handles health checks")
 }
 
 func testStaticModeExcludesNewDevices(ctx context.Context) {
@@ -1681,7 +1674,6 @@ func testRAIDVGWithLocalDevices(ctx context.Context) {
 	instances.LVM.EXPECT().ListPVs(ctx, "").Return(nil, nil).Once()
 	instances.LSBLK.EXPECT().ListBlockDevices(ctx).Return([]lsblk.BlockDevice{blockDevice1, blockDevice2}, nil).Once()
 	instances.LSBLK.EXPECT().BlockDeviceInfos(ctx, mock.Anything).Return(bdi, nil).Once()
-	instances.LVM.EXPECT().ListLVs(ctx, vg.GetName()).Return(&lvm.LVReport{Report: []lvm.LVReportItem{}}, nil).Once()
 	_, err = instances.Reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(vg)})
 	Expect(err).ToNot(HaveOccurred())
 
@@ -1707,7 +1699,6 @@ func testRAIDVGWithLocalDevices(ctx context.Context) {
 		PVs:    []lvm.PhysicalVolume{lvmPV1, lvmPV2},
 	}
 	instances.LVM.EXPECT().ListVGs(ctx, true).Return([]lvm.VolumeGroup{createdVG}, nil).Once()
-	instances.LVM.EXPECT().ListLVs(ctx, vg.GetName()).Return(&lvm.LVReport{Report: []lvm.LVReportItem{}}, nil).Twice()
 
 	_, err = instances.Reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(vg)})
 	Expect(err).ToNot(HaveOccurred())
@@ -1809,7 +1800,6 @@ func testRAIDVGInsufficientDevices(ctx context.Context) {
 	instances.LVM.EXPECT().ListPVs(ctx, "").Return(nil, nil).Once()
 	instances.LSBLK.EXPECT().ListBlockDevices(ctx).Return([]lsblk.BlockDevice{blockDevice}, nil).Once()
 	instances.LSBLK.EXPECT().BlockDeviceInfos(ctx, mock.Anything).Return(bdi, nil).Once()
-	instances.LVM.EXPECT().ListLVs(ctx, vg.GetName()).Return(&lvm.LVReport{Report: []lvm.LVReportItem{}}, nil).Once()
 	_, err = instances.Reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(vg)})
 	Expect(err).ToNot(HaveOccurred())
 
@@ -1830,7 +1820,6 @@ func testRAIDVGInsufficientDevices(ctx context.Context) {
 	instances.LVM.EXPECT().ListPVs(ctx, "").Return(nil, nil).Once()
 	instances.LSBLK.EXPECT().ListBlockDevices(ctx).Return([]lsblk.BlockDevice{blockDevice}, nil).Once()
 	instances.LSBLK.EXPECT().BlockDeviceInfos(ctx, mock.Anything).Return(bdi, nil).Once()
-	instances.LVM.EXPECT().ListLVs(ctx, vg.GetName()).Return(&lvm.LVReport{Report: []lvm.LVReportItem{}}, nil).Twice()
 	_, err = instances.Reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(vg)})
 	Expect(err).To(HaveOccurred())
 	Expect(err.Error()).To(ContainSubstring("raid1 requires at least 2 devices, got 1"))
@@ -1847,162 +1836,3 @@ func testRAIDVGInsufficientDevices(ctx context.Context) {
 	Expect(found).To(BeTrue(), "VG status should exist and be failed")
 }
 
-func testRAIDMissingPVsReturnsError(ctx context.Context) {
-	logger := zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
-	ctx = log.IntoContext(ctx, logger)
-
-	instances := setupInstances()
-
-	tmpDir := GinkgoT().TempDir()
-	device1Path := filepath.Join(tmpDir, "mock0")
-	device2Path := filepath.Join(tmpDir, "mock1")
-	device1 := getKNameFromDevice(device1Path)
-	device2 := getKNameFromDevice(device2Path)
-
-	_, err := os.Create(device1.Unresolved())
-	Expect(err).To(Succeed(), "should create mock device file %s", device1.Unresolved())
-	_, err = os.Create(device2.Unresolved())
-	Expect(err).To(Succeed(), "should create mock device file %s", device2.Unresolved())
-
-	vg := &lvmv1alpha1.LVMVolumeGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vg1",
-			Namespace: instances.namespace.GetName(),
-		},
-		Spec: lvmv1alpha1.LVMVolumeGroupSpec{
-			RAIDConfig: &lvmv1alpha1.RAIDConfig{
-				Type: lvmv1alpha1.RAIDTypeRAID1,
-			},
-			DeviceSelector: &lvmv1alpha1.DeviceSelector{
-				Paths: []lvmv1alpha1.DevicePath{device1, device2},
-			},
-			NodeSelector: instances.nodeSelector.DeepCopy(),
-		},
-	}
-
-	By("creating the LVMVolumeGroup and NodeStatus")
-	Expect(instances.client.Create(ctx, vg)).To(Succeed(), "should create LVMVolumeGroup")
-	nodeStatus := &lvmv1alpha1.LVMVolumeGroupNodeStatus{}
-	nodeStatus.SetName(instances.node.GetName())
-	nodeStatus.SetNamespace(instances.namespace.GetName())
-	Expect(instances.client.Create(ctx, nodeStatus)).To(Succeed(), "should create LVMVolumeGroupNodeStatus")
-
-	By("triggering reconciliation to add finalizer")
-	_, err = instances.Reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(vg)})
-	Expect(err).ToNot(HaveOccurred(), "finalizer reconciliation should succeed")
-
-	By("simulating a VG with missing PVs (disk failure)")
-	vgWithMissing := lvm.VolumeGroup{
-		Name:   vg.GetName(),
-		VgSize: "2.0G",
-		PVs: []lvm.PhysicalVolume{
-			{PvName: device1.Unresolved(), UUID: "pv-uuid-1"},
-			{PvName: "[unknown]", UUID: "missing-pv-uuid", PvMissing: "missing"},
-		},
-	}
-
-	instances.LSBLK.EXPECT().ListBlockDevices(ctx).Return(nil, nil).Once()
-	instances.LVM.EXPECT().ListVGs(ctx, true).Return([]lvm.VolumeGroup{vgWithMissing}, nil).Once()
-	instances.LVM.EXPECT().ListLVs(ctx, vg.GetName()).Return(&lvm.LVReport{Report: []lvm.LVReportItem{}}, nil).Once()
-
-	result, err := instances.Reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(vg)})
-	Expect(err).ToNot(HaveOccurred(), "reconciler should not return error for missing PVs (it requeues instead)")
-	Expect(result.RequeueAfter).To(Equal(30*time.Second), "should requeue after 30s when RAID VG has missing PVs")
-}
-
-func testRAIDHealthyAfterRepair(ctx context.Context) {
-	logger := zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
-	ctx = log.IntoContext(ctx, logger)
-
-	instances := setupInstances()
-
-	tmpDir := GinkgoT().TempDir()
-	device1Path := filepath.Join(tmpDir, "mock0")
-	device2Path := filepath.Join(tmpDir, "mock1")
-	device1 := getKNameFromDevice(device1Path)
-	device2 := getKNameFromDevice(device2Path)
-
-	_, err := os.Create(device1.Unresolved())
-	Expect(err).To(Succeed(), "should create mock device file %s", device1.Unresolved())
-	_, err = os.Create(device2.Unresolved())
-	Expect(err).To(Succeed(), "should create mock device file %s", device2.Unresolved())
-
-	blockDevice1 := createMockedBlockDevice(device1.Unresolved())
-	blockDevice2 := lsblk.BlockDevice{
-		Name:   "mock1",
-		KName:  device2.Unresolved(),
-		Type:   "mocked",
-		Model:  "mocked",
-		Vendor: "mocked",
-		State:  "live",
-		FSType: "LVM2_member",
-		Size:   "1G",
-		Serial: "MOCK2",
-	}
-	blockDevice1.FSType = "LVM2_member"
-
-	vg := &lvmv1alpha1.LVMVolumeGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vg1",
-			Namespace: instances.namespace.GetName(),
-		},
-		Spec: lvmv1alpha1.LVMVolumeGroupSpec{
-			RAIDConfig: &lvmv1alpha1.RAIDConfig{
-				Type: lvmv1alpha1.RAIDTypeRAID1,
-			},
-			DeviceSelector: &lvmv1alpha1.DeviceSelector{
-				Paths: []lvmv1alpha1.DevicePath{device1, device2},
-			},
-			NodeSelector: instances.nodeSelector.DeepCopy(),
-		},
-	}
-
-	By("creating the LVMVolumeGroup and NodeStatus")
-	Expect(instances.client.Create(ctx, vg)).To(Succeed(), "should create LVMVolumeGroup")
-	nodeStatus := &lvmv1alpha1.LVMVolumeGroupNodeStatus{}
-	nodeStatus.SetName(instances.node.GetName())
-	nodeStatus.SetNamespace(instances.namespace.GetName())
-	Expect(instances.client.Create(ctx, nodeStatus)).To(Succeed(), "should create LVMVolumeGroupNodeStatus")
-
-	By("triggering reconciliation to add finalizer")
-	_, err = instances.Reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(vg)})
-	Expect(err).ToNot(HaveOccurred(), "finalizer reconciliation should succeed")
-
-	bdi := lsblk.BlockDeviceInfos{
-		blockDevice1.KName: {IsUsableLoopDev: false},
-		blockDevice2.KName: {IsUsableLoopDev: false},
-	}
-
-	By("simulating a healthy VG after admin repair (no missing PVs)")
-	healthyVG := lvm.VolumeGroup{
-		Name:   vg.GetName(),
-		VgSize: "2.0G",
-		PVs: []lvm.PhysicalVolume{
-			{PvName: device1.Unresolved(), UUID: "pv-uuid-1"},
-			{PvName: device2.Unresolved(), UUID: "pv-uuid-2"},
-		},
-	}
-
-	instances.LSBLK.EXPECT().ListBlockDevices(ctx).Return([]lsblk.BlockDevice{blockDevice1, blockDevice2}, nil).Once()
-	instances.LVM.EXPECT().ListVGs(ctx, true).Return([]lvm.VolumeGroup{healthyVG}, nil).Once()
-	instances.LVM.EXPECT().ListPVs(ctx, "").Return([]lvm.PhysicalVolume{
-		{PvName: device1.Unresolved(), UUID: "pv-uuid-1", VgName: vg.GetName()},
-		{PvName: device2.Unresolved(), UUID: "pv-uuid-2", VgName: vg.GetName()},
-	}, nil).Once()
-	instances.LSBLK.EXPECT().BlockDeviceInfos(ctx, mock.Anything).Return(bdi, nil).Once()
-	instances.LVM.EXPECT().ListLVs(ctx, vg.GetName()).Return(&lvm.LVReport{Report: []lvm.LVReportItem{}}, nil).Once()
-
-	_, err = instances.Reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(vg)})
-	Expect(err).ToNot(HaveOccurred(), "reconciliation of repaired RAID VG should succeed")
-
-	By("verifying the VGStatus is Ready")
-	Expect(instances.client.Get(ctx, client.ObjectKeyFromObject(nodeStatus), nodeStatus)).To(Succeed(), "should fetch LVMVolumeGroupNodeStatus")
-	found := false
-	for _, status := range nodeStatus.Spec.LVMVGStatus {
-		if status.Name == vg.GetName() {
-			found = true
-			Expect(status.Status).To(Equal(lvmv1alpha1.VGStatusReady), "VG status should be Ready after repair")
-		}
-	}
-	Expect(found).To(BeTrue(), "VG status should exist and be ready")
-}

--- a/internal/controllers/vgmanager/events.go
+++ b/internal/controllers/vgmanager/events.go
@@ -1,0 +1,51 @@
+package vgmanager
+
+import (
+	"context"
+	"fmt"
+
+	lvmv1alpha1 "github.com/openshift/lvm-operator/v4/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func emitEventToVGAndOwners(
+	ctx context.Context,
+	c client.Reader,
+	recorder events.EventRecorder,
+	nodeName, namespace string,
+	obj *lvmv1alpha1.LVMVolumeGroup,
+	eventType, reason, action, message string,
+) {
+	nodeKey := client.ObjectKey{Name: nodeName, Namespace: namespace}
+	nodeStatus := &lvmv1alpha1.LVMVolumeGroupNodeStatus{}
+	nodeStatus.SetName(nodeName)
+	nodeStatus.SetNamespace(namespace)
+	if err := c.Get(ctx, client.ObjectKeyFromObject(nodeStatus), nodeStatus); err == nil {
+		recorder.Eventf(nodeStatus, nil, eventType, reason, action, message)
+	}
+	for _, ref := range obj.GetOwnerReferences() {
+		owner := &metav1.PartialObjectMetadata{}
+		owner.SetName(ref.Name)
+		owner.SetNamespace(obj.GetNamespace())
+		owner.SetUID(ref.UID)
+		owner.SetGroupVersionKind(schema.FromAPIVersionAndKind(ref.APIVersion, ref.Kind))
+		if eventType == corev1.EventTypeWarning {
+			recorder.Eventf(owner, nil, eventType, reason, action,
+				fmt.Sprintf("error on node %s in volume group %s: %s", nodeKey, client.ObjectKeyFromObject(obj), message))
+		} else {
+			recorder.Eventf(owner, nil, eventType, reason, action,
+				fmt.Sprintf("update on node %s in volume group %s: %s", nodeKey, client.ObjectKeyFromObject(obj), message))
+		}
+	}
+	if eventType == corev1.EventTypeWarning {
+		recorder.Eventf(obj, nil, eventType, reason, action,
+			fmt.Sprintf("error on node %s: %s", nodeKey, message))
+	} else {
+		recorder.Eventf(obj, nil, eventType, reason, action,
+			fmt.Sprintf("update on node %s: %s", nodeKey, message))
+	}
+}

--- a/internal/controllers/vgmanager/node.go
+++ b/internal/controllers/vgmanager/node.go
@@ -1,0 +1,21 @@
+package vgmanager
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1helper "k8s.io/component-helpers/scheduling/corev1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func matchesNode(ctx context.Context, c client.Reader, nodeName string, selector *corev1.NodeSelector) (bool, error) {
+	node := &corev1.Node{}
+	if err := c.Get(ctx, client.ObjectKeyFromObject(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}), node); err != nil {
+		return false, err
+	}
+	if selector == nil {
+		return true, nil
+	}
+	return corev1helper.MatchNodeSelectorTerms(node, selector)
+}

--- a/internal/controllers/vgmanager/raid_metrics.go
+++ b/internal/controllers/vgmanager/raid_metrics.go
@@ -14,25 +14,41 @@ var (
 		[]string{"node", "device_class"},
 	)
 
-	raidSyncInProgress = prometheus.NewGaugeVec(
+	raidMemberCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "lvms_raid_sync_in_progress",
-			Help: "Whether any RAID LV in the device class is resynchronizing. 1=syncing, 0=idle.",
+			Name: "lvms_raid_member_count",
+			Help: "Total number of physical volumes in the RAID volume group.",
 		},
 		[]string{"node", "device_class"},
 	)
+
+	raidDegradedCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "lvms_raid_degraded_count",
+			Help: "Number of missing or failed physical volumes in the RAID volume group.",
+		},
+		[]string{"node", "device_class"},
+	)
+
+	raidSyncPercent = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "lvms_raid_sync_percent",
+			Help: "RAID resynchronization progress per logical volume (0-100).",
+		},
+		[]string{"node", "device_class", "lv"},
+	)
 )
 
-// RAIDMetrics returns the Prometheus collectors for RAID health and sync status.
 func RAIDMetrics() []prometheus.Collector {
-	return []prometheus.Collector{raidHealthStatus, raidSyncInProgress}
+	return []prometheus.Collector{raidHealthStatus, raidMemberCount, raidDegradedCount, raidSyncPercent}
 }
 
-// updateRAIDMetrics sets the RAID health and sync-in-progress gauges for a device class on a node.
-func updateRAIDMetrics(nodeName, deviceClassName string, raidStatus *lvmv1alpha1.RAIDStatus) {
+func updateRAIDMetrics(nodeName, deviceClassName string, raidStatus *lvmv1alpha1.RAIDStatus, totalPVs, missingPVs int) {
+	raidMemberCount.WithLabelValues(nodeName, deviceClassName).Set(float64(totalPVs))
+	raidDegradedCount.WithLabelValues(nodeName, deviceClassName).Set(float64(missingPVs))
+
 	if raidStatus == nil {
 		raidHealthStatus.WithLabelValues(nodeName, deviceClassName).Set(0)
-		raidSyncInProgress.WithLabelValues(nodeName, deviceClassName).Set(0)
 		return
 	}
 
@@ -47,18 +63,15 @@ func updateRAIDMetrics(nodeName, deviceClassName string, raidStatus *lvmv1alpha1
 	}
 	raidHealthStatus.WithLabelValues(nodeName, deviceClassName).Set(healthValue)
 
-	var syncing float64
+	raidSyncPercent.DeletePartialMatch(prometheus.Labels{"node": nodeName, "device_class": deviceClassName})
 	for _, lv := range raidStatus.LVHealth {
-		if lv.SyncPercent < 100 {
-			syncing = 1
-			break
-		}
+		raidSyncPercent.WithLabelValues(nodeName, deviceClassName, lv.Name).Set(float64(lv.SyncPercent))
 	}
-	raidSyncInProgress.WithLabelValues(nodeName, deviceClassName).Set(syncing)
 }
 
-// deleteRAIDMetrics removes the RAID metric series for a device class on a node.
 func deleteRAIDMetrics(nodeName, deviceClassName string) {
 	raidHealthStatus.DeleteLabelValues(nodeName, deviceClassName)
-	raidSyncInProgress.DeleteLabelValues(nodeName, deviceClassName)
+	raidMemberCount.DeleteLabelValues(nodeName, deviceClassName)
+	raidDegradedCount.DeleteLabelValues(nodeName, deviceClassName)
+	raidSyncPercent.DeletePartialMatch(prometheus.Labels{"node": nodeName, "device_class": deviceClassName})
 }

--- a/internal/controllers/vgmanager/raid_metrics_test.go
+++ b/internal/controllers/vgmanager/raid_metrics_test.go
@@ -20,81 +20,6 @@ func getGaugeValue(g *prometheus.GaugeVec, labels ...string) float64 {
 	return m.GetGauge().GetValue()
 }
 
-func TestUpdateRAIDMetrics(t *testing.T) {
-	tests := []struct {
-		name               string
-		raidStatus         *lvmv1alpha1.RAIDStatus
-		expectedHealth     float64
-		expectedSyncActive float64
-	}{
-		{
-			name: "healthy status",
-			raidStatus: &lvmv1alpha1.RAIDStatus{
-				Status: lvmv1alpha1.RAIDHealthStatusHealthy,
-				LVHealth: []lvmv1alpha1.RAIDLVHealth{
-					{Name: "lv1", SyncPercent: 100},
-				},
-			},
-			expectedHealth:     0,
-			expectedSyncActive: 0,
-		},
-		{
-			name: "degraded status",
-			raidStatus: &lvmv1alpha1.RAIDStatus{
-				Status: lvmv1alpha1.RAIDHealthStatusDegraded,
-				LVHealth: []lvmv1alpha1.RAIDLVHealth{
-					{Name: "lv1", SyncPercent: 100, HealthStatus: "partial"},
-				},
-			},
-			expectedHealth:     1,
-			expectedSyncActive: 0,
-		},
-		{
-			name: "failed status",
-			raidStatus: &lvmv1alpha1.RAIDStatus{
-				Status: lvmv1alpha1.RAIDHealthStatusFailed,
-			},
-			expectedHealth:     2,
-			expectedSyncActive: 0,
-		},
-		{
-			name: "sync in progress",
-			raidStatus: &lvmv1alpha1.RAIDStatus{
-				Status: lvmv1alpha1.RAIDHealthStatusHealthy,
-				LVHealth: []lvmv1alpha1.RAIDLVHealth{
-					{Name: "lv1", SyncPercent: 42},
-				},
-			},
-			expectedHealth:     0,
-			expectedSyncActive: 1,
-		},
-		{
-			name:               "nil status clears metrics to zero",
-			raidStatus:         nil,
-			expectedHealth:     0,
-			expectedSyncActive: 0,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			raidHealthStatus.Reset()
-			raidSyncInProgress.Reset()
-
-			updateRAIDMetrics("test-node", "test-dc", tt.raidStatus)
-
-			gotHealth := getGaugeValue(raidHealthStatus, "test-node", "test-dc")
-			if gotHealth != tt.expectedHealth {
-				t.Errorf("health: expected %f, got %f", tt.expectedHealth, gotHealth)
-			}
-			gotSync := getGaugeValue(raidSyncInProgress, "test-node", "test-dc")
-			if gotSync != tt.expectedSyncActive {
-				t.Errorf("sync: expected %f, got %f", tt.expectedSyncActive, gotSync)
-			}
-		})
-	}
-}
-
 func collectMetricCount(c prometheus.Collector) int {
 	ch := make(chan prometheus.Metric, 100)
 	c.Collect(ch)
@@ -106,24 +31,139 @@ func collectMetricCount(c prometheus.Collector) int {
 	return count
 }
 
+func TestUpdateRAIDMetrics(t *testing.T) {
+	tests := []struct {
+		name             string
+		raidStatus       *lvmv1alpha1.RAIDStatus
+		totalPVs         int
+		missingPVs       int
+		expectedHealth   float64
+		expectedMembers  float64
+		expectedDegraded float64
+	}{
+		{
+			name: "healthy status with 4 PVs",
+			raidStatus: &lvmv1alpha1.RAIDStatus{
+				Status: lvmv1alpha1.RAIDHealthStatusHealthy,
+				LVHealth: []lvmv1alpha1.RAIDLVHealth{
+					{Name: "lv1", SyncPercent: 100},
+				},
+			},
+			totalPVs:         4,
+			missingPVs:       0,
+			expectedHealth:   0,
+			expectedMembers:  4,
+			expectedDegraded: 0,
+		},
+		{
+			name: "degraded status with 1 missing PV",
+			raidStatus: &lvmv1alpha1.RAIDStatus{
+				Status: lvmv1alpha1.RAIDHealthStatusDegraded,
+				LVHealth: []lvmv1alpha1.RAIDLVHealth{
+					{Name: "lv1", SyncPercent: 100, HealthStatus: "partial"},
+				},
+			},
+			totalPVs:         4,
+			missingPVs:       1,
+			expectedHealth:   1,
+			expectedMembers:  4,
+			expectedDegraded: 1,
+		},
+		{
+			name: "failed status",
+			raidStatus: &lvmv1alpha1.RAIDStatus{
+				Status: lvmv1alpha1.RAIDHealthStatusFailed,
+			},
+			totalPVs:         4,
+			missingPVs:       2,
+			expectedHealth:   2,
+			expectedMembers:  4,
+			expectedDegraded: 2,
+		},
+		{
+			name:             "nil status clears to zero",
+			raidStatus:       nil,
+			totalPVs:         0,
+			missingPVs:       0,
+			expectedHealth:   0,
+			expectedMembers:  0,
+			expectedDegraded: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raidHealthStatus.Reset()
+			raidMemberCount.Reset()
+			raidDegradedCount.Reset()
+			raidSyncPercent.Reset()
+
+			updateRAIDMetrics("test-node", "test-dc", tt.raidStatus, tt.totalPVs, tt.missingPVs)
+
+			if got := getGaugeValue(raidHealthStatus, "test-node", "test-dc"); got != tt.expectedHealth {
+				t.Errorf("health: expected %f, got %f", tt.expectedHealth, got)
+			}
+			if got := getGaugeValue(raidMemberCount, "test-node", "test-dc"); got != tt.expectedMembers {
+				t.Errorf("members: expected %f, got %f", tt.expectedMembers, got)
+			}
+			if got := getGaugeValue(raidDegradedCount, "test-node", "test-dc"); got != tt.expectedDegraded {
+				t.Errorf("degraded: expected %f, got %f", tt.expectedDegraded, got)
+			}
+		})
+	}
+}
+
+func TestUpdateRAIDMetricsSyncPercent(t *testing.T) {
+	raidHealthStatus.Reset()
+	raidMemberCount.Reset()
+	raidDegradedCount.Reset()
+	raidSyncPercent.Reset()
+
+	updateRAIDMetrics("test-node", "test-dc", &lvmv1alpha1.RAIDStatus{
+		Status: lvmv1alpha1.RAIDHealthStatusHealthy,
+		LVHealth: []lvmv1alpha1.RAIDLVHealth{
+			{Name: "lv1", SyncPercent: 42},
+			{Name: "lv2", SyncPercent: 100},
+		},
+	}, 4, 0)
+
+	if got := getGaugeValue(raidSyncPercent, "test-node", "test-dc", "lv1"); got != 42 {
+		t.Errorf("sync percent lv1: expected 42, got %f", got)
+	}
+	if got := getGaugeValue(raidSyncPercent, "test-node", "test-dc", "lv2"); got != 100 {
+		t.Errorf("sync percent lv2: expected 100, got %f", got)
+	}
+}
+
 func TestDeleteRAIDMetrics(t *testing.T) {
 	raidHealthStatus.Reset()
-	raidSyncInProgress.Reset()
+	raidMemberCount.Reset()
+	raidDegradedCount.Reset()
+	raidSyncPercent.Reset()
 
 	updateRAIDMetrics("test-node", "test-dc", &lvmv1alpha1.RAIDStatus{
 		Status: lvmv1alpha1.RAIDHealthStatusDegraded,
-	})
+		LVHealth: []lvmv1alpha1.RAIDLVHealth{
+			{Name: "lv1", SyncPercent: 50},
+		},
+	}, 4, 1)
 
 	if n := collectMetricCount(raidHealthStatus); n != 1 {
-		t.Fatalf("expected 1 metric series, got %d", n)
+		t.Fatalf("expected 1 health metric series, got %d", n)
 	}
 
 	deleteRAIDMetrics("test-node", "test-dc")
 
 	if n := collectMetricCount(raidHealthStatus); n != 0 {
-		t.Fatalf("expected 0 metric series after delete, got %d", n)
+		t.Fatalf("expected 0 health metric series after delete, got %d", n)
 	}
-	if n := collectMetricCount(raidSyncInProgress); n != 0 {
+	if n := collectMetricCount(raidMemberCount); n != 0 {
+		t.Fatalf("expected 0 member metric series after delete, got %d", n)
+	}
+	if n := collectMetricCount(raidDegradedCount); n != 0 {
+		t.Fatalf("expected 0 degraded metric series after delete, got %d", n)
+	}
+	if n := collectMetricCount(raidSyncPercent); n != 0 {
 		t.Fatalf("expected 0 sync metric series after delete, got %d", n)
 	}
 }

--- a/internal/controllers/vgmanager/raid_monitor.go
+++ b/internal/controllers/vgmanager/raid_monitor.go
@@ -1,0 +1,275 @@
+package vgmanager
+
+import (
+	"context"
+	"fmt"
+
+	lvmv1alpha1 "github.com/openshift/lvm-operator/v4/api/v1alpha1"
+	"github.com/openshift/lvm-operator/v4/internal/controllers/vgmanager/lvm"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const RAIDMonitorName = "raid-monitor"
+
+const (
+	EventReasonRAIDDegraded      EventReasonError = "RAIDDegraded"
+	EventReasonRAIDFailed        EventReasonError = "RAIDFailed"
+	EventReasonRAIDRecovered     EventReasonInfo  = "RAIDRecovered"
+	EventReasonRAIDSyncStarted   EventReasonInfo  = "RAIDSyncStarted"
+	EventReasonRAIDSyncCompleted EventReasonInfo  = "RAIDSyncCompleted"
+)
+
+type RAIDMonitorReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	events.EventRecorder
+	lvm.LVM
+	NodeName  string
+	Namespace string
+}
+
+func (r *RAIDMonitorReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(RAIDMonitorName).
+		For(&lvmv1alpha1.LVMVolumeGroup{}).
+		Complete(r)
+}
+
+func (r *RAIDMonitorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithName(RAIDMonitorName)
+
+	volumeGroup := &lvmv1alpha1.LVMVolumeGroup{}
+	if err := r.Get(ctx, req.NamespacedName, volumeGroup); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if !volumeGroup.DeletionTimestamp.IsZero() {
+		if volumeGroup.Spec.RAIDConfig != nil {
+			deleteRAIDMetrics(r.NodeName, volumeGroup.GetName())
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if volumeGroup.Spec.RAIDConfig == nil {
+		return ctrl.Result{}, nil
+	}
+
+	nodeMatches, err := r.matchesThisNode(ctx, volumeGroup.Spec.NodeSelector)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to match nodeSelector to node labels: %w", err)
+	}
+	if !nodeMatches {
+		return ctrl.Result{}, nil
+	}
+
+	vgs, err := r.ListVGs(ctx, true)
+	if err != nil {
+		logger.Error(err, "failed to list volume groups for RAID health check")
+		return reconcileAgain, nil
+	}
+
+	var targetVG *lvm.VolumeGroup
+	for i := range vgs {
+		if vgs[i].Name == volumeGroup.Name {
+			targetVG = &vgs[i]
+			break
+		}
+	}
+	if targetVG == nil {
+		return reconcileAgain, nil
+	}
+
+	totalPVs := len(targetVG.PVs)
+	missingPVs := 0
+	for _, pv := range targetVG.PVs {
+		if pv.PvMissing != "" {
+			missingPVs++
+		}
+	}
+
+	lvReport, err := r.ListLVs(ctx, volumeGroup.GetName())
+	if err != nil {
+		logger.Error(err, "failed to list logical volumes for RAID health check")
+		return reconcileAgain, nil
+	}
+
+	var allLVs []lvm.LogicalVolume
+	for _, report := range lvReport.Report {
+		allLVs = append(allLVs, report.Lv...)
+	}
+
+	newRAIDStatus := buildRAIDStatus(allLVs, volumeGroup.Spec.RAIDConfig.Type)
+	if newRAIDStatus == nil && missingPVs > 0 {
+		newRAIDStatus = &lvmv1alpha1.RAIDStatus{
+			Status: lvmv1alpha1.RAIDHealthStatusDegraded,
+		}
+	}
+
+	nodeStatus := &lvmv1alpha1.LVMVolumeGroupNodeStatus{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.NodeName,
+			Namespace: r.Namespace,
+		},
+	}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(nodeStatus), nodeStatus); err != nil {
+		logger.Error(err, "failed to get LVMVolumeGroupNodeStatus")
+		return reconcileAgain, nil
+	}
+
+	var oldRAIDStatus *lvmv1alpha1.RAIDStatus
+	for _, vgStatus := range nodeStatus.Spec.LVMVGStatus {
+		if vgStatus.Name == volumeGroup.GetName() {
+			oldRAIDStatus = vgStatus.RAIDStatus
+			break
+		}
+	}
+
+	r.emitTransitionEvents(ctx, volumeGroup, oldRAIDStatus, newRAIDStatus)
+
+	if statusChanged(oldRAIDStatus, newRAIDStatus) {
+		if _, err := r.updateRAIDStatusOnNode(ctx, volumeGroup, nodeStatus, newRAIDStatus); err != nil {
+			logger.Error(err, "failed to update RAID status on LVMVolumeGroupNodeStatus")
+			return reconcileAgain, nil
+		}
+	}
+
+	updateRAIDMetrics(r.NodeName, volumeGroup.GetName(), newRAIDStatus, totalPVs, missingPVs)
+
+	return reconcileAgain, nil
+}
+
+func (r *RAIDMonitorReconciler) updateRAIDStatusOnNode(
+	ctx context.Context,
+	vg *lvmv1alpha1.LVMVolumeGroup,
+	nodeStatus *lvmv1alpha1.LVMVolumeGroupNodeStatus,
+	raidStatus *lvmv1alpha1.RAIDStatus,
+) (bool, error) {
+	result, err := ctrl.CreateOrUpdate(ctx, r.Client, nodeStatus, func() error {
+		for i, vgStatus := range nodeStatus.Spec.LVMVGStatus {
+			if vgStatus.Name == vg.GetName() {
+				nodeStatus.Spec.LVMVGStatus[i].RAIDStatus = raidStatus
+				if raidStatus != nil &&
+					(raidStatus.Status == lvmv1alpha1.RAIDHealthStatusDegraded || raidStatus.Status == lvmv1alpha1.RAIDHealthStatusFailed) &&
+					(vgStatus.Status == lvmv1alpha1.VGStatusReady || vgStatus.Status == lvmv1alpha1.VGStatusProgressing) {
+					nodeStatus.Spec.LVMVGStatus[i].Status = lvmv1alpha1.VGStatusDegraded
+				}
+				if raidStatus != nil &&
+					raidStatus.Status == lvmv1alpha1.RAIDHealthStatusHealthy &&
+					vgStatus.Status == lvmv1alpha1.VGStatusDegraded {
+					nodeStatus.Spec.LVMVGStatus[i].Status = lvmv1alpha1.VGStatusReady
+				}
+				break
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to update LVMVolumeGroupNodeStatus: %w", err)
+	}
+	return result != controllerutil.OperationResultNone, nil
+}
+
+func (r *RAIDMonitorReconciler) emitTransitionEvents(
+	ctx context.Context,
+	vg *lvmv1alpha1.LVMVolumeGroup,
+	oldStatus, newStatus *lvmv1alpha1.RAIDStatus,
+) {
+	oldOverall := overallStatus(oldStatus)
+	newOverall := overallStatus(newStatus)
+
+	if oldOverall != newOverall {
+		switch newOverall {
+		case lvmv1alpha1.RAIDHealthStatusDegraded:
+			r.raidWarningEvent(ctx, vg, EventReasonRAIDDegraded,
+				fmt.Errorf("RAID array %s on node %s is degraded", vg.GetName(), r.NodeName))
+		case lvmv1alpha1.RAIDHealthStatusFailed:
+			r.raidWarningEvent(ctx, vg, EventReasonRAIDFailed,
+				fmt.Errorf("RAID array %s on node %s has failed", vg.GetName(), r.NodeName))
+		case lvmv1alpha1.RAIDHealthStatusHealthy:
+			if oldOverall != "" {
+				r.raidNormalEvent(ctx, vg, EventReasonRAIDRecovered,
+					fmt.Sprintf("RAID array %s on node %s has recovered", vg.GetName(), r.NodeName))
+			}
+		}
+	}
+
+	oldSyncing := syncingLVs(oldStatus)
+	newSyncing := syncingLVs(newStatus)
+
+	for lv := range newSyncing {
+		if !oldSyncing[lv] {
+			r.raidNormalEvent(ctx, vg, EventReasonRAIDSyncStarted,
+				fmt.Sprintf("RAID LV %s in %s on node %s started resynchronization", lv, vg.GetName(), r.NodeName))
+		}
+	}
+	for lv := range oldSyncing {
+		if !newSyncing[lv] {
+			r.raidNormalEvent(ctx, vg, EventReasonRAIDSyncCompleted,
+				fmt.Sprintf("RAID LV %s in %s on node %s completed resynchronization", lv, vg.GetName(), r.NodeName))
+		}
+	}
+}
+
+func (r *RAIDMonitorReconciler) raidWarningEvent(ctx context.Context, obj *lvmv1alpha1.LVMVolumeGroup, reason EventReasonError, errMsg error) {
+	emitEventToVGAndOwners(ctx, r.Client, r.EventRecorder, r.NodeName, r.Namespace, obj,
+		corev1.EventTypeWarning, string(reason), "MonitorRAIDHealth", errMsg.Error())
+}
+
+func (r *RAIDMonitorReconciler) raidNormalEvent(ctx context.Context, obj *lvmv1alpha1.LVMVolumeGroup, reason EventReasonInfo, message string) {
+	emitEventToVGAndOwners(ctx, r.Client, r.EventRecorder, r.NodeName, r.Namespace, obj,
+		corev1.EventTypeNormal, string(reason), "MonitorRAIDHealth", message)
+}
+
+func (r *RAIDMonitorReconciler) matchesThisNode(ctx context.Context, selector *corev1.NodeSelector) (bool, error) {
+	return matchesNode(ctx, r.Client, r.NodeName, selector)
+}
+
+func overallStatus(s *lvmv1alpha1.RAIDStatus) lvmv1alpha1.RAIDHealthStatus {
+	if s == nil {
+		return ""
+	}
+	return s.Status
+}
+
+func syncingLVs(s *lvmv1alpha1.RAIDStatus) map[string]bool {
+	result := make(map[string]bool)
+	if s == nil {
+		return result
+	}
+	for _, lv := range s.LVHealth {
+		if lv.SyncPercent < 100 {
+			result[lv.Name] = true
+		}
+	}
+	return result
+}
+
+func statusChanged(old, new *lvmv1alpha1.RAIDStatus) bool {
+	if old == nil && new == nil {
+		return false
+	}
+	if old == nil || new == nil {
+		return true
+	}
+	if old.Status != new.Status {
+		return true
+	}
+	if len(old.LVHealth) != len(new.LVHealth) {
+		return true
+	}
+	for i := range old.LVHealth {
+		if old.LVHealth[i].Name != new.LVHealth[i].Name ||
+			old.LVHealth[i].SyncPercent != new.LVHealth[i].SyncPercent ||
+			old.LVHealth[i].HealthStatus != new.LVHealth[i].HealthStatus {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controllers/vgmanager/raid_monitor_test.go
+++ b/internal/controllers/vgmanager/raid_monitor_test.go
@@ -1,0 +1,194 @@
+package vgmanager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	lvmv1alpha1 "github.com/openshift/lvm-operator/v4/api/v1alpha1"
+	"github.com/openshift/lvm-operator/v4/internal/controllers/vgmanager/lvm"
+	lvmmocks "github.com/openshift/lvm-operator/v4/internal/controllers/vgmanager/lvm/mocks"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func setupRAIDMonitor(t *testing.T) (*RAIDMonitorReconciler, *lvmmocks.MockLVM, client.WithWatch, *events.FakeRecorder) {
+	t.Helper()
+	mockLVM := lvmmocks.NewMockLVM(t)
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node", Labels: map[string]string{
+		"kubernetes.io/hostname": "test-host",
+	}}}
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-lvm-storage"}}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithObjects(node, namespace).
+		Build()
+	fakeRecorder := events.NewFakeRecorder(100)
+
+	reconciler := &RAIDMonitorReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme.Scheme,
+		EventRecorder: fakeRecorder,
+		LVM:           mockLVM,
+		NodeName:      node.GetName(),
+		Namespace:     namespace.GetName(),
+	}
+	return reconciler, mockLVM, fakeClient, fakeRecorder
+}
+
+func TestRAIDMonitorSkipsNonRAIDVG(t *testing.T) {
+	ctx := log.IntoContext(context.Background(), zap.New(zap.UseDevMode(true)))
+	reconciler, _, fakeClient, _ := setupRAIDMonitor(t)
+
+	vg := &lvmv1alpha1.LVMVolumeGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "vg1", Namespace: "openshift-lvm-storage"},
+		Spec:       lvmv1alpha1.LVMVolumeGroupSpec{},
+	}
+	if err := fakeClient.Create(ctx, vg); err != nil {
+		t.Fatalf("failed to create VG: %v", err)
+	}
+
+	result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(vg)})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Errorf("expected no requeue for non-RAID VG, got %v", result.RequeueAfter)
+	}
+}
+
+func TestRAIDMonitorDetectsDegradedState(t *testing.T) {
+	ctx := log.IntoContext(context.Background(), zap.New(zap.UseDevMode(true)))
+	reconciler, mockLVM, fakeClient, _ := setupRAIDMonitor(t)
+
+	vg := &lvmv1alpha1.LVMVolumeGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "vg1", Namespace: "openshift-lvm-storage"},
+		Spec: lvmv1alpha1.LVMVolumeGroupSpec{
+			RAIDConfig: &lvmv1alpha1.RAIDConfig{Type: lvmv1alpha1.RAIDTypeRAID1},
+		},
+	}
+	if err := fakeClient.Create(ctx, vg); err != nil {
+		t.Fatalf("failed to create VG: %v", err)
+	}
+
+	nodeStatus := &lvmv1alpha1.LVMVolumeGroupNodeStatus{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node", Namespace: "openshift-lvm-storage"},
+		Spec: lvmv1alpha1.LVMVolumeGroupNodeStatusSpec{
+			LVMVGStatus: []lvmv1alpha1.VGStatus{
+				{Name: "vg1", Status: lvmv1alpha1.VGStatusReady},
+			},
+		},
+	}
+	if err := fakeClient.Create(ctx, nodeStatus); err != nil {
+		t.Fatalf("failed to create node status: %v", err)
+	}
+
+	mockLVM.EXPECT().ListVGs(ctx, true).Return([]lvm.VolumeGroup{{
+		Name:   "vg1",
+		VgSize: "2G",
+		PVs: []lvm.PhysicalVolume{
+			{PvName: "/dev/sda", VgName: "vg1"},
+			{PvName: "[unknown]", VgName: "vg1", PvMissing: "missing"},
+		},
+	}}, nil).Once()
+
+	mockLVM.EXPECT().ListLVs(ctx, "vg1").Return(&lvm.LVReport{
+		Report: []lvm.LVReportItem{{
+			Lv: []lvm.LogicalVolume{
+				{
+					Name:            "lv1",
+					VgName:          "vg1",
+					LvAttr:          "rwi-a-r---",
+					RAIDSyncPercent: "100",
+					LVHealthStatus:  "partial",
+				},
+				{
+					Name:            "lv2",
+					VgName:          "vg1",
+					LvAttr:          "rwi-a-r---",
+					RAIDSyncPercent: "100",
+					LVHealthStatus:  "",
+				},
+			},
+		}},
+	}, nil).Once()
+
+	result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(vg)})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter != 30*time.Second {
+		t.Errorf("expected 30s requeue, got %v", result.RequeueAfter)
+	}
+
+	updatedStatus := &lvmv1alpha1.LVMVolumeGroupNodeStatus{}
+	if err := fakeClient.Get(ctx, client.ObjectKeyFromObject(nodeStatus), updatedStatus); err != nil {
+		t.Fatalf("failed to get updated status: %v", err)
+	}
+	if len(updatedStatus.Spec.LVMVGStatus) != 1 {
+		t.Fatalf("expected 1 VG status, got %d", len(updatedStatus.Spec.LVMVGStatus))
+	}
+	if updatedStatus.Spec.LVMVGStatus[0].Status != lvmv1alpha1.VGStatusDegraded {
+		t.Errorf("expected VG status Degraded, got %s", updatedStatus.Spec.LVMVGStatus[0].Status)
+	}
+	if updatedStatus.Spec.LVMVGStatus[0].RAIDStatus == nil {
+		t.Fatal("expected RAID status to be set")
+	}
+	if updatedStatus.Spec.LVMVGStatus[0].RAIDStatus.Status != lvmv1alpha1.RAIDHealthStatusDegraded {
+		t.Errorf("expected RAID status Degraded, got %s", updatedStatus.Spec.LVMVGStatus[0].RAIDStatus.Status)
+	}
+}
+
+func TestRAIDMonitorHandlesLVMFailureGracefully(t *testing.T) {
+	ctx := log.IntoContext(context.Background(), zap.New(zap.UseDevMode(true)))
+	reconciler, mockLVM, fakeClient, _ := setupRAIDMonitor(t)
+
+	vg := &lvmv1alpha1.LVMVolumeGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "vg1", Namespace: "openshift-lvm-storage"},
+		Spec: lvmv1alpha1.LVMVolumeGroupSpec{
+			RAIDConfig: &lvmv1alpha1.RAIDConfig{Type: lvmv1alpha1.RAIDTypeRAID1},
+		},
+	}
+	if err := fakeClient.Create(ctx, vg); err != nil {
+		t.Fatalf("failed to create VG: %v", err)
+	}
+
+	mockLVM.EXPECT().ListVGs(ctx, true).Return(nil, fmt.Errorf("lvm command failed")).Once()
+
+	result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(vg)})
+	if err != nil {
+		t.Fatalf("expected nil error on LVM failure, got %v", err)
+	}
+	if result.RequeueAfter != 30*time.Second {
+		t.Errorf("expected 30s requeue on LVM failure, got %v", result.RequeueAfter)
+	}
+}
+
+func TestStatusChanged(t *testing.T) {
+	tests := []struct {
+		name     string
+		old, new *lvmv1alpha1.RAIDStatus
+		expected bool
+	}{
+		{"both nil", nil, nil, false},
+		{"old nil new set", nil, &lvmv1alpha1.RAIDStatus{Status: lvmv1alpha1.RAIDHealthStatusHealthy}, true},
+		{"old set new nil", &lvmv1alpha1.RAIDStatus{Status: lvmv1alpha1.RAIDHealthStatusHealthy}, nil, true},
+		{"same status", &lvmv1alpha1.RAIDStatus{Status: lvmv1alpha1.RAIDHealthStatusHealthy}, &lvmv1alpha1.RAIDStatus{Status: lvmv1alpha1.RAIDHealthStatusHealthy}, false},
+		{"different status", &lvmv1alpha1.RAIDStatus{Status: lvmv1alpha1.RAIDHealthStatusHealthy}, &lvmv1alpha1.RAIDStatus{Status: lvmv1alpha1.RAIDHealthStatusDegraded}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := statusChanged(tt.old, tt.new); got != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}

--- a/internal/controllers/vgmanager/status.go
+++ b/internal/controllers/vgmanager/status.go
@@ -43,12 +43,6 @@ func (r *Reconciler) setVolumeGroupProgressingStatus(ctx context.Context, vg *lv
 		return false, err
 	}
 
-	if vg.Spec.RAIDConfig != nil {
-		if err := r.applyRAIDStatus(ctx, vg, status); err != nil {
-			return false, fmt.Errorf("failed to collect RAID status: %w", err)
-		}
-	}
-
 	return r.setVolumeGroupStatus(ctx, vg, status)
 }
 
@@ -60,12 +54,6 @@ func (r *Reconciler) setVolumeGroupReadyStatus(ctx context.Context, vg *lvmv1alp
 
 	if _, err := r.setDevices(status, vgs, devices); err != nil {
 		return false, err
-	}
-
-	if vg.Spec.RAIDConfig != nil {
-		if err := r.applyRAIDStatus(ctx, vg, status); err != nil {
-			return false, fmt.Errorf("failed to collect RAID status: %w", err)
-		}
 	}
 
 	return r.setVolumeGroupStatus(ctx, vg, status)
@@ -82,12 +70,6 @@ func (r *Reconciler) setVolumeGroupFailedStatus(ctx context.Context, vg *lvmv1al
 		return false, fmt.Errorf("could not set devices in VGStatus: %w", err)
 	} else if devicesExist {
 		status.Status = lvmv1alpha1.VGStatusDegraded
-	}
-
-	if vg.Spec.RAIDConfig != nil {
-		if err := r.applyRAIDStatus(ctx, vg, status); err != nil {
-			return false, fmt.Errorf("failed to collect RAID status: %w", err)
-		}
 	}
 
 	return r.setVolumeGroupStatus(ctx, vg, status)
@@ -118,6 +100,7 @@ func (r *Reconciler) setVolumeGroupStatus(ctx context.Context, vg *lvmv1alpha1.L
 		for i, existingVGStatus := range nodeStatus.Spec.LVMVGStatus {
 			if existingVGStatus.Name == status.Name {
 				exists = true
+				status.RAIDStatus = existingVGStatus.RAIDStatus
 				nodeStatus.Spec.LVMVGStatus[i] = *status
 			}
 		}
@@ -140,10 +123,6 @@ func (r *Reconciler) setVolumeGroupStatus(ctx context.Context, vg *lvmv1alpha1.L
 
 func (r *Reconciler) removeVolumeGroupStatus(ctx context.Context, vg *lvmv1alpha1.LVMVolumeGroup) error {
 	logger := log.FromContext(ctx)
-
-	if vg.Spec.RAIDConfig != nil {
-		deleteRAIDMetrics(r.NodeName, vg.GetName())
-	}
 
 	// Get LVMVolumeGroupNodeStatus and remove the relevant VGStatus
 	nodeStatus := &lvmv1alpha1.LVMVolumeGroupNodeStatus{
@@ -245,26 +224,3 @@ func (r *Reconciler) getLVMVolumeGroupNodeStatus() *lvmv1alpha1.LVMVolumeGroupNo
 	}
 }
 
-// applyRAIDStatus queries logical volumes for the volume group and populates status with RAID health and metrics.
-func (r *Reconciler) applyRAIDStatus(ctx context.Context, vg *lvmv1alpha1.LVMVolumeGroup, status *lvmv1alpha1.VGStatus) error {
-	lvReport, err := r.ListLVs(ctx, vg.GetName())
-	if err != nil {
-		return fmt.Errorf("failed to list logical volumes for RAID status: %w", err)
-	}
-
-	var allLVs []lvm.LogicalVolume
-	for _, report := range lvReport.Report {
-		allLVs = append(allLVs, report.Lv...)
-	}
-
-	raidStatus := buildRAIDStatus(allLVs, vg.Spec.RAIDConfig.Type)
-	if raidStatus != nil {
-		status.RAIDStatus = raidStatus
-		if raidStatus.Status == lvmv1alpha1.RAIDHealthStatusDegraded || raidStatus.Status == lvmv1alpha1.RAIDHealthStatusFailed {
-			status.Status = lvmv1alpha1.VGStatusDegraded
-		}
-	}
-
-	updateRAIDMetrics(r.NodeName, vg.GetName(), raidStatus)
-	return nil
-}


### PR DESCRIPTION
Extract RAID health monitoring from VGManager into a dedicated RAIDMonitorReconciler that checks RAID status independently every 30s. This ensures RAID degradation is detected even when VGManager's reconcile fails at earlier steps.

The monitor emits events on state transitions, updates RAIDStatus on LVMVolumeGroupNodeStatus, and reports richer Prometheus metrics (lvms_raid_member_count, lvms_raid_degraded_count, per-LV lvms_raid_sync_percent). VGManager retains RAID setup logic only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added continuous RAID monitoring for volume groups on matching nodes.
  * Exposed richer RAID metrics, including member count, degraded count, and per-volume resync progress.
  * Added new status change events for degraded, failed, recovered, and sync start/completion states.

* **Bug Fixes**
  * RAID health checks are now handled separately from main volume group reconciliation, reducing unnecessary requeues.
  * Volume group status updates now preserve existing RAID state more consistently.
  * RAID-related metrics are cleaned up more reliably when resources are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->