### PR TITLE
OCPBUGS-90617: feat(tests): read new overprovision ratio

### DIFF
--- a/test/integration/qe_tests/lvms.go
+++ b/test/integration/qe_tests/lvms.go
@@ -4249,6 +4249,11 @@ spec:
 			logf("Created PVC %s and Deployment %s on node %s\n", pvcName, depName, workerName)
 		}
 
+		g.By("#. Get CSIStorageCapacity before decreasing overprovision ratio")
+		capacityBeforeDecrease := getCurrentTotalLvmStorageCapacityByStorageClass(storageClassName)
+		logf("CSIStorageCapacity before ratio decrease: %d\n", capacityBeforeDecrease)
+		o.Expect(capacityBeforeDecrease).To(o.BeNumerically(">", 0), "CSIStorageCapacity before ratio decrease must be positive")
+
 		g.By("#. Decrease overprovision ratio value to 1")
 		err = patchOverprovisionRatio(newLVMClusterName, lvmsNamespace, "1")
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -4260,6 +4265,13 @@ spec:
 			deviceClassName: deviceClassName,
 		}
 		checkLVMClusterAndVGManagerPodReady(tc, lvmClusterObj)
+
+		g.By("#. Wait for CSIStorageCapacity to be updated after ratio decrease")
+		o.Eventually(func() int {
+			capacity := getCurrentTotalLvmStorageCapacityByStorageClass(storageClassName)
+			logf("Current CSIStorageCapacity: %d (was: %d)\n", capacity, capacityBeforeDecrease)
+			return capacity
+		}, 3*time.Minute, 5*time.Second).Should(o.BeNumerically("<", capacityBeforeDecrease))
 
 		g.By("#. Create pvc2")
 		pvc2Name := "test-pvc-final-76425"


### PR DESCRIPTION
Read updated overprovision ratio value before running other tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened validation of storage capacity updates after reducing LVM overprovisioning.
  * Added a convergence wait to confirm CSI-reported storage capacity decreases before running the expected PVC provisioning failure assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->