### PR TITLE
NO-ISSUE: Add inspect-catalog helper

### DIFF
--- a/hack/inspect-catalog.sh
+++ b/hack/inspect-catalog.sh
@@ -15,13 +15,16 @@ Options:
   --arch ARCH      Platform architecture (default: amd64)
   --package NAME   Filter to a specific package
   --version VER    Filter to a specific version (e.g., 4.19.3 or v4.19.3)
-  --labels         Fetch image labels (vcs-ref, build-date) via skopeo inspect per bundle
+  --labels         Fetch image labels (vcs-ref, build-date) via skopeo inspect
+  --registry-override OLD=NEW
+                   Remap registry prefix when fetching labels (repeatable)
   -h, --help       Show this help
 
 Examples:
   $(basename "$0") quay.io/org/catalog@sha256:abc123...
   $(basename "$0") --json --labels quay.io/org/catalog:latest
-  $(basename "$0") --package lvms-operator --version 4.19.3 quay.io/org/catalog@sha256:abc123...
+  $(basename "$0") --package lvms-operator --version 4.19.3 IMAGE
+  $(basename "$0") --labels --registry-override OLD_REG=NEW_REG IMAGE
 EOF
     exit "${1:-0}"
 }
@@ -32,6 +35,7 @@ PACKAGE_FILTER=""
 VERSION_FILTER=""
 FETCH_LABELS=false
 CATALOG_IMAGE=""
+REGISTRY_OVERRIDES=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -54,6 +58,10 @@ while [[ $# -gt 0 ]]; do
         --labels)
             FETCH_LABELS=true
             shift
+            ;;
+        --registry-override)
+            REGISTRY_OVERRIDES+=("$2")
+            shift 2
             ;;
         -h|--help)
             usage 0
@@ -92,20 +100,23 @@ resolve_arch_digest() {
     raw=$(skopeo inspect --raw "docker://${image}" 2>/dev/null)
 
     local media_type
-    media_type=$(echo "${raw}" | jq -r '.mediaType // .schemaVersion' 2>/dev/null)
+    media_type=$(echo "${raw}" | \
+        jq -r '.mediaType // .schemaVersion' 2>/dev/null)
 
     case "${media_type}" in
         *index*|*list*)
             local digest
             digest=$(echo "${raw}" | jq -r \
                 --arg arch "${arch}" \
-                '.manifests[] | select(.platform.architecture == $arch) | .digest' 2>/dev/null | head -1)
+                '.manifests[] | select(.platform.architecture == $arch) | .digest' \
+                2>/dev/null | head -1)
             if [[ -z "${digest}" ]]; then
-                echo "Error: no manifest found for architecture ${arch}" >&2
+                echo "Error: no manifest for arch ${arch}" >&2
                 exit 1
             fi
             local base
-            base=$(echo "${image}" | sed 's/@sha256:.*//; s/:.*$//')
+            base=$(echo "${image}" | \
+                sed 's/@sha256:.*//; s/:.*$//')
             echo "${base}@${digest}"
             ;;
         *)
@@ -120,20 +131,26 @@ echo "Pulling image layers..." >&2
 
 IMGDIR="${TMPDIR}/image"
 mkdir -p "${IMGDIR}"
-skopeo copy "docker://${RESOLVED_IMAGE}" "dir://${IMGDIR}" >/dev/null 2>&1
+skopeo copy "docker://${RESOLVED_IMAGE}" \
+    "dir://${IMGDIR}" >/dev/null 2>&1
 
 FBCDIR="${TMPDIR}/fbc"
 mkdir -p "${FBCDIR}"
 
-LAYERS=$(jq -r '.layers[].digest | sub("sha256:";"")' "${IMGDIR}/manifest.json")
+LAYERS=$(jq -r \
+    '.layers[].digest | sub("sha256:";"")' \
+    "${IMGDIR}/manifest.json")
 for layer in ${LAYERS}; do
-    has_configs=$(tar tf "${IMGDIR}/${layer}" 2>/dev/null | grep -c "^configs/" || true)
+    has_configs=$(tar tf "${IMGDIR}/${layer}" \
+        2>/dev/null | grep -c "^configs/" || true)
     if [[ "${has_configs}" -gt 0 ]]; then
-        tar xf "${IMGDIR}/${layer}" -C "${FBCDIR}" "configs" 2>/dev/null || true
+        tar xf "${IMGDIR}/${layer}" \
+            -C "${FBCDIR}" "configs" 2>/dev/null || true
     fi
 done
 
-CATALOG_FILES=$(find "${FBCDIR}" -name "catalog.json" -type f 2>/dev/null)
+CATALOG_FILES=$(find "${FBCDIR}" \
+    -name "catalog.json" -type f 2>/dev/null)
 if [[ -z "${CATALOG_FILES}" ]]; then
     echo "Error: no catalog.json found in image" >&2
     exit 1
@@ -144,54 +161,86 @@ for f in ${CATALOG_FILES}; do
     cat "${f}"
 done | jq -s '.' > "${ALL_ENTRIES}"
 
