### PR TITLE
NO-JIRA: fix: updating 4.21.1 to use an override operator snapshot

### DIFF
--- a/releases/lvm-operator-rhba-v4.21.1.yaml
+++ b/releases/lvm-operator-rhba-v4.21.1.yaml
@@ -2,13 +2,13 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: lvm-operator-rhba-v4.21.1
+  name: lvm-operator-rhba-v4.21.1-redo
   namespace: logical-volume-manag-tenant
   labels:
-    release.appstudio.openshift.io/author: "Pablo Acevedo Montserrat <pacevedo@redhat.com>"
+    release.appstudio.openshift.io/author: "Jeff Roche <jeroche@redhat.com>"
 spec:
   releasePlan: lvm-operator-production-releaseplan-4-21
-  snapshot: lvm-operator-4-21-20260623-150433-000
+  snapshot: lvm-operator-4-21-1-override
   data:
     releaseNotes:
       description: |


### PR DESCRIPTION
New snapshot was generated with the command from #2879 