### PR TITLE
OCPEDGE-2875: Automate OCP-90162-Verify LVMS RAID5 survives disk failure and can be recovered

### DIFF
--- a/test/integration/qe_tests/lvms.go
+++ b/test/integration/qe_tests/lvms.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -5960,6 +5961,287 @@ spec:
 		o.Expect(err).NotTo(o.HaveOccurred())
 		err = waitForLVMClusterReady(originLVMClusterName, lvmsNamespace, LVMClusterReadyTimeout)
 		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It("Author:mmakwana-High-90162-[OTP][LVMS] Verify LVMS RAID5 survives disk failure and can be repaired with replacement disk [Disruptive]", g.Label("SNO", "MNO", "Serial"), func() {
+
+		g.By("#. Get list of available block devices/disks attached to all worker nodes")
+		freeDiskNameCountMap, err := getListOfFreeDisksFromWorkerNodes(tc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		workerNodes, err := getWorkersList()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		workerNodeCount := len(workerNodes)
+
+		// RAID5 needs 3 disks; a 4th disk is required as the replacement/spare.
+		// All 4 must exist with the same name on every worker node so the RAID5
+		// device class can be created and repaired regardless of pod placement.
+		var disks []string
+		for diskName, count := range freeDiskNameCountMap {
+			if count == int64(workerNodeCount) {
+				disks = append(disks, diskName)
+			}
+			if len(disks) == 4 {
+				break
+			}
+		}
+		if len(disks) < 4 {
+			g.Skip("Skipped: RAID5 disk-failure test needs at least 4 free block devices/disks with the same name on all worker nodes (3 for RAID5 + 1 replacement)")
+		}
+		// Sort disks alphabetically for deterministic selection across test runs.
+		sort.Strings(disks)
+
+		diskPath1 := "/dev/" + disks[0]
+		diskPath2 := "/dev/" + disks[1]
+		diskPath3 := "/dev/" + disks[2]
+		spareDisk := disks[3]
+		spareDiskPath := "/dev/" + spareDisk
+		logf("RAID5 disks: %s, %s, %s | replacement disk: %s\n", diskPath1, diskPath2, diskPath3, spareDiskPath)
+
+		g.By("#. Copy and save existing LVMCluster configuration in JSON format")
+		originLVMClusterName, err := getLVMClusterName(lvmsNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		originLVMJSON, err := getLVMClusterJSON(originLVMClusterName, lvmsNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		logf("Original LVMCluster saved: %s\n", originLVMClusterName)
+
+		g.By("#. Delete existing LVMCluster resource")
+		deleteSpecifiedResource("lvmcluster", originLVMClusterName, lvmsNamespace)
+
+		g.By("#. Wait for baseline VG to be fully removed from all worker nodes")
+		o.Eventually(func() bool {
+			// On multi-node clusters, must verify baseline VG is removed from all nodes
+			for _, node := range workerNodes {
+				cmd := exec.Command("oc", "debug", "node/"+node, "--", "chroot", "/host", "/bin/bash", "-c", "vgs --noheadings -o vg_name 2>/dev/null")
+				output, err := cmd.CombinedOutput()
+				// If vgs returns output, check that baseline VGs are not present
+				if err == nil {
+					vgList := strings.TrimSpace(string(output))
+					if strings.Contains(vgList, "vg1") || strings.Contains(vgList, originLVMClusterName) {
+						return false // Baseline VG still exists on this node
+					}
+				}
+				// If vgs failed, assume no VGs on this node (expected after deletion)
+			}
+			return true // All nodes have baseline VG removed
+		}, 2*time.Minute, 5*time.Second).Should(o.BeTrue(), "Baseline VG should be removed from all nodes before RAID5 creation")
+		logf("Baseline VG removed from all worker nodes\n")
+
+		defer func() {
+			exists, _ := resourceExists("lvmcluster", originLVMClusterName, lvmsNamespace)
+			if !exists {
+				logf("Restoring original LVMCluster from saved JSON...\n")
+				if err := createLVMClusterFromJSON(originLVMJSON); err != nil {
+					logf("Warning: Failed to restore LVMCluster from JSON: %v\n", err)
+				}
+			}
+			if err := waitForLVMClusterReady(originLVMClusterName, lvmsNamespace, LVMClusterReadyTimeout); err != nil {
+				logf("Warning: LVMCluster did not become ready: %v\n", err)
+			}
+		}()
+
+		g.By("#. Create LVMCluster with RAID5 configuration")
+		newLVMClusterName := "test-raid5"
+		deviceClassName := "raid5-class"
+		err = createLVMClusterWithRAID(newLVMClusterName, lvmsNamespace, deviceClassName,
+			[]string{diskPath1, diskPath2, diskPath3},
+			RAIDConfig{Type: "raid5", Mirrors: "null", Stripes: "2"})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Safety net for the failure path: if the test aborts while Degraded, the
+		// LVMCluster delete above strips the finalizer but can leave a stale VG (with
+		// a missing PV) and LVM signatures on the disks, which would collide with the
+		// baseline LVMCluster restore. This defer is registered after the delete defer
+		// so it runs first (LIFO): delete CR -> clean VG/wipe disks -> restore baseline.
+		raid5DiskPaths := []string{diskPath1, diskPath2, diskPath3, spareDiskPath}
+		defer func() {
+			for _, node := range workerNodes {
+				cleanupRAID5VGOnNode(node, deviceClassName, raid5DiskPaths)
+			}
+		}()
+
+		defer func() {
+			logf("Cleaning up test LVMCluster %s...\n", newLVMClusterName)
+			deleteLVMClusterSafely(newLVMClusterName, lvmsNamespace, deviceClassName)
+		}()
+
+		g.By("#. Wait for RAID5 LVMCluster to be Ready")
+		err = waitForLVMClusterReady(newLVMClusterName, lvmsNamespace, LVMClusterForceWipeReadyTimeout)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		logf("RAID5 LVMCluster created successfully\n")
+
+		g.By("#. Create PVC with RAID5 storage class")
+		storageClassName := "lvms-" + deviceClassName
+		pvcName := "raid5-pvc"
+		err = createPVCWithOC(pvcConfig{
+			name:             pvcName,
+			namespace:        testNamespace,
+			storageClassName: storageClassName,
+			storage:          "1Gi",
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create PVC")
+		logf("PVC created: %s\n", pvcName)
+
+		defer func() {
+			deleteSpecifiedResource("pvc", pvcName, testNamespace)
+		}()
+
+		g.By("#. Create Pod with PVC")
+		podName := "raid5-pod"
+		err = createPodWithOC(podConfig{
+			name:      podName,
+			namespace: testNamespace,
+			pvcName:   pvcName,
+			mountPath: "/mnt/data",
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create pod")
+		logf("Pod created: %s\n", podName)
+
+		defer func() {
+			deleteSpecifiedResource("pod", podName, testNamespace)
+		}()
+
+		g.By("#. Wait for PVC to be bound")
+		o.Eventually(func() string {
+			cmd := exec.Command("oc", "get", "pvc", pvcName, "-n", testNamespace, "-o=jsonpath={.status.phase}")
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				logf("Error getting PVC status: %v, output: %s\n", err, string(output))
+			}
+			return strings.TrimSpace(string(output))
+		}, PVCBoundTimeout, 5*time.Second).Should(o.Equal("Bound"))
+		logf("PVC %s is Bound\n", pvcName)
+
+		g.By("#. Wait for Pod to be Running")
+		o.Eventually(func() string {
+			cmd := exec.Command("oc", "get", "pod", podName, "-n", testNamespace, "-o=jsonpath={.status.phase}")
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				logf("Error getting Pod status: %v, output: %s\n", err, string(output))
+			}
+			return strings.TrimSpace(string(output))
+		}, PodReadyTimeout, 5*time.Second).Should(o.Equal("Running"))
+		logf("Pod %s is Running\n", podName)
+
+		g.By("#. Determine the node hosting the RAID5 volume")
+		targetNode := getNodeNameByPod(testNamespace, podName)
+		o.Expect(targetNode).NotTo(o.BeEmpty(), "Pod is not scheduled to any node")
+		logf("RAID5 volume is hosted on target node\n")
+
+		g.By("#. Write test data to the volume")
+		testData := "RAID5 test data"
+		writeCmd := exec.Command("oc", "exec", podName, "-n", testNamespace, "-c", "test-container", "--", "/bin/sh", "-c",
+			fmt.Sprintf("echo '%s' > /mnt/data/testfile && sync", testData))
+		writeOutput, err := writeCmd.CombinedOutput()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to write data to pod: %s", string(writeOutput))
+		logf("Test data written to volume\n")
+
+		g.By("#. Read and verify test data")
+		readCmd := exec.Command("oc", "exec", podName, "-n", testNamespace, "-c", "test-container", "--", "/bin/sh", "-c", "cat /mnt/data/testfile")
+		readOutput, err := readCmd.CombinedOutput()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to read data from pod: %s", string(readOutput))
+		o.Expect(strings.TrimSpace(string(readOutput))).To(o.Equal(testData))
+		logf("Data verified: %s\n", strings.TrimSpace(string(readOutput)))
+
+		g.By("#. Simulate disk failure - remove one RAID5 disk from the node")
+		// Best-effort restore of the node's disk topology for subsequent tests
+		// and baseline restoration, even if the test fails part-way through.
+		defer rescanDisksOnNode(targetNode)
+		simulateDiskFailureOnNode(targetNode, disks[2])
+
+		g.By("#. Verify LVMCluster enters Degraded state")
+		o.Eventually(func() string {
+			state, err := getLVMClusterState(newLVMClusterName, lvmsNamespace)
+			if err != nil {
+				logf("Warning: failed to get LVMCluster state: %v\n", err)
+				return ""
+			}
+			logf("LVMCluster %s state: %s\n", newLVMClusterName, state)
+			return state
+		}, 5*time.Minute, 10*time.Second).Should(o.Equal("Degraded"), "LVMCluster should report Degraded after disk failure")
+		logf("LVMCluster is Degraded after disk failure - verified\n")
+
+		g.By("#. Verify data still accessible during degraded state")
+		readDegradedCmd := exec.Command("oc", "exec", podName, "-n", testNamespace, "-c", "test-container", "--", "/bin/sh", "-c", "cat /mnt/data/testfile")
+		readOutput, err = readDegradedCmd.CombinedOutput()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to read data during degraded state: %s", string(readOutput))
+		o.Expect(string(readOutput)).To(o.ContainSubstring(testData), "Data should remain readable while RAID5 is degraded")
+		logf("Data still accessible during degraded state: %s\n", strings.TrimSpace(string(readOutput)))
+
+		g.By("#. Verify writes work during degraded state")
+		degradedData := "Written during degraded"
+		writeDegradedCmd := exec.Command("oc", "exec", podName, "-n", testNamespace, "-c", "test-container", "--", "/bin/sh", "-c",
+			fmt.Sprintf("echo '%s' >> /mnt/data/testfile && sync", degradedData))
+		writeDegradedOutput, err := writeDegradedCmd.CombinedOutput()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to write data during degraded state: %s", string(writeDegradedOutput))
+		logf("Data written during degraded state\n")
+
+		g.By("#. Repair RAID5 on the node using the replacement disk")
+		repairRAID5OnNode(targetNode, deviceClassName, spareDiskPath)
+
+		g.By("#. Update LVMCluster CR with the replacement device path")
+		newPaths := fmt.Sprintf(`[{"op":"replace","path":"/spec/storage/deviceClasses/0/deviceSelector/paths","value":["%s","%s","%s"]}]`, diskPath1, diskPath2, spareDiskPath)
+		patchCmd := exec.Command("oc", "patch", "lvmcluster", newLVMClusterName, "-n", lvmsNamespace, "--type=json", "-p", newPaths)
+		patchOutput, err := patchCmd.CombinedOutput()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to patch LVMCluster device paths: %s", string(patchOutput))
+		logf("LVMCluster device paths patched to use replacement disk\n")
+
+		g.By("#. Wait for LVMCluster to return to Ready after repair")
+		err = waitForLVMClusterReady(newLVMClusterName, lvmsNamespace, LVMClusterForceWipeReadyTimeout)
+		o.Expect(err).NotTo(o.HaveOccurred(), "LVMCluster did not return to Ready after repair")
+		logf("LVMCluster is Ready after RAID5 repair\n")
+
+		g.By("#. Wait for RAID5 resync to complete (sync_percent == 100%)")
+		// RAID5 rebuild happens in background; we need to wait for full resync before
+		// verifying data integrity. Query the RAID LV's sync_percent from the target node.
+		o.Eventually(func() bool {
+			// Scope to the RAID LV (--select 'segtype=~raid') so an unrelated LV at 100%
+			// cannot satisfy the wait, and match the reported value format (LVM prints
+			// "100.00", not "100") so the poll can actually succeed.
+			cmd := exec.Command("oc", "debug", "node/"+targetNode, "--", "chroot", "/host", "/bin/bash", "-c",
+				"lvs --noheadings -o sync_percent --select 'segtype=~raid' "+deviceClassName+" 2>/dev/null | tr -d ' %' | grep -qE '^100(\\.0+)?$' && echo true || echo false")
+			// Output() (stdout only): the `oc debug` stderr banner would otherwise make
+			// TrimSpace(output) != "true" and the poll would never see a synced state.
+			output, err := cmd.Output()
+			if err != nil {
+				logf("Warning: failed to query RAID5 sync status: %v\n", err)
+				return false
+			}
+			isSynced := strings.TrimSpace(string(output)) == "true"
+			if isSynced {
+				logf("RAID5 resync complete: sync_percent=100%%\n")
+			}
+			return isSynced
+		}, 10*time.Minute, 10*time.Second).Should(o.BeTrue(), "RAID5 resync should complete to 100% before data verification")
+
+		g.By("#. Verify all data intact after recovery")
+		readFinalCmd := exec.Command("oc", "exec", podName, "-n", testNamespace, "-c", "test-container", "--", "/bin/sh", "-c", "cat /mnt/data/testfile")
+		readOutput, err = readFinalCmd.CombinedOutput()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to read data after recovery: %s", string(readOutput))
+		o.Expect(string(readOutput)).To(o.ContainSubstring(testData), "Original data should survive RAID5 recovery")
+		o.Expect(string(readOutput)).To(o.ContainSubstring(degradedData), "Data written during degraded state should survive recovery")
+		logf("All data intact after recovery: %s\n", strings.TrimSpace(string(readOutput)))
+
+		g.By("#. Verify new writes work after repair")
+		recoveryData := "Written after repair"
+		writeRecoveryCmd := exec.Command("oc", "exec", podName, "-n", testNamespace, "-c", "test-container", "--", "/bin/sh", "-c",
+			fmt.Sprintf("echo '%s' >> /mnt/data/testfile && sync", recoveryData))
+		writeRecoveryOutput, err := writeRecoveryCmd.CombinedOutput()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to write new data after repair: %s", string(writeRecoveryOutput))
+
+		readFinalVerifyCmd := exec.Command("oc", "exec", podName, "-n", testNamespace, "-c", "test-container", "--", "/bin/sh", "-c", "cat /mnt/data/testfile")
+		readFinalVerifyOutput, err := readFinalVerifyCmd.CombinedOutput()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to verify data after post-recovery write: %s", string(readFinalVerifyOutput))
+		o.Expect(string(readFinalVerifyOutput)).To(o.ContainSubstring(recoveryData), "New data written after repair should be present")
+		logf("New data written successfully after repair: %s\n", strings.TrimSpace(string(readFinalVerifyOutput)))
+
+		g.By("#. Delete Pod, PVC and LVMCluster")
+		deleteSpecifiedResource("pod", podName, testNamespace)
+		deleteSpecifiedResource("pvc", pvcName, testNamespace)
+		deleteLVMClusterSafely(newLVMClusterName, lvmsNamespace, deviceClassName)
+
+		g.By("#. Test completed successfully - RAID5 disk failure and repair verified")
+		logf("RAID5 disk-failure survival and repair test passed\n")
 	})
 })
 

--- a/test/integration/qe_tests/lvms_utils.go
+++ b/test/integration/qe_tests/lvms_utils.go
@@ -2148,3 +2148,189 @@ func createLVMClusterWithDeviceDiscoveryPolicy(cfg lvmClusterDeviceDiscoveryConf
 	}
 	return nil
 }
+
+// RAIDConfig specifies RAID type and parameters for a RAID LVMCluster.
+// Type is "raid1", "raid5", "raid6", or "raid10".
+// Mirrors is used for raid1/raid10 (e.g., "1" for raid1, "2" for raid10), or "null" for raid4/raid5/raid6.
+// Stripes is used for raid4/raid5/raid6/raid10 (e.g., "2" for raid5 with 3 disks), or "null" for raid1.
+// WithThinPool adds a thinPoolConfig block alongside raidConfig. RAID and thinPool are
+// mutually exclusive, so this is only set by the negative validation test that asserts
+// the webhook rejects the combination; leave false for all valid RAID clusters.
+type RAIDConfig struct {
+	Type         string
+	Mirrors      string
+	Stripes      string
+	WithThinPool bool
+}
+
+// createLVMClusterWithRAID creates an LVMCluster with the specified RAID configuration using the lvmcluster-raid-template.
+// diskPaths contains device paths (e.g., ["/dev/nvme1n1", "/dev/nvme2n1"]).
+// raidCfg specifies the RAID type and parameters.
+// Returns validation errors from the API (e.g., mutually exclusive, requires at least N disks).
+func createLVMClusterWithRAID(name, namespace, deviceClassName string, diskPaths []string, raidCfg RAIDConfig) error {
+	if len(diskPaths) == 0 {
+		return fmt.Errorf("at least one disk path is required")
+	}
+
+	// Build paths array for the template (must be valid JSON array syntax)
+	pathsArray := "["
+	for i, p := range diskPaths {
+		if i > 0 {
+			pathsArray += ","
+		}
+		pathsArray += fmt.Sprintf(`"%s"`, p)
+	}
+	pathsArray += "]"
+
+	// THINPOOL is appended after the raidConfig block. It is empty for valid RAID
+	// clusters and populated only for the negative test that expects the webhook to
+	// reject the mutually-exclusive RAID + thinPool combination. The indentation
+	// matches the template (de-indented by two spaces during template processing).
+	thinPool := ""
+	if raidCfg.WithThinPool {
+		thinPool = "\n        thinPoolConfig:" +
+			"\n          name: thin-pool" +
+			"\n          sizePercent: 90" +
+			"\n          overprovisionRatio: 10"
+	}
+
+	err := applyResourceFromTemplate("lvmcluster-raid-template.yaml",
+		"--ignore-unknown-parameters=true",
+		"-p", "NAME="+name,
+		"-p", "NAMESPACE="+namespace,
+		"-p", "DEVICECLASS="+deviceClassName,
+		"-p", "PATHS="+pathsArray,
+		"-p", "RAIDTYPE="+raidCfg.Type,
+		"-p", "MIRRORS="+raidCfg.Mirrors,
+		"-p", "STRIPES="+raidCfg.Stripes,
+		"-p", "THINPOOL="+thinPool,
+	)
+
+	// Validation logic: pass back API validation errors for negative test cases
+	if err != nil {
+		// Check if error contains validation messages (for negative tests)
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "mutually exclusive") ||
+			strings.Contains(errMsg, "requires at least") {
+			return err // Return the validation error as-is for test assertions
+		}
+		return fmt.Errorf("failed to create RAID LVMCluster %s: %w", name, err)
+	}
+
+	logf("RAID LVMCluster %s created with %s configuration\n", name, raidCfg.Type)
+	return nil
+}
+
+func getLVMClusterState(name string, namespace string) (string, error) {
+	cmd := exec.Command("oc", "get", "lvmcluster", name, "-n", namespace, "-o=jsonpath={.status.state}")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to get LVMCluster %s state: %w, output: %s", name, err, string(output))
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func simulateDiskFailureOnNode(nodeName string, diskName string) {
+	// For NVMe devices, verify the controller isn't shared by multiple namespaces before removal
+	// to avoid accidentally removing storage for other test workloads.
+	validateCmd := "lsblk -n -o NAME /dev/" + diskName + " 2>/dev/null | grep -E '^nvme' | wc -l"
+	cmd := exec.Command("oc", "debug", "node/"+nodeName, "--", "chroot", "/host", "/bin/bash", "-c", validateCmd)
+	output, err := cmd.CombinedOutput()
+	if err == nil && strings.TrimSpace(string(output)) == "1" {
+		// NVMe device found; verify controller is dedicated to this namespace
+		ctrlCheckCmd := "ls -1 /sys/block/" + diskName + "/device/subsystem/devices 2>/dev/null | grep -c '^nvme' || echo 0"
+		ctrlCmd := exec.Command("oc", "debug", "node/"+nodeName, "--", "chroot", "/host", "/bin/bash", "-c", ctrlCheckCmd)
+		ctrlOutput, ctrlErr := ctrlCmd.CombinedOutput()
+		if ctrlErr == nil && strings.TrimSpace(string(ctrlOutput)) != "1" {
+			logf("Warning: NVMe device %s controller may host multiple namespaces; proceeding with caution\n", diskName)
+		}
+	}
+
+	// Remove the disk using device-specific delete paths (SCSI/virtio use /device/delete, NVMe may use /device/device/remove)
+	removeDiskCmd := "echo 1 > /sys/block/" + diskName + "/device/delete 2>/dev/null || echo 1 > /sys/block/" + diskName + "/device/device/remove"
+	cmd = exec.Command("oc", "debug", "node/"+nodeName, "--", "chroot", "/host", "/bin/bash", "-c", removeDiskCmd)
+	output, err = cmd.CombinedOutput()
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to simulate disk failure on node %s: %s", nodeName, string(output))
+
+	// Verify the device was actually removed
+	verifyCmd := "lsblk -n /dev/" + diskName + " >/dev/null 2>&1 && echo FOUND || echo REMOVED"
+	verifyExecCmd := exec.Command("oc", "debug", "node/"+nodeName, "--", "chroot", "/host", "/bin/bash", "-c", verifyCmd)
+	verifyOutput, verifyErr := verifyExecCmd.CombinedOutput()
+	o.Expect(verifyErr).NotTo(o.HaveOccurred(), "failed to verify disk removal on node %s: %s", nodeName, string(verifyOutput))
+	o.Expect(string(verifyOutput)).To(o.ContainSubstring("REMOVED"), "Disk /dev/%s was not successfully removed from node %s", diskName, nodeName)
+
+	logf("Simulated disk failure of /dev/%s on node %s\n", diskName, nodeName)
+}
+
+func rescanDisksOnNode(nodeName string) {
+	cmd := exec.Command("oc", "debug", "node/"+nodeName, "--", "chroot", "/host", "/bin/bash", "-c", "echo 1 > /sys/bus/pci/rescan")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logf("Warning: failed to rescan PCI bus on node %s: %s\n", nodeName, string(output))
+	}
+	logf("Rescanned PCI bus on node %s\n", nodeName)
+}
+
+// cleanupRAID5VGOnNode removes the RAID5 volume group from a node and wipes LVM
+// signatures off the given disks, mirroring the check-then-remove cleanup that
+// removeLogicalVolumeOnDisk does for test 71012. It is the failure-path safety
+// net: if the test aborts while the cluster is Degraded, deleting the LVMCluster
+// CR strips its finalizer but can leave a stale VG (with a missing PV) and LVM
+// signatures behind, which would collide with the baseline LVMCluster being
+// restored and break every subsequent [Serial] test. vgremove -ff removes a VG
+// even when a PV is missing. Steps are guarded by existence checks and errors are
+// logged (best-effort) so cleanup never panics and masks the real test failure.
+func cleanupRAID5VGOnNode(nodeName string, vgName string, diskPaths []string) {
+	// Remove the VG only if it is still present on the node.
+	cleanupCmd := "if vgs --noheadings -o vg_name 2>/dev/null | grep -qw " + vgName + "; then vgremove -ff " + vgName + "; fi; " +
+		"for d in " + strings.Join(diskPaths, " ") + "; do wipefs -a $d 2>/dev/null || true; done; " +
+		"echo RAID5_CLEANUP_DONE"
+	cmd := exec.Command("oc", "debug", "node/"+nodeName, "--", "chroot", "/host", "/bin/bash", "-c", cleanupCmd)
+	output, err := cmd.CombinedOutput()
+	if err != nil || !strings.Contains(string(output), "RAID5_CLEANUP_DONE") {
+		logf("Warning: RAID5 VG cleanup on node %s was not fully successful (best-effort): %v, output: %s\n", nodeName, err, string(output))
+		return
+	}
+	logf("RAID5 VG %s cleaned up on node %s (VG removed if present, disks wiped)\n", vgName, nodeName)
+}
+
+// repairRAID5OnNode repairs a degraded RAID5 logical volume by adding a replacement disk.
+// replacementDiskPath must be an unused disk; pvcreate -ff -y will destroy its existing data.
+func repairRAID5OnNode(nodeName string, vgName string, replacementDiskPath string) {
+	// Explicitly select the RAID5 logical volume and fail immediately if none found
+	getLVCmd := "lvs --noheadings -o lv_name --select 'segtype=~raid' " + vgName + " 2>/dev/null | head -1 | tr -d ' '"
+	lvCmd := exec.Command("oc", "debug", "node/"+nodeName, "--", "chroot", "/host", "/bin/bash", "-c", getLVCmd)
+	// Use Output() (stdout only), not CombinedOutput(): `oc debug` writes its
+	// "Starting pod/..." banner to stderr, and merging it in would make TrimSpace
+	// capture "Starting" as the LV name instead of the real value.
+	lvOutput, lvErr := lvCmd.Output()
+	o.Expect(lvErr).NotTo(o.HaveOccurred(), "failed to query RAID5 logical volumes on node %s: %s", nodeName, string(lvOutput))
+
+	lvName := strings.TrimSpace(string(lvOutput))
+	o.Expect(lvName).NotTo(o.BeEmpty(), "No RAID5 logical volume found in VG %s on node %s", vgName, nodeName)
+
+	// Now repair the RAID array using the identified LV and replacement disk
+	repairCmd := "set -e; " +
+		"pvcreate -ff -y " + replacementDiskPath + " && " +
+		"vgextend " + vgName + " " + replacementDiskPath + " && " +
+		"lvconvert --repair -y " + vgName + "/" + lvName + " " + replacementDiskPath + " && " +
+		"vgreduce --removemissing --force " + vgName
+	cmd := exec.Command("oc", "debug", "node/"+nodeName, "--", "chroot", "/host", "/bin/bash", "-c", repairCmd)
+	output, err := cmd.CombinedOutput()
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to repair RAID5 on node %s: %s", nodeName, string(output))
+
+	// Verify RAID repair succeeded by checking RAID health status instead of relying on
+	// exact output text which varies across LVM2 versions. Check sync_percent (should be
+	// 100 when fully synced) rather than health_status as health_status semantics differ by type.
+	verifyCmd := "lvs --noheadings -o sync_percent " + vgName + "/" + lvName + " 2>/dev/null | tr -d ' %'"
+	verifyExecCmd := exec.Command("oc", "debug", "node/"+nodeName, "--", "chroot", "/host", "/bin/bash", "-c", verifyCmd)
+	// Output() (stdout only) so the `oc debug` stderr banner does not contaminate the value
+	verifyOutput, verifyErr := verifyExecCmd.Output()
+	if verifyErr == nil {
+		syncPercent := strings.TrimSpace(string(verifyOutput))
+		logf("RAID5 repair on node %s: sync_percent=%s\n", nodeName, syncPercent)
+		// Sync is typically not 100% immediately after repair (still syncing in background), so we just log it
+		// The RAID is considered repaired once lvconvert succeeds and vgreduce completes successfully
+	}
+	logf("RAID5 repair completed on node %s using %s for LV %s\n", nodeName, replacementDiskPath, lvName)
+}

--- a/test/integration/qe_tests/testdata/lvmcluster-raid-template.yaml
+++ b/test/integration/qe_tests/testdata/lvmcluster-raid-template.yaml
@@ -1,0 +1,54 @@
+kind: Template
+apiVersion: template.openshift.io/v1
+metadata:
+  name: lvmcluster-raid-template
+objects:
+- apiVersion: lvm.topolvm.io/v1alpha1
+  kind: LVMCluster
+  metadata:
+    name: ${NAME}
+    namespace: ${NAMESPACE}
+  spec:
+    storage:
+      deviceClasses:
+      - name: ${DEVICECLASS}
+        deviceSelector:
+          paths: ${{PATHS}}
+        raidConfig:
+          type: ${RAIDTYPE}
+          mirrors: ${MIRRORS}
+          stripes: ${STRIPES}${THINPOOL}
+parameters:
+- name: NAME
+  required: true
+  value: "test-raid"
+- name: NAMESPACE
+  required: true
+  value: "openshift-lvm-storage"
+- name: DEVICECLASS
+  required: true
+  value: "raid-class"
+# PATHS is a JSON array of device paths, e.g. ["/dev/nvme1n1","/dev/nvme2n1"]
+- name: PATHS
+  required: true
+  value: '["/dev/nvme1n1","/dev/nvme2n1"]'
+- name: RAIDTYPE
+  required: true
+  value: "raid1"
+# MIRRORS is used for raid1/raid10 (e.g., 1 for raid1, 2 for raid10).
+# Leave empty or "null" for raid4/raid5/raid6.
+- name: MIRRORS
+  required: false
+  value: "1"
+# STRIPES is used for raid4/raid5/raid6/raid10 (e.g., 2 for raid5 with 3 disks).
+# Leave empty or "null" for raid1.
+- name: STRIPES
+  required: false
+  value: "null"
+# THINPOOL injects an optional thinPoolConfig block appended to the deviceClass.
+# It is empty for valid RAID clusters (RAID and thinPool are mutually exclusive)
+# and is only populated by the negative validation test that asserts the webhook
+# rejects the RAID + thinPool combination.
+- name: THINPOOL
+  required: false
+  value: ""


### PR DESCRIPTION
… repaired with replacement disk

Test log: https://privatebin.corp.redhat.com/?6e62dbc86c4580ca#8fcWjiUhG6UC5NuoKsktBDkfykU1ur9LnWEnTi4NGiQY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added integration coverage for RAID5 storage resilience.
  - Validates workload access and data integrity during disk failure, degraded operation, repair, and recovery.
  - Confirms restoration with a replacement disk and verifies post-repair readiness.
  - Improved reliability through consistent storage-device selection.

- **New Features**
  - Added configurable storage templates for device paths, RAID types, mirrors, and stripes.
  - Added validation for RAID5 setup, failure handling, repair, and cleanup workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->