+JQ_QUERY_FILE="${TMPDIR}/query.jq"
+cat > "${JQ_QUERY_FILE}" << 'JQEOF'
+def channel_entries:
+    [.[] | select(.schema == "olm.channel") |
+        . as $ch | .entries[]? |
+        {channel: $ch.name, bundle: .name, replaces: .replaces,
+         skips: (.skips // []), skipRange: .skipRange}];
+
+def get_version:
+    [(.properties // [])[] |
+        select(.type == "olm.package") | .value.version
+    ] | first // "";
+
+. as $all |
+channel_entries as $channels |
+[.[] | select(.schema == "olm.bundle") |
+    select(if $pkg != "" then .package == $pkg else true end) |
+    get_version as $bv |
+    select(if $ver != "" then
+        ($bv == $ver) or (.name | endswith("v" + $ver))
+    else true end) |
+    . as $bundle |
+    {
+        package: .package,
+        name: .name,
+        image: .image,
+        channels: ([($channels[] |
+            select(.bundle == $bundle.name) | .channel)] | unique),
+        upgrade_info: [($channels[] |
+            select(.bundle == $bundle.name) |
+            {channel: .channel, replaces: .replaces,
+             skips: .skips, skipRange: .skipRange})],
+        relatedImages: [(.relatedImages // [])[] |
+            {name: .name, image: .image}],
+        properties: [(.properties // [])[] |
+            select(.type == "olm.package") | .value]
+    }
+] | sort_by(.package, .name)
+JQEOF
+
 build_output() {
     local package_filter="$1"
     local version_filter="$2"
 
-    jq --arg pkg "${package_filter}" --arg ver "${version_filter}" '
-    def channel_entries:
-        [.[] | select(.schema == "olm.channel") |
-            . as $ch |
-            .entries[]? |
-            {channel: $ch.name, bundle: .name, replaces: .replaces, skips: (.skips // []), skipRange: .skipRange}
-        ];
-
-    . as $all |
-    channel_entries as $channels |
-
-    [.[] | select(.schema == "olm.bundle") |
-        select(if $pkg != "" then .package == $pkg else true end) |
-        ((.properties // [])[] | select(.type == "olm.package") | .value.version) as $bundle_version |
-        select(if $ver != "" then ($bundle_version == $ver or .name == (".*v" + $ver) or (.name | endswith("v" + $ver))) else true end) |
-        . as $bundle |
-        {
-            package: .package,
-            name: .name,
-            image: .image,
-            channels: [($channels[] | select(.bundle == $bundle.name) | .channel)] | unique,
-            upgrade_info: [($channels[] | select(.bundle == $bundle.name) |
-                {channel: .channel, replaces: .replaces, skips: .skips, skipRange: .skipRange})],
-            relatedImages: [(.relatedImages // [])[] | {name: .name, image: .image}],
-            properties: [(.properties // [])[] |
-                select(.type == "olm.package") | .value]
-        }
-    ] | sort_by(.package, .name)
-    ' "${ALL_ENTRIES}"
+    jq --arg pkg "${package_filter}" \
+       --arg ver "${version_filter}" \
+       -f "${JQ_QUERY_FILE}" "${ALL_ENTRIES}"
 }
 
 echo "Extracting bundle information..." >&2
 
 RESULT=$(build_output "${PACKAGE_FILTER}" "${VERSION_FILTER}")
 
+apply_registry_overrides() {
+    local image="$1"
+    for override in "${REGISTRY_OVERRIDES[@]}"; do
+        local old="${override%%=*}"
+        local new="${override#*=}"
+        image="${image/${old}/${new}}"
+    done
+    echo "${image}"
+}
+
 fetch_image_labels() {
     local image="$1"
-    skopeo inspect "docker://${image}" 2>/dev/null | jq '{
-        "vcs-ref": .Labels["vcs-ref"],
-        "org.opencontainers.image.revision": .Labels["org.opencontainers.image.revision"],
-        "org.opencontainers.image.created": .Labels["org.opencontainers.image.created"],
-        "build-date": .Labels["build-date"],
-        "version": .Labels["version"]
-    } | with_entries(select(.value != null))' 2>/dev/null || echo '{}'
+    local inspect_image
+    if [[ ${#REGISTRY_OVERRIDES[@]} -gt 0 ]]; then
+        inspect_image=$(apply_registry_overrides "${image}")
+    else
+        inspect_image="${image}"
+    fi
+    local label_query
+    label_query='{"vcs-ref": .Labels["vcs-ref"],'
+    label_query+='"org.opencontainers.image.revision": .Labels["org.opencontainers.image.revision"],'
+    label_query+='"org.opencontainers.image.created": .Labels["org.opencontainers.image.created"],'
+    label_query+='"build-date": .Labels["build-date"],'
+    label_query+='"version": .Labels["version"]}'
+    label_query+=' | with_entries(select(.value != null))'
+    skopeo inspect "docker://${inspect_image}" 2>/dev/null \
+        | jq "${label_query}" 2>/dev/null || echo '{}'
 }
 
 if [[ "${FETCH_LABELS}" == "true" ]]; then
@@ -204,13 +253,15 @@ if [[ "${FETCH_LABELS}" == "true" ]]; then
     for image in $(echo "${RESULT}" | jq -r '.[].image'); do
         echo "  Inspecting ${image##*@}..." >&2
         labels=$(fetch_image_labels "${image}")
-        jq --arg img "${image}" --argjson labels "${labels}" \
-            '. + {($img): $labels}' "${LABELS_FILE}" > "${LABELS_FILE}.tmp" \
+        jq --arg img "${image}" \
+            --argjson labels "${labels}" \
+            '. + {($img): $labels}' \
+            "${LABELS_FILE}" > "${LABELS_FILE}.tmp" \
             && mv "${LABELS_FILE}.tmp" "${LABELS_FILE}"
     done
 
-    RESULT=$(echo "${RESULT}" | jq --slurpfile labels "${LABELS_FILE}" '
-        . as $bundles |
+    RESULT=$(echo "${RESULT}" | \
+        jq --slurpfile labels "${LABELS_FILE}" '
         ($labels[0] // {}) as $all_labels |
         [.[] | . + {labels: ($all_labels[.image] // {})}]
     ')
@@ -221,30 +272,30 @@ if [[ "${OUTPUT_JSON}" == "true" ]]; then
     exit 0
 fi
 
-echo "${RESULT}" | jq -r '
-    .[] |
-    "================================================================================",
-    "Package:  \(.package)",
-    "Bundle:   \(.name)",
-    "Image:    \(.image)",
-    "Channels: \(.channels | join(", "))",
-    (if .labels and (.labels | length) > 0 then
-        "Labels:",
-        (.labels | to_entries[] | "  \(.key): \(.value)")
-    else empty end),
-    "",
-    (if (.upgrade_info | length) > 0 then
-        (.upgrade_info[] |
-            "  Channel \(.channel):" +
-            (if .replaces then "\n    Replaces:  \(.replaces)" else "" end) +
-            (if (.skips | length) > 0 then "\n    Skips:     \(.skips | join(", "))" else "" end) +
-            (if .skipRange then "\n    SkipRange: \(.skipRange)" else "" end)
-        )
-    else "" end),
-    "",
-    "Related Images:",
-    (.relatedImages[] |
-        "  \(if .name != "" then "[\(.name)] " else "" end)\(.image)"
-    ),
-    ""
-'
+TABLE_FORMAT_FILE="${TMPDIR}/table.jq"
+cat > "${TABLE_FORMAT_FILE}" << 'JQEOF'
+.[] |
+"=" * 80,
+"Package:  \(.package)",
+"Bundle:   \(.name)",
+"Image:    \(.image)",
+"Channels: \(.channels | join(", "))",
+(if .labels and (.labels | length) > 0 then
+    "Labels:",
+    (.labels | to_entries[] | "  \(.key): \(.value)")
+else empty end),
+"",
+(if (.upgrade_info | length) > 0 then
+    (.upgrade_info[] |
+        "  Channel \(.channel):" +
+        (if .replaces then "\n    Replaces:  \(.replaces)" else "" end) +
+        (if (.skips | length) > 0 then "\n    Skips:     \(.skips | join(", "))" else "" end) +
+        (if .skipRange then "\n    SkipRange: \(.skipRange)" else "" end))
+else "" end),
+"",
+"Related Images:",
+(.relatedImages[] | "  \(if .name != "" then "[\(.name)] " else "" end)\(.image)"),
+""
+JQEOF
+
+echo "${RESULT}" | jq -r -f "${TABLE_FORMAT_FILE}"

--- a/hack/inspect-catalog.sh
+++ b/hack/inspect-catalog.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS] CATALOG_IMAGE
+
+Extract and display all bundles from an OLM file-based catalog image.
+
+Arguments:
+  CATALOG_IMAGE    Catalog image reference (tag or digest)
+
+Options:
+  --json           Output as JSON array
+  --arch ARCH      Platform architecture (default: amd64)
+  --package NAME   Filter to a specific package
+  --version VER    Filter to a specific version (e.g., 4.19.3 or v4.19.3)
+  --labels         Fetch image labels (vcs-ref, build-date) via skopeo inspect per bundle
+  -h, --help       Show this help
+
+Examples:
+  $(basename "$0") quay.io/org/catalog@sha256:abc123...
+  $(basename "$0") --json --labels quay.io/org/catalog:latest
+  $(basename "$0") --package lvms-operator --version 4.19.3 quay.io/org/catalog@sha256:abc123...
+EOF
+    exit "${1:-0}"
+}
+
+OUTPUT_JSON=false
+ARCH="amd64"
+PACKAGE_FILTER=""
+VERSION_FILTER=""
+FETCH_LABELS=false
+CATALOG_IMAGE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --json)
+            OUTPUT_JSON=true
+            shift
+            ;;
+        --arch)
+            ARCH="$2"
+            shift 2
+            ;;
+        --package)
+            PACKAGE_FILTER="$2"
+            shift 2
+            ;;
+        --version)
+            VERSION_FILTER="${2#v}"
+            shift 2
+            ;;
+        --labels)
+            FETCH_LABELS=true
+            shift
+            ;;
+        -h|--help)
+            usage 0
+            ;;
+        -*)
+            echo "Error: unknown option $1" >&2
+            usage 1
+            ;;
+        *)
+            CATALOG_IMAGE="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "${CATALOG_IMAGE}" ]]; then
+    echo "Error: catalog image argument required" >&2
+    usage 1
+fi
+
+for cmd in skopeo jq tar; do
+    if ! command -v "${cmd}" &>/dev/null; then
+        echo "Error: ${cmd} is required but not found" >&2
+        exit 1
+    fi
+done
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+resolve_arch_digest() {
+    local image="$1"
+    local arch="$2"
+
+    local raw
+    raw=$(skopeo inspect --raw "docker://${image}" 2>/dev/null)
+
+    local media_type
+    media_type=$(echo "${raw}" | jq -r '.mediaType // .schemaVersion' 2>/dev/null)
+
+    case "${media_type}" in
+        *index*|*list*)
+            local digest
+            digest=$(echo "${raw}" | jq -r \
+                --arg arch "${arch}" \
+                '.manifests[] | select(.platform.architecture == $arch) | .digest' 2>/dev/null | head -1)
+            if [[ -z "${digest}" ]]; then
+                echo "Error: no manifest found for architecture ${arch}" >&2
+                exit 1
+            fi
+            local base
+            base=$(echo "${image}" | sed 's/@sha256:.*//; s/:.*$//')
+            echo "${base}@${digest}"
+            ;;
+        *)
+            echo "${image}"
+            ;;
+    esac
+}
+
+echo "Resolving ${ARCH} manifest..." >&2
+RESOLVED_IMAGE=$(resolve_arch_digest "${CATALOG_IMAGE}" "${ARCH}")
+echo "Pulling image layers..." >&2
+
+IMGDIR="${TMPDIR}/image"
+mkdir -p "${IMGDIR}"
+skopeo copy "docker://${RESOLVED_IMAGE}" "dir://${IMGDIR}" >/dev/null 2>&1
+
+FBCDIR="${TMPDIR}/fbc"
+mkdir -p "${FBCDIR}"
+
+LAYERS=$(jq -r '.layers[].digest | sub("sha256:";"")' "${IMGDIR}/manifest.json")
+for layer in ${LAYERS}; do
+    has_configs=$(tar tf "${IMGDIR}/${layer}" 2>/dev/null | grep -c "^configs/" || true)
+    if [[ "${has_configs}" -gt 0 ]]; then
+        tar xf "${IMGDIR}/${layer}" -C "${FBCDIR}" "configs" 2>/dev/null || true
+    fi
+done
+
+CATALOG_FILES=$(find "${FBCDIR}" -name "catalog.json" -type f 2>/dev/null)
+if [[ -z "${CATALOG_FILES}" ]]; then
+    echo "Error: no catalog.json found in image" >&2
+    exit 1
+fi
+
+ALL_ENTRIES="${TMPDIR}/all_entries.json"
+for f in ${CATALOG_FILES}; do
+    cat "${f}"
+done | jq -s '.' > "${ALL_ENTRIES}"
+
+build_output() {
+    local package_filter="$1"
+    local version_filter="$2"
+
+    jq --arg pkg "${package_filter}" --arg ver "${version_filter}" '
+    def channel_entries:
+        [.[] | select(.schema == "olm.channel") |
+            . as $ch |
+            .entries[]? |
+            {channel: $ch.name, bundle: .name, replaces: .replaces, skips: (.skips // []), skipRange: .skipRange}
+        ];
+
+    . as $all |
+    channel_entries as $channels |
+
+    [.[] | select(.schema == "olm.bundle") |
+        select(if $pkg != "" then .package == $pkg else true end) |
+        ((.properties // [])[] | select(.type == "olm.package") | .value.version) as $bundle_version |
+        select(if $ver != "" then ($bundle_version == $ver or .name == (".*v" + $ver) or (.name | endswith("v" + $ver))) else true end) |
+        . as $bundle |
+        {
+            package: .package,
+            name: .name,
+            image: .image,
+            channels: [($channels[] | select(.bundle == $bundle.name) | .channel)] | unique,
+            upgrade_info: [($channels[] | select(.bundle == $bundle.name) |
+                {channel: .channel, replaces: .replaces, skips: .skips, skipRange: .skipRange})],
+            relatedImages: [(.relatedImages // [])[] | {name: .name, image: .image}],
+            properties: [(.properties // [])[] |
+                select(.type == "olm.package") | .value]
+        }
+    ] | sort_by(.package, .name)
+    ' "${ALL_ENTRIES}"
+}
+
+echo "Extracting bundle information..." >&2
+
+RESULT=$(build_output "${PACKAGE_FILTER}" "${VERSION_FILTER}")
+
+fetch_image_labels() {
+    local image="$1"
+    skopeo inspect "docker://${image}" 2>/dev/null | jq '{
+        "vcs-ref": .Labels["vcs-ref"],
+        "org.opencontainers.image.revision": .Labels["org.opencontainers.image.revision"],
+        "org.opencontainers.image.created": .Labels["org.opencontainers.image.created"],
+        "build-date": .Labels["build-date"],
+        "version": .Labels["version"]
+    } | with_entries(select(.value != null))' 2>/dev/null || echo '{}'
+}
+
+if [[ "${FETCH_LABELS}" == "true" ]]; then
+    BUNDLE_COUNT=$(echo "${RESULT}" | jq 'length')
+    echo "Fetching labels for ${BUNDLE_COUNT} bundle(s)..." >&2
+
+    LABELS_FILE="${TMPDIR}/labels.json"
+    echo '{}' > "${LABELS_FILE}"
+
+    for image in $(echo "${RESULT}" | jq -r '.[].image'); do
+        echo "  Inspecting ${image##*@}..." >&2
+        labels=$(fetch_image_labels "${image}")
+        jq --arg img "${image}" --argjson labels "${labels}" \
+            '. + {($img): $labels}' "${LABELS_FILE}" > "${LABELS_FILE}.tmp" \
+            && mv "${LABELS_FILE}.tmp" "${LABELS_FILE}"
+    done
+
+    RESULT=$(echo "${RESULT}" | jq --slurpfile labels "${LABELS_FILE}" '
+        . as $bundles |
+        ($labels[0] // {}) as $all_labels |
+        [.[] | . + {labels: ($all_labels[.image] // {})}]
+    ')
+fi
+
+if [[ "${OUTPUT_JSON}" == "true" ]]; then
+    echo "${RESULT}" | jq '.'
+    exit 0
+fi
+
+echo "${RESULT}" | jq -r '
+    .[] |
+    "================================================================================",
+    "Package:  \(.package)",
+    "Bundle:   \(.name)",
+    "Image:    \(.image)",
+    "Channels: \(.channels | join(", "))",
+    (if .labels and (.labels | length) > 0 then
+        "Labels:",
+        (.labels | to_entries[] | "  \(.key): \(.value)")
+    else empty end),
+    "",
+    (if (.upgrade_info | length) > 0 then
+        (.upgrade_info[] |
+            "  Channel \(.channel):" +
+            (if .replaces then "\n    Replaces:  \(.replaces)" else "" end) +
+            (if (.skips | length) > 0 then "\n    Skips:     \(.skips | join(", "))" else "" end) +
+            (if .skipRange then "\n    SkipRange: \(.skipRange)" else "" end)
+        )
+    else "" end),
+    "",
+    "Related Images:",
+    (.relatedImages[] |
+        "  \(if .name != "" then "[\(.name)] " else "" end)\(.image)"
+    ),
+    ""
+'

--- a/hack/inspect-catalog.sh
+++ b/hack/inspect-catalog.sh
@@ -15,16 +15,12 @@ Options:
   --arch ARCH      Platform architecture (default: amd64)
   --package NAME   Filter to a specific package
   --version VER    Filter to a specific version (e.g., 4.19.3 or v4.19.3)
-  --labels         Fetch image labels (vcs-ref, build-date) via skopeo inspect
-  --registry-override OLD=NEW
-                   Remap registry prefix when fetching labels (repeatable)
   -h, --help       Show this help
 
 Examples:
   $(basename "$0") quay.io/org/catalog@sha256:abc123...
-  $(basename "$0") --json --labels quay.io/org/catalog:latest
+  $(basename "$0") --json quay.io/org/catalog:latest
   $(basename "$0") --package lvms-operator --version 4.19.3 IMAGE
-  $(basename "$0") --labels --registry-override OLD_REG=NEW_REG IMAGE
 EOF
     exit "${1:-0}"
 }
@@ -33,9 +29,7 @@ OUTPUT_JSON=false
 ARCH="amd64"
 PACKAGE_FILTER=""
 VERSION_FILTER=""
-FETCH_LABELS=false
 CATALOG_IMAGE=""
-REGISTRY_OVERRIDES=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -53,14 +47,6 @@ while [[ $# -gt 0 ]]; do
             ;;
         --version)
             VERSION_FILTER="${2#v}"
-            shift 2
-            ;;
-        --labels)
-            FETCH_LABELS=true
-            shift
-            ;;
-        --registry-override)
-            REGISTRY_OVERRIDES+=("$2")
             shift 2
             ;;
         -h|--help)
@@ -214,59 +200,6 @@ echo "Extracting bundle information..." >&2
 
 RESULT=$(build_output "${PACKAGE_FILTER}" "${VERSION_FILTER}")
 
-apply_registry_overrides() {
-    local image="$1"
-    for override in "${REGISTRY_OVERRIDES[@]}"; do
-        local old="${override%%=*}"
-        local new="${override#*=}"
-        image="${image/${old}/${new}}"
-    done
-    echo "${image}"
-}
-
-fetch_image_labels() {
-    local image="$1"
-    local inspect_image
-    if [[ ${#REGISTRY_OVERRIDES[@]} -gt 0 ]]; then
-        inspect_image=$(apply_registry_overrides "${image}")
-    else
-        inspect_image="${image}"
-    fi
-    local label_query
-    label_query='{"vcs-ref": .Labels["vcs-ref"],'
-    label_query+='"org.opencontainers.image.revision": .Labels["org.opencontainers.image.revision"],'
-    label_query+='"org.opencontainers.image.created": .Labels["org.opencontainers.image.created"],'
-    label_query+='"build-date": .Labels["build-date"],'
-    label_query+='"version": .Labels["version"]}'
-    label_query+=' | with_entries(select(.value != null))'
-    skopeo inspect "docker://${inspect_image}" 2>/dev/null \
-        | jq "${label_query}" 2>/dev/null || echo '{}'
-}
-
-if [[ "${FETCH_LABELS}" == "true" ]]; then
-    BUNDLE_COUNT=$(echo "${RESULT}" | jq 'length')
-    echo "Fetching labels for ${BUNDLE_COUNT} bundle(s)..." >&2
-
-    LABELS_FILE="${TMPDIR}/labels.json"
-    echo '{}' > "${LABELS_FILE}"
-
-    for image in $(echo "${RESULT}" | jq -r '.[].image'); do
-        echo "  Inspecting ${image##*@}..." >&2
-        labels=$(fetch_image_labels "${image}")
-        jq --arg img "${image}" \
-            --argjson labels "${labels}" \
-            '. + {($img): $labels}' \
-            "${LABELS_FILE}" > "${LABELS_FILE}.tmp" \
-            && mv "${LABELS_FILE}.tmp" "${LABELS_FILE}"
-    done
-
-    RESULT=$(echo "${RESULT}" | \
-        jq --slurpfile labels "${LABELS_FILE}" '
-        ($labels[0] // {}) as $all_labels |
-        [.[] | . + {labels: ($all_labels[.image] // {})}]
-    ')
-fi
-
 if [[ "${OUTPUT_JSON}" == "true" ]]; then
     echo "${RESULT}" | jq '.'
     exit 0
@@ -280,10 +213,6 @@ cat > "${TABLE_FORMAT_FILE}" << 'JQEOF'
 "Bundle:   \(.name)",
 "Image:    \(.image)",
 "Channels: \(.channels | join(", "))",
-(if .labels and (.labels | length) > 0 then
-    "Labels:",
-    (.labels | to_entries[] | "  \(.key): \(.value)")
-else empty end),
 "",
 (if (.upgrade_info | length) > 0 then
     (.upgrade_info[] |

--- a/hack/inspect-catalog.sh
+++ b/hack/inspect-catalog.sh
@@ -11,10 +11,11 @@ Arguments:
   CATALOG_IMAGE    Catalog image reference (tag or digest)
 
 Options:
-  --json           Output as JSON array
+  --json           Output as JSON array (includes commit IDs)
   --arch ARCH      Platform architecture (default: amd64)
   --package NAME   Filter to a specific package
   --version VER    Filter to a specific version (e.g., 4.19.3 or v4.19.3)
+  --no-commits     Skip fetching commit IDs (faster)
   -h, --help       Show this help
 
 Examples:
@@ -30,6 +31,7 @@ ARCH="amd64"
 PACKAGE_FILTER=""
 VERSION_FILTER=""
 CATALOG_IMAGE=""
+FETCH_COMMITS=true
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -48,6 +50,10 @@ while [[ $# -gt 0 ]]; do
         --version)
             VERSION_FILTER="${2#v}"
             shift 2
+            ;;
+        --no-commits)
+            FETCH_COMMITS=false
+            shift
             ;;
         -h|--help)
             usage 0
@@ -94,8 +100,10 @@ resolve_arch_digest() {
             local digest
             digest=$(echo "${raw}" | jq -r \
                 --arg arch "${arch}" \
-                '.manifests[] | select(.platform.architecture == $arch) | .digest' \
-                2>/dev/null | head -1)
+                '[.manifests[] |
+                    select(.platform.architecture == $arch) |
+                    .digest] | first' \
+                2>/dev/null)
             if [[ -z "${digest}" ]]; then
                 echo "Error: no manifest for arch ${arch}" >&2
                 exit 1
@@ -172,6 +180,7 @@ channel_entries as $channels |
     {
         package: .package,
         name: .name,
+        version: $bv,
         image: .image,
         channels: ([($channels[] |
             select(.bundle == $bundle.name) | .channel)] | unique),
@@ -180,9 +189,7 @@ channel_entries as $channels |
             {channel: .channel, replaces: .replaces,
              skips: .skips, skipRange: .skipRange})],
         relatedImages: [(.relatedImages // [])[] |
-            {name: .name, image: .image}],
-        properties: [(.properties // [])[] |
-            select(.type == "olm.package") | .value]
+            {name: .name, image: .image}]
     }
 ] | sort_by(.package, .name)
 JQEOF
@@ -200,31 +207,126 @@ echo "Extracting bundle information..." >&2
 
 RESULT=$(build_output "${PACKAGE_FILTER}" "${VERSION_FILTER}")
 
+# Collect all unique images and fetch commit IDs in parallel
+COMMITS_FILE="${TMPDIR}/commits.json"
+
+if [[ "${FETCH_COMMITS}" == "true" ]]; then
+    IMAGES_FILE="${TMPDIR}/all_images.txt"
+    echo "${RESULT}" | jq -r \
+        '([.[].image] + [.[].relatedImages[].image]) | unique | .[]' \
+        > "${IMAGES_FILE}"
+
+    IMAGE_COUNT=$(wc -l < "${IMAGES_FILE}")
+    echo "Fetching commit IDs for ${IMAGE_COUNT} images..." >&2
+
+    COMMITS_RAW="${TMPDIR}/commits_raw.txt"
+    : > "${COMMITS_RAW}"
+
+    fetch_commit() {
+        local image="$1"
+        local output_file="$2"
+        local commit
+        commit=$(skopeo inspect "docker://${image}" 2>/dev/null | \
+            jq -r '.Labels["vcs-ref"] // empty' 2>/dev/null || true)
+        if [[ -n "${commit}" ]]; then
+            echo "${image} ${commit}" >> "${output_file}"
+        fi
+    }
+    export -f fetch_commit
+
+    xargs -a "${IMAGES_FILE}" -P 8 -I {} \
+        bash -c 'fetch_commit "$@"' _ {} "${COMMITS_RAW}"
+
+    # Build JSON lookup from raw results
+    jq -Rn '[inputs | split(" ") | {(.[0]): .[1]}] | add // {}' \
+        "${COMMITS_RAW}" > "${COMMITS_FILE}"
+
+    echo "Done." >&2
+else
+    echo '{}' > "${COMMITS_FILE}"
+fi
+
+# Merge commit IDs into result
+RESULT_WITH_COMMITS=$(jq --slurpfile commits "${COMMITS_FILE}" '
+    ($commits[0] // {}) as $cm |
+    [.[] | . + {
+        commit: ($cm[.image] // null),
+        relatedImages: [.relatedImages[] | . + {
+            commit: ($cm[.image] // null)
+        }]
+    }]
+' <<< "${RESULT}")
+
 if [[ "${OUTPUT_JSON}" == "true" ]]; then
-    echo "${RESULT}" | jq '.'
+    echo "${RESULT_WITH_COMMITS}" | jq '.'
     exit 0
 fi
 
-TABLE_FORMAT_FILE="${TMPDIR}/table.jq"
-cat > "${TABLE_FORMAT_FILE}" << 'JQEOF'
-.[] |
-"=" * 80,
-"Package:  \(.package)",
-"Bundle:   \(.name)",
-"Image:    \(.image)",
-"Channels: \(.channels | join(", "))",
-"",
-(if (.upgrade_info | length) > 0 then
-    (.upgrade_info[] |
-        "  Channel \(.channel):" +
-        (if .replaces then "\n    Replaces:  \(.replaces)" else "" end) +
-        (if (.skips | length) > 0 then "\n    Skips:     \(.skips | join(", "))" else "" end) +
-        (if .skipRange then "\n    SkipRange: \(.skipRange)" else "" end))
-else "" end),
-"",
-"Related Images:",
-(.relatedImages[] | "  \(if .name != "" then "[\(.name)] " else "" end)\(.image)"),
-""
-JQEOF
+# Compact human-readable output grouped by package > channel > bundle
+echo ""
+echo "${RESULT_WITH_COMMITS}" | jq -r '
+def short_sha:
+    if . then
+        split("@sha256:") |
+        if length > 1 then .[1][:12] else .[0] end
+    else "------------" end;
 
-echo "${RESULT}" | jq -r -f "${TABLE_FORMAT_FILE}"
+def short_commit:
+    if . then .[:12] else "------------" end;
+
+def strip_prefix:
+    ltrimstr("lvms-operator.");
+
+def pad($n):
+    . + (" " * ([$n - length, 0] | max));
+
+def format_upgrade:
+    [
+        (if .replaces then
+            "replaces " + (.replaces | strip_prefix)
+        else null end),
+        (if (.skips | length) > 0 then
+            "skips " + ([.skips[] |
+                strip_prefix] | join(","))
+        else null end),
+        (if .skipRange then
+            "range " + .skipRange
+        else null end)
+    ] | map(select(. != null)) | join("  ");
+
+def bundle_line:
+    .image as $sha | .commit as $c |
+    "  [bundle] \(.name | pad(28)) " +
+    "\($sha | short_sha)  " +
+    "commit:\($c | short_commit)";
+
+def related_line:
+    "    \(.name | pad(20)) " +
+    "\(.image | short_sha)  " +
+    "commit:\(.commit | short_commit)";
+
+group_by(.package)[] |
+    .[0].package as $pkg |
+    "Package: \($pkg)",
+    (group_by(.channels[0])[] |
+        .[0].channels[0] as $chan |
+        "",
+        "  Channel: \($chan)",
+        "  \("-" * 70)",
+        (sort_by(.version |
+            split(".") | map(tonumber? // 0))[] |
+            .image as $bundle_img |
+            (.upgrade_info[0] |
+                format_upgrade) as $ug |
+            bundle_line +
+            (if ($ug | length) > 0 then
+                "\n    \($ug)"
+            else "" end),
+            (.relatedImages[] |
+                select(.image != $bundle_img) |
+                related_line
+            )
+        )
+    ),
+    ""
+'


### PR DESCRIPTION
```bash
$ ./hack/inspect-catalog.sh --help
Usage: inspect-catalog.sh [OPTIONS] CATALOG_IMAGE

Extract and display all bundles from an OLM file-based catalog image.

Arguments:
  CATALOG_IMAGE    Catalog image reference (tag or digest)

Options:
  --json           Output as JSON array (includes commit IDs)
  --arch ARCH      Platform architecture (default: amd64)
  --package NAME   Filter to a specific package
  --version VER    Filter to a specific version (e.g., 4.19.3 or v4.19.3)
  --no-commits     Skip fetching commit IDs (faster)
  -h, --help       Show this help

Examples:
  inspect-catalog.sh quay.io/org/catalog@sha256:abc123...
  inspect-catalog.sh --json quay.io/org/catalog:latest
  inspect-catalog.sh --package lvms-operator --version 4.19.3 IMAGE

$ ./hack/inspect-catalog.sh quay.io/redhat-user-workloads/logical-volume-manag-tenant/lvm-operator-catalog@sha256:40e1f0e2fb764b6e166c0f1af1e68b0ecd9662d9c7737e7159d7c1f3443d011f
Resolving amd64 manifest...
Pulling image layers...
Extracting bundle information...
Fetching commit IDs for 28 images...
Done.

Package: lvms-operator

  Channel: stable-4.18
  ----------------------------------------------------------------------
  [bundle] lvms-operator.v4.18.0        3ebaca245644  commit:9a7ea209dbfb
    lvms-must-gather     fa96b89ffaa0  commit:987f74ada360
    lvms-operator        0c0153db16cb  commit:74db7522c618
    topolvm-csi          4c8ee1fa1ec1  commit:def13df88eab
  [bundle] lvms-operator.v4.18.1        647b839a19ef  commit:43ef276e7931
    lvms-must-gather     075eb4426082  commit:3b4c8cd9fbcd
    lvms-operator        8888d4544134  commit:c2f53303d014
    topolvm-csi          fa2575c4ff57  commit:bc8d1f802991
  [bundle] lvms-operator.v4.18.2        1e37fa696824  commit:d104f2dd1dde
    lvms-must-gather     57f26d3fd9c3  commit:e528d837e449
    lvms-operator        59740856359e  commit:dd529263c81f
    topolvm-csi          cb349df9ef3a  commit:4cc6524a4b81
  [bundle] lvms-operator.v4.18.3        43d5efde837d  commit:2009097c581c
    skips v4.18.0,v4.18.1,v4.18.2
    lvms-must-gather     5d0534e08790  commit:9b475e877af0
    lvms-operator        80f5e48600d9  commit:38a92258b91c
    topolvm-csi          b3b1c4836a82  commit:045802c3cf20

  Channel: stable-4.19
  ----------------------------------------------------------------------
  [bundle] lvms-operator.v4.19.0        6cec0bc33b40  commit:b102ce576e22
    lvms-must-gather     28e0e1feecc7  commit:ee82fa46314b
    lvms-operator        373371743d4c  commit:50c9aac27f7e
  [bundle] lvms-operator.v4.19.1        db9b7aa0d4fe  commit:5bc4a2ad56c7
    lvms-must-gather     1e455df18829  commit:98d5f8d5ac09
    lvms-operator        3701735419e2  commit:c2f3347b7f1a
  [bundle] lvms-operator.v4.19.2        077222b42d5a  commit:f78f77c60ad2
    lvms-must-gather     128106963d49  commit:5b96492f0c53
    lvms-operator        ef047e920236  commit:5b96492f0c53
  [bundle] lvms-operator.v4.19.3        5245275268dd  commit:------------
    replaces v4.18.3  skips v4.18.0,v4.18.1,v4.18.2,v4.19.0,v4.19.1,v4.19.2  range >=4.2.0 <4.19.3
    lvms-must-gather     a780573a1ea5  commit:bff279174d0a
    lvms-operator        e0ebe6eba711  commit:------------
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a command-line utility to inspect file-based catalogs bundled in container images.
  * Supports architecture selection plus package and version filtering, and outputs either normalized JSON or a human-readable report.
  * Extracts bundle package/image details, channel lists, and upgrade/replacement/skip relationships (including skip ranges).
  * Includes related images and selected package properties for the matched entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->