### PR TITLE
NO-JIRA: feat(status): fix raid status display

### DIFF
--- a/internal/controllers/vgmanager/raid.go
+++ b/internal/controllers/vgmanager/raid.go
@@ -123,18 +123,24 @@ func buildRAIDStatus(lvs []lvm.LogicalVolume, pvs []lvm.PhysicalVolume, raidType
 		return nil
 	}
 
-	unhealthyCount := 0
+	failedCount := 0
+	degradedCount := 0
 	for _, h := range lvHealth {
-		if h.HealthStatus != "" {
-			unhealthyCount++
+		switch h.HealthStatus {
+		case "":
+			// healthy
+		case "partial":
+			degradedCount++
+		default:
+			failedCount++
 		}
 	}
 
 	overallStatus := lvmv1alpha1.RAIDHealthStatusHealthy
 	if len(lvHealth) > 0 {
-		if unhealthyCount == len(lvHealth) {
+		if failedCount == len(lvHealth) {
 			overallStatus = lvmv1alpha1.RAIDHealthStatusFailed
-		} else if unhealthyCount > 0 {
+		} else if failedCount > 0 || degradedCount > 0 {
 			overallStatus = lvmv1alpha1.RAIDHealthStatusDegraded
 		}
 	}

--- a/internal/controllers/vgmanager/raid_test.go
+++ b/internal/controllers/vgmanager/raid_test.go
@@ -359,13 +359,13 @@ func TestBuildRAIDStatus(t *testing.T) {
 			expectedMinSyncPercent: ptr.To(42),
 		},
 		{
-			name: "single LV with partial health is failed",
+			name: "single LV with partial health is degraded",
 			lvs: []lvm.LogicalVolume{
 				{Name: "lv-pvc-abc", LvAttr: "rwi-a-r--p", RAIDSyncPercent: "100.00", LVHealthStatus: "partial", LVLayout: "raid,raid1"},
 			},
 			raidType: lvmv1alpha1.RAIDTypeRAID1,
 			expected: &lvmv1alpha1.RAIDStatus{
-				Status: lvmv1alpha1.RAIDHealthStatusFailed,
+				Status: lvmv1alpha1.RAIDHealthStatusDegraded,
 				LVHealth: []lvmv1alpha1.RAIDLVHealth{
 					{Name: "lv-pvc-abc", RAIDType: lvmv1alpha1.RAIDTypeRAID1, SyncPercent: 100, HealthStatus: "partial"},
 				},
@@ -389,16 +389,46 @@ func TestBuildRAIDStatus(t *testing.T) {
 			expectedMinSyncPercent: ptr.To(100),
 		},
 		{
-			name: "all LVs unhealthy is failed",
+			name: "all LVs partial is degraded not failed",
 			lvs: []lvm.LogicalVolume{
 				{Name: "lv-pvc-abc", LvAttr: "rwi-a-r--p", RAIDSyncPercent: "100.00", LVHealthStatus: "partial", LVLayout: "raid,raid1"},
 				{Name: "lv-pvc-def", LvAttr: "rwi-a-r--p", RAIDSyncPercent: "100.00", LVHealthStatus: "partial", LVLayout: "raid,raid1"},
 			},
 			raidType: lvmv1alpha1.RAIDTypeRAID1,
 			expected: &lvmv1alpha1.RAIDStatus{
-				Status: lvmv1alpha1.RAIDHealthStatusFailed,
+				Status: lvmv1alpha1.RAIDHealthStatusDegraded,
 				LVHealth: []lvmv1alpha1.RAIDLVHealth{
 					{Name: "lv-pvc-abc", RAIDType: lvmv1alpha1.RAIDTypeRAID1, SyncPercent: 100, HealthStatus: "partial"},
+					{Name: "lv-pvc-def", RAIDType: lvmv1alpha1.RAIDTypeRAID1, SyncPercent: 100, HealthStatus: "partial"},
+				},
+			},
+			expectedMinSyncPercent: ptr.To(100),
+		},
+		{
+			name: "all LVs with non-partial health status is failed",
+			lvs: []lvm.LogicalVolume{
+				{Name: "lv-pvc-abc", LvAttr: "rwi-a-r---", RAIDSyncPercent: "100.00", LVHealthStatus: "refresh needed", LVLayout: "raid,raid1"},
+			},
+			raidType: lvmv1alpha1.RAIDTypeRAID1,
+			expected: &lvmv1alpha1.RAIDStatus{
+				Status: lvmv1alpha1.RAIDHealthStatusFailed,
+				LVHealth: []lvmv1alpha1.RAIDLVHealth{
+					{Name: "lv-pvc-abc", RAIDType: lvmv1alpha1.RAIDTypeRAID1, SyncPercent: 100, HealthStatus: "refresh needed"},
+				},
+			},
+			expectedMinSyncPercent: ptr.To(100),
+		},
+		{
+			name: "mixed failed and partial is degraded not failed",
+			lvs: []lvm.LogicalVolume{
+				{Name: "lv-pvc-abc", LvAttr: "rwi-a-r---", RAIDSyncPercent: "100.00", LVHealthStatus: "refresh needed", LVLayout: "raid,raid1"},
+				{Name: "lv-pvc-def", LvAttr: "rwi-a-r--p", RAIDSyncPercent: "100.00", LVHealthStatus: "partial", LVLayout: "raid,raid1"},
+			},
+			raidType: lvmv1alpha1.RAIDTypeRAID1,
+			expected: &lvmv1alpha1.RAIDStatus{
+				Status: lvmv1alpha1.RAIDHealthStatusDegraded,
+				LVHealth: []lvmv1alpha1.RAIDLVHealth{
+					{Name: "lv-pvc-abc", RAIDType: lvmv1alpha1.RAIDTypeRAID1, SyncPercent: 100, HealthStatus: "refresh needed"},
 					{Name: "lv-pvc-def", RAIDType: lvmv1alpha1.RAIDTypeRAID1, SyncPercent: 100, HealthStatus: "partial"},
 				},
 			},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RAID health classification across volume health states.
  * RAID arrays with partially healthy volumes are now reported as **Degraded** instead of **Failed**.
  * RAID status is now **Failed** only when all volumes are in a failed (non-partial) state.
  * Mixed combinations of failed and partial volumes now correctly show **Degraded** overall status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->