### PR TITLE
OCPEDGE-2877: Fix OCP-89594 - Remove deviceSelector from devicediscovery template

### DIFF
--- a/test/integration/qe_tests/testdata/lvmcluster-devicediscovery-template.yaml
+++ b/test/integration/qe_tests/testdata/lvmcluster-devicediscovery-template.yaml
@@ -15,8 +15,6 @@ objects:
         default: true
         deviceDiscoveryPolicy: ${DEVICE_DISCOVERY_POLICY}
         fstype: ${FSTYPE}
-        deviceSelector:
-          forceWipeDevicesAndDestroyAllData: true
         thinPoolConfig:
           name: thin-pool-1
           sizePercent: 90


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Removed the forced device wipe setting from the LVMCluster device discovery template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->