### PR TITLE
Add Konflux override snapshot generation script and slash command

### DIFF
--- a/.claude/commands/lvms/konflux/create_snapshot.md
+++ b/.claude/commands/lvms/konflux/create_snapshot.md
@@ -4,7 +4,13 @@ argument-hint: [BUNDLE_IMAGE_REF]
 allowed-tools:
   - Read(hack/generate_override_snapshot_yaml.sh)
   - Read(snapshots/**)
-  - Bash
+  - Bash(hack/generate_override_snapshot_yaml.sh:*)
+  - Bash(oc login:*)
+  - Bash(oc status:*)
+  - Bash(oc project:*)
+  - Bash(oc whoami:*)
+  - Bash(oc apply:*)
+  - Bash(oc get snapshot:*)
   - AskUserQuestion
 ---
 
@@ -30,6 +36,7 @@ Create a konflux override snapshot for the LVM Operator.
 2. Write the output to a file in the snapshots folder matching the name field from the yaml output
 3. Ask the user "Do you want to apply the snapshot yaml now, or do you want to apply it later?"
 4. If the user wants to apply the yaml now:
+	- Immediately before applying, validate the cluster context with `oc whoami --show-server` and `oc project -q`, confirming the server is `https://api.stone-prd-rh01.pg1f.p1.openshiftapps.com:6443` and the project is `logical-volume-manag-tenant`. If either does not match, stop and ask the user to fix their context before continuing.
 	- run `oc apply -n logical-volume-manag-tenant -f` with the path to the generated yaml file.
-	- monitor the snapshot apply to make sure it is applied successfully by starting a background poller (Bash tool, `run_in_background: true`) to track the integration test status without blocking the conversation. Poll `oc get snapshot <name> -n logical-volume-manag-tenant -o jsonpath='{range .status.conditions[*]}{.type}{"="}{.status}{" ("}{.reason}{") "}{end}'` every ~20s, logging each check, and stop once the `AppStudioIntegrationStatus` condition's reason reaches a terminal state (`Finished`, `Failed`, or `Error`). Cap the loop at roughly 30 minutes. On exit, dump the full `oc get snapshot ... -o yaml` for the final state. Report the outcome to the user once the poller finishes.
+	- monitor the snapshot apply to make sure it is applied successfully by starting a background poller (Bash tool, `run_in_background: true`) to track the integration test status without blocking the conversation. Every poll command must include the validated `-n logical-volume-manag-tenant` namespace and target the validated server context so the poller cannot drift to a different cluster or project if the kubeconfig changes later. Poll `oc get snapshot <name> -n logical-volume-manag-tenant -o jsonpath='{range .status.conditions[*]}{.type}{"="}{.status}{" ("}{.reason}{") "}{end}'` every ~20s, logging each check, and stop once the `AppStudioIntegrationStatus` condition's reason reaches a terminal state (`Finished`, `Failed`, or `Error`). Cap the loop at roughly 30 minutes. On exit, dump the full `oc get snapshot ... -o yaml` for the final state. Report the outcome to the user once the poller finishes.
 5. If the user does not want to apply the yaml now, provide them a path to the generated snapshot

--- a/.claude/commands/lvms/konflux/create_snapshot.md
+++ b/.claude/commands/lvms/konflux/create_snapshot.md
@@ -1,0 +1,35 @@
+---
+description: Create an LVM Operator override snapshot in Konflux based off a specified bundle image
+argument-hint: [BUNDLE_IMAGE_REF]
+allowed-tools:
+  - Read(hack/generate_override_snapshot_yaml.sh)
+  - Read(snapshots/**)
+  - Bash
+  - AskUserQuestion
+---
+
+# Create Snapshot
+
+Create a konflux override snapshot for the LVM Operator.
+
+## Prerequisites
+1. The user must have the following CLIs:
+	- `oc`
+	- `hack/generate_override_snapshot_yaml.sh`
+
+2. The user must be logged into the konflux cluster
+	- `oc status` should show the user logged into the server `https://api.stone-prd-rh01.pg1f.p1.openshiftapps.com:6443`
+	- If the user is not logged in, the user will need to run `oc login --web https://api.stone-prd-rh01.pg1f.p1.openshiftapps.com:6443/` to log into the konflux server.
+		Prompt the user to do the login and wait for them to confirm they have logged in before continuing.
+	
+3. The user must have access to the `logical-volume-manag-tenant` project/namespace on the cluster: `oc project logical-volume-manag-tenant`
+
+## Workflow
+
+1. Run the `hack/generate_override_snapshot_yaml.sh` script passing [BUNDLE_IMAGE_REF] as a positional arg. Save the output.
+2. Write the output to a file in the snapshots folder matching the name field from the yaml output
+3. Ask the user "Do you want to apply the snapshot yaml now, or do you want to apply it later?"
+4. If the user wants to apply the yaml now:
+	- run `oc apply -n logical-volume-manag-tenant -f` with the path to the generated yaml file.
+	- monitor the snapshot apply to make sure it is applied successfully by starting a background poller (Bash tool, `run_in_background: true`) to track the integration test status without blocking the conversation. Poll `oc get snapshot <name> -n logical-volume-manag-tenant -o jsonpath='{range .status.conditions[*]}{.type}{"="}{.status}{" ("}{.reason}{") "}{end}'` every ~20s, logging each check, and stop once the `AppStudioIntegrationStatus` condition's reason reaches a terminal state (`Finished`, `Failed`, or `Error`). Cap the loop at roughly 30 minutes. On exit, dump the full `oc get snapshot ... -o yaml` for the final state. Report the outcome to the user once the poller finishes.
+5. If the user does not want to apply the yaml now, provide them a path to the generated snapshot

--- a/hack/generate_override_snapshot_yaml.sh
+++ b/hack/generate_override_snapshot_yaml.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+#
+# get_related_images.sh
+#
+# Extract the related images from an operator bundle image's
+# ClusterServiceVersion manifest.
+#
+# Usage: get_related_images.sh BUNDLE_IMAGE_REF
+#
+# Example:
+#   get_related_images.sh quay.io/redhat-user-workloads/logical-volume-manag-tenant/lvm-operator-bundle@sha256:abc123
+#
+
+set -euo pipefail
+
+readonly TEMP_DIR="/tmp/get-related-images-$$"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") BUNDLE_IMAGE_REF
+
+Extract the related images from an operator bundle image.
+
+Positional Arguments:
+    BUNDLE_IMAGE_REF   Full bundle image reference (e.g., quay.io/org/bundle@sha256:...)
+
+EOF
+}
+
+IMAGE_BASE_URL="quay.io/redhat-user-workloads/logical-volume-manag-tenant"
+
+error() {
+    echo "ERROR: $*" >&2
+}
+
+cleanup() {
+    rm -rf "$TEMP_DIR"
+}
+
+trap cleanup EXIT
+
+check_dependencies() {
+    local missing=()
+
+    for tool in skopeo jq yq tar; do
+        if ! command -v "$tool" >/dev/null 2>&1; then
+            missing+=("$tool")
+        fi
+    done
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        error "Missing required tools: ${missing[*]}"
+        exit 1
+    fi
+}
+
+get_image_sha(){
+	local image_ref="${1}"
+	image_ref=${image_ref#*@} # Drop anything before the 'sha:'
+	echo ${image_ref%\"} # Remove the trailing quote
+}
+
+get_image_git_ref(){
+	local image_ref="${1}"
+	echo $(skopeo inspect --config docker://${image_ref} | jq -r '.config.Labels."vcs-ref"')
+}
+
+# Copies the bundle image locally and extracts its layers, leaving the
+# ClusterServiceVersion manifest accessible under $TEMP_DIR/extracted.
+extract_bundle_manifests() {
+    local bundle_image="$1"
+    local copy_dir="$TEMP_DIR/image"
+    local extract_dir="$TEMP_DIR/extracted"
+
+    mkdir -p "$copy_dir" "$extract_dir"
+
+    if ! skopeo copy "docker://${bundle_image}" "dir:${copy_dir}" >/dev/null; then
+        error "Failed to copy bundle image: $bundle_image"
+        exit 1
+    fi
+
+    local layer_digest
+    while IFS= read -r layer_digest; do
+        layer_digest="${layer_digest#sha256:}"
+        tar -xf "${copy_dir}/${layer_digest}" -C "$extract_dir"
+    done < <(jq -r '.layers[].digest' "${copy_dir}/manifest.json")
+}
+
+find_csv_file() {
+    find "$TEMP_DIR/extracted" -type f -iname '*.clusterserviceversion.yaml' | head -n1
+}
+
+# Parses the flat "- image: ...\n  name: ..." relatedImages list out of the
+# ClusterServiceVersion yaml and emits it as a JSON object mapping each
+# related image's name to its image reference.
+extract_related_images() {
+    local csv_file="$1"
+    local related_images_block
+    related_images_block=$(awk '/^  relatedImages:/{flag=1; next} flag && /^  [a-zA-Z]/{exit} flag' "$csv_file")
+
+    if [ -z "$related_images_block" ]; then
+        echo "{}"
+        return
+    fi
+
+    local images names
+    images=$(echo "$related_images_block" | grep -E '^\s*-\s*image:' | sed -E 's/^\s*-\s*image:\s*//')
+    names=$(echo "$related_images_block" | grep -E '^\s*name:' | sed -E 's/^\s*name:\s*//')
+
+    paste -d'\t' <(echo "$names") <(echo "$images") | jq -R -s '
+    split("\n") | map(select(length > 0)) | map(split("\t")) | map({key: .[0], value: .[1]}) | from_entries
+    '
+}
+
+main() {
+    if [ $# -ne 1 ]; then
+        usage
+        exit 1
+    fi
+
+    local bundle_image="$1"
+
+    check_dependencies
+
+	# Get the needed data for the bundle
+    VERSION=$(skopeo inspect --config docker://${bundle_image} | jq -r '.config.Labels.version')
+    X="${VERSION%%.*}"
+    Y="${VERSION#*.}"
+    Y="${Y%.*}"
+    Z="${VERSION##*.}"
+
+    BUNDLE_GIT_REF=$(get_image_git_ref ${bundle_image})
+
+	# Extract the manifests so we can get the needed info for the related images
+    extract_bundle_manifests "$bundle_image"
+
+    local csv_file
+    csv_file=$(find_csv_file)
+    if [ -z "$csv_file" ]; then
+        error "No ClusterServiceVersion manifest found in bundle image: $bundle_image"
+        exit 1
+    fi
+
+    local related_images
+    related_images=$(extract_related_images "$csv_file")
+
+	# Get the related image refs
+	OPERAND_SHA=$(get_image_sha $(echo "${related_images}" | jq -r '."lvms-operator"'))
+	MUST_GATHER_SHA=$(get_image_sha $(echo "${related_images}" | jq -r '."lvms-must-gather"'))
+	TOPOLVM_SHA=$(get_image_sha $(echo "${related_images}" | jq -r '."topolvm-csi"'))
+
+	SKIP_TOPOLVM=0
+	if [[ -z "${TOPOLVM_SHA}" || "${TOPOLVM_SHA}" == "null" ]] ; then
+		SKIP_TOPOLVM=1
+	fi
+
+	# Get the git ref for each image
+	OPERAND_IMG="${IMAGE_BASE_URL}/lvm-operator@${OPERAND_SHA}"
+	OPERAND_GIT_REF=$(get_image_git_ref "${OPERAND_IMG}")
+
+	MUST_GATHER_IMG="${IMAGE_BASE_URL}/lvms-must-gather@${MUST_GATHER_SHA}"
+	MUST_GATHER_GIT_REF=$(get_image_git_ref "${MUST_GATHER_IMG}")
+
+	BUNDLE_IMG="${bundle_image}"
+
+	output_yaml=$(cat <<EOF
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  name: lvm-operator-${X}-${Y}-${Z}-override
+  namespace: logical-volume-manag-tenant
+  labels:
+    test.appstudio.openshift.io/type: override
+spec:
+  application: lvm-operator-${X}-${Y}
+  components:
+    - name: lvm-operator-${X}-${Y}
+      containerImage: ${OPERAND_IMG}
+      source:
+        git:
+          url: https://github.com/openshift/lvm-operator
+          revision: ${OPERAND_GIT_REF}
+    - name: lvms-must-gather-${X}-${Y}
+      containerImage: ${MUST_GATHER_IMG}
+      source:
+        git:
+          url: https://github.com/openshift/lvm-operator
+          revision: ${MUST_GATHER_GIT_REF}
+    - name: lvm-operator-bundle-${X}-${Y}
+      containerImage: ${BUNDLE_IMG}
+      source:
+        git:
+          url: https://github.com/openshift/lvm-operator
+          revision: ${BUNDLE_GIT_REF}
+EOF
+	)
+
+	if [ "$SKIP_TOPOLVM" -eq 0 ]; then
+		TOPOLVM_IMG="${IMAGE_BASE_URL}/topolvm@${TOPOLVM_SHA}"
+		TOPOLVM_GIT_REF=$(get_image_git_ref "${TOPOLVM_IMG}")
+
+		topolvm_obj=$(cat <<-EOF
+		{
+		  "name": "topolvm-${X}-${Y}",
+		  "containerImage": "${TOPOLVM_IMG}",
+		  "source": {
+		    "git": {
+		      "url": "https://github.com/openshift/topolvm",
+		      "revision": "${TOPOLVM_GIT_REF}"
+		    }
+		  }
+		}
+		EOF
+		)
+
+		output_yaml=$(echo "${output_yaml}" | yq ".spec.components += [${topolvm_obj}]")
+	fi
+
+	echo "${output_yaml}"
+}
+
+main "$@"

--- a/hack/generate_override_snapshot_yaml.sh
+++ b/hack/generate_override_snapshot_yaml.sh
@@ -13,7 +13,7 @@
 
 set -euo pipefail
 
-readonly TEMP_DIR="/tmp/get-related-images-$$"
+readonly TEMP_DIR="$(mktemp -d -t get-related-images.XXXXXX)"
 
 usage() {
     cat <<EOF
@@ -42,7 +42,7 @@ trap cleanup EXIT
 check_dependencies() {
     local missing=()
 
-    for tool in skopeo jq yq tar; do
+    for tool in skopeo jq tar; do
         if ! command -v "$tool" >/dev/null 2>&1; then
             missing+=("$tool")
         fi
@@ -56,13 +56,13 @@ check_dependencies() {
 
 get_image_sha(){
 	local image_ref="${1}"
-	image_ref=${image_ref#*@} # Drop anything before the 'sha:'
-	echo ${image_ref%\"} # Remove the trailing quote
+	image_ref="${image_ref#*@}" # Drop anything before the 'sha:'
+	echo "${image_ref%\"}" # Remove the trailing quote
 }
 
 get_image_git_ref(){
 	local image_ref="${1}"
-	echo $(skopeo inspect --config docker://${image_ref} | jq -r '.config.Labels."vcs-ref"')
+	skopeo inspect --config "docker://${image_ref}" | jq -r '.config.Labels."vcs-ref"'
 }
 
 # Copies the bundle image locally and extracts its layers, leaving the
@@ -123,13 +123,13 @@ main() {
     check_dependencies
 
 	# Get the needed data for the bundle
-    VERSION=$(skopeo inspect --config docker://${bundle_image} | jq -r '.config.Labels.version')
+    VERSION=$(skopeo inspect --config "docker://${bundle_image}" | jq -r '.config.Labels.version')
     X="${VERSION%%.*}"
     Y="${VERSION#*.}"
     Y="${Y%.*}"
     Z="${VERSION##*.}"
 
-    BUNDLE_GIT_REF=$(get_image_git_ref ${bundle_image})
+    BUNDLE_GIT_REF=$(get_image_git_ref "${bundle_image}")
 
 	# Extract the manifests so we can get the needed info for the related images
     extract_bundle_manifests "$bundle_image"
@@ -145,9 +145,9 @@ main() {
     related_images=$(extract_related_images "$csv_file")
 
 	# Get the related image refs
-	OPERAND_SHA=$(get_image_sha $(echo "${related_images}" | jq -r '."lvms-operator"'))
-	MUST_GATHER_SHA=$(get_image_sha $(echo "${related_images}" | jq -r '."lvms-must-gather"'))
-	TOPOLVM_SHA=$(get_image_sha $(echo "${related_images}" | jq -r '."topolvm-csi"'))
+	OPERAND_SHA=$(get_image_sha "$(echo "${related_images}" | jq -r '."lvms-operator"')")
+	MUST_GATHER_SHA=$(get_image_sha "$(echo "${related_images}" | jq -r '."lvms-must-gather"')")
+	TOPOLVM_SHA=$(get_image_sha "$(echo "${related_images}" | jq -r '."topolvm-csi"')")
 
 	SKIP_TOPOLVM=0
 	if [[ -z "${TOPOLVM_SHA}" || "${TOPOLVM_SHA}" == "null" ]] ; then
@@ -199,21 +199,13 @@ EOF
 		TOPOLVM_IMG="${IMAGE_BASE_URL}/topolvm@${TOPOLVM_SHA}"
 		TOPOLVM_GIT_REF=$(get_image_git_ref "${TOPOLVM_IMG}")
 
-		topolvm_obj=$(cat <<-EOF
-		{
-		  "name": "topolvm-${X}-${Y}",
-		  "containerImage": "${TOPOLVM_IMG}",
-		  "source": {
-		    "git": {
-		      "url": "https://github.com/openshift/topolvm",
-		      "revision": "${TOPOLVM_GIT_REF}"
-		    }
-		  }
-		}
-		EOF
-		)
-
-		output_yaml=$(echo "${output_yaml}" | yq ".spec.components += [${topolvm_obj}]")
+		output_yaml="${output_yaml}
+    - name: topolvm-${X}-${Y}
+      containerImage: ${TOPOLVM_IMG}
+      source:
+        git:
+          url: https://github.com/openshift/topolvm
+          revision: ${TOPOLVM_GIT_REF}"
 	fi
 
 	echo "${output_yaml}"


### PR DESCRIPTION
## Summary
- Add `hack/generate_override_snapshot_yaml.sh`, which derives an override `Snapshot` manifest from a bundle image by pulling related image digests and git revisions.
- Add a `/lvms:konflux:create_snapshot` command that drives the generate → save → apply → monitor workflow for creating and applying an override snapshot in Konflux.

## Test plan
- [x] Ran `hack/generate_override_snapshot_yaml.sh` against a bundle image and confirmed the generated YAML matched the expected `Snapshot` structure.
- [x] Applied the generated snapshot to the `logical-volume-manag-tenant` namespace and confirmed it was created and began integration testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command guide for creating and optionally applying LVM Operator override snapshots from a bundle image.
  * Added a utility that generates Snapshot YAML by extracting bundle metadata, image digests, and source revisions.
  * Added readiness monitoring with status reporting when applying snapshots.
  * Supports optional TopoLVM CSI component details when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->