### PR TITLE
OCPEDGE-2977: Fix 5.1 images tekton configuration

### DIFF
--- a/.tekton/lvm-operator-catalog-pull-request.yaml
+++ b/.tekton/lvm-operator-catalog-pull-request.yaml
@@ -26,14 +26,14 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/logical-volume-manag-tenant/lvm-operator-catalog:v5.0-on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/logical-volume-manag-tenant/lvm-operator-catalog:v5.1-on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile
     value: release/catalog/catalog.konflux.Dockerfile
   - name: build-args
     value:
-    - CATALOG_VERSION=v5.0
+    - CATALOG_VERSION=v5.1
   - name: hermetic
     value: "true"
   - name: skip-additional-tags

--- a/.tekton/lvm-operator-catalog-push.yaml
+++ b/.tekton/lvm-operator-catalog-push.yaml
@@ -25,12 +25,12 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/logical-volume-manag-tenant/lvm-operator-catalog:v5.0-{{revision}}
+    value: quay.io/redhat-user-workloads/logical-volume-manag-tenant/lvm-operator-catalog:v5.1-{{revision}}
   - name: dockerfile
     value: release/catalog/catalog.konflux.Dockerfile
   - name: build-args
     value:
-    - CATALOG_VERSION=v5.0
+    - CATALOG_VERSION=v5.1
   - name: hermetic
     value: "true"
   - name: build-platforms

--- a/release/catalog/catalog.konflux.Dockerfile
+++ b/release/catalog/catalog.konflux.Dockerfile
@@ -1,7 +1,8 @@
 ARG CATALOG_VERSION
+ARG BASE_IMAGE_TAG=v5.0.0
 ARG BASE_IMAGE=registry.redhat.io/openshift4/ose-operator-registry-rhel9
 # Global args to be used to build the final base image url
-FROM ${BASE_IMAGE}:${CATALOG_VERSION}
+FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG}
 ARG CATALOG_VERSION
 
 COPY release/catalog/lvm-operator-catalog.json /configs/lvms-operator/catalog.json


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated catalog build and publishing workflows to use the `v5.1` image and catalog version.
  - Added explicit base image versioning for consistent catalog builds.
  - Ensured generated catalog artifacts are published with the expected versions.
  - Aligned catalog build inputs and published outputs across the release process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->