### PR TITLE
No-Jira: Skip rapidast in disconnected cluster

### DIFF
--- a/test/integration/qe_tests/lvms_utils.go
+++ b/test/integration/qe_tests/lvms_utils.go
@@ -41,36 +41,34 @@ func getRandomString() string {
 }
 
 func isDisconnectedCluster() bool {
-	// Get a node name to run the network probe
 	nodeCmd := exec.Command("oc", "get", "nodes", "-o=jsonpath={.items[0].metadata.name}")
 	nodeOutput, err := nodeCmd.CombinedOutput()
 	if err != nil {
 		logf("Warning: failed to get node name: %v", err)
-		return false
+		return true
 	}
 	nodeName := strings.TrimSpace(string(nodeOutput))
 	if nodeName == "" {
 		logf("Warning: no nodes found")
-		return false
+		return true
 	}
 
-	// Network probe: curl an external URL from the node to check connectivity
 	probeCmd := exec.Command("oc", "debug", "node/"+nodeName, "--",
 		"chroot", "/host", "sh", "-c",
 		"curl -s --connect-timeout 5 https://fedoraproject.org/static/hotspot.txt &>/dev/null && echo Connected || echo Disconnected")
 	probeOutput, err := probeCmd.CombinedOutput()
 	if err != nil {
 		logf("Warning: network probe failed: %v", err)
-		return false
-	}
-
-	result := strings.TrimSpace(string(probeOutput))
-	if strings.Contains(result, "Disconnected") {
-		logf("Detected disconnected cluster: network probe failed to reach external URL")
 		return true
 	}
 
-	return false
+	result := strings.TrimSpace(string(probeOutput))
+	if strings.Contains(result, "Connected") {
+		return false
+	}
+
+	logf("Detected disconnected cluster: network probe failed to reach external URL")
+	return true
 }
 
 type lvmCluster struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disconnected-cluster detection to consistently handle missing nodes, node retrieval failures, and network probe errors.
  * Clusters are now classified as connected only when the connectivity check explicitly reports “Connected.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->