### PR TITLE
NO-JIRA: chore: correct version number for the candidate catalog template

### DIFF
--- a/release/catalog/lvm-operator-catalog-candidate-template.yaml
+++ b/release/catalog/lvm-operator-catalog-candidate-template.yaml
@@ -5,4 +5,4 @@ GenerateMajorChannels: false
 GenerateMinorChannels: true
 Stable:
   Bundles:
-    - Image: registry.stage.redhat.io/lvms4/lvms-operator-bundle@sha256:1a8a0fcf3c9713c7339213dbb0d43e1ca0acc1b43dd6062d2f0384edb6c7cae1 # v5.0.0
+    - Image: registry.stage.redhat.io/lvms4/lvms-operator-bundle@sha256:1a8a0fcf3c9713c7339213dbb0d43e1ca0acc1b43dd6062d2f0384edb6c7cae1 # v5.1.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the stable LVM operator bundle to version 5.1.0.
  * Refreshed the bundle’s image reference to the corresponding release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->