### PR TITLE
OCPEDGE-2388: Release 4.20.1 fixes

### DIFF
--- a/releases/lvm-operator-catalog-4.20.1.yaml
+++ b/releases/lvm-operator-catalog-4.20.1.yaml
@@ -2,10 +2,10 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: lvm-operator-catalog-4-20-20260604-115618-000
+  name: lvm-operator-catalog-4-20-20260723-111014-000
   namespace: logical-volume-manag-tenant
   labels:
     release.appstudio.openshift.io/author: "Pablo Acevedo Montserrat <pacevedo@redhat.com>"
 spec:
   releasePlan: lvm-operator-catalog-production-releaseplan-4-20
-  snapshot: lvm-operator-catalog-4-20-20260604-115618-000
+  snapshot: lvm-operator-catalog-4-20-20260723-111014-000

--- a/releases/lvm-operator-rhba-v4.20.1.yaml
+++ b/releases/lvm-operator-rhba-v4.20.1.yaml
@@ -2,13 +2,13 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: lvm-operator-rhba-v4.20.1
+  name: lvm-operator-rhba-v4.20.1-1
   namespace: logical-volume-manag-tenant
   labels:
     release.appstudio.openshift.io/author: "Pablo Acevedo Montserrat <pacevedo@redhat.com>"
 spec:
   releasePlan: lvm-operator-production-releaseplan-4-20
-  snapshot: lvm-operator-4-20-20260604-111251-000
+  snapshot: lvm-operator-4-20-1-manual-release
   data:
     releaseNotes:
       description: |


### PR DESCRIPTION
- Fixed must-gather image to include cpe labels.
- Fixed bundle image to include cpe labels.
- Pinned the operator image to the one that was tested in https://github.com/openshift/lvm-operator/pull/2546
- Updated the bundle image.
- Updated the catalog to reference the new bundle.

Because of approvals in https://github.com/openshift/lvm-operator/pull/2546, will override them as there are no code changes.