### PR TITLE
NO-JIRA: Sync renovate.json with main to fix rpm-lock automation

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,44 +1,39 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>konflux-ci/mintmaker//config/renovate/renovate.json"
+    "github>konflux-ci/mintmaker//config/renovate/renovate.json",
+    "github>konflux-ci/mintmaker-presets:refresh-rpm-lockfiles",
+    "github>konflux-ci/mintmaker-presets:disable-minor-updates"
   ],
-  "gomod": {
-    "enabled": false
-  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "datasourceTemplate": "docker",
+      "managerFilePatterns": ["/.*\\-catalog\\-template\\.yaml$/"],
+      "matchStrings": [
+        "(?<depName>quay\\.io[\\w\\-\\.\\/]+)(?<currentValue>)?@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "versioningTemplate": "docker"
+    }
+  ],
+  "gomod": { "enabled": false },
+  "pre-commit": { "enabled": false },
   "commitBody": "Signed-off-by: {{{gitAuthor}}}",
+  "commitMessagePrefix": "NO-JIRA:",
   "packageRules": [
     {
-      "addLabels": [
-        "approved",
-        "lgtm"
-      ],
+      "addLabels": ["approved", "lgtm"],
       "autoApprove": true,
       "automerge": true,
       "automergeType": "pr",
       "automergeStrategy": "rebase",
       "enabled": true,
-      "includePaths": [
-        "release/**"
-      ],
-      "matchManagers": [
-        "custom.regex"
-      ],
-      "matchUpdateTypes": [
-        "digest"
-      ],
-      "platformAutomerge": true,
-      "commitMessagePrefix": "NO-JIRA:",
-      "schedule": [
-        "at any time"
-      ]
+      "includePaths": ["release/**"],
+      "matchManagers": ["custom.regex"],
+      "matchUpdateTypes": ["digest"],
+      "platformAutomerge": true
     },
-    {
-      "matchUpdateTypes": [
-        "minor"
-      ],
-      "enabled": false
-    }
+    { "matchUpdateTypes": ["minor"], "enabled": false }
   ],
   "prConcurrentLimit": 0,
   "pruneBranchAfterAutomerge": true,
@@ -49,29 +44,23 @@
     "automerge": true,
     "automergeType": "pr",
     "automergeStrategy": "rebase",
-    "addLabels": [
-      "approved",
-      "lgtm"
-    ],
+    "addLabels": ["approved", "lgtm"],
     "enabled": true,
-    "managerFilePatterns": [
-      "/\\.yaml$/",
-      "/\\.yml$/"
-    ],
+    "managerFilePatterns": ["/\\.yaml$/", "/\\.yml$/"],
     "ignoreTests": true,
-    "includePaths": [
-      ".tekton/**",
-      "release/**"
-    ],
-    "platformAutomerge": true,
-    "commitMessagePrefix": "NO-JIRA:",
-    "schedule": [
-      "at any time"
-    ]
+    "includePaths": [".tekton/**", "release/**"],
+    "platformAutomerge": true
   },
-  "rpm-lockfile": {
-    "lockFileMaintenance": {
-      "enabled": true
-    }
+  "lockFileMaintenance": {
+    "enabled": true,
+    "recreateWhen": "auto",
+    "rebaseWhen": "behind-base-branch",
+    "branchTopic": "lock-file-maintenance",
+    "schedule": ["before 5am"],
+    "automerge": true,
+    "automergeType": "pr",
+    "automergeStrategy": "rebase",
+    "addLabels": ["approved", "lgtm"],
+    "platformAutomerge": true
   }
 }


### PR DESCRIPTION
## What

Aligns `renovate.json` on `release-4.20` with `main`.

## Why

Mintmaker rpm `lockFileMaintenance` is not producing lockfile PRs on this branch. Root cause: the repo-level `rpm-lockfile` override lacked the preset's schedule and effectively suppressed scheduled runs. Working branches (4.21/4.22) do not carry this override.

## Change

- Add `mintmaker-presets:refresh-rpm-lockfiles` and `mintmaker-presets:disable-minor-updates` to `extends`
- Add a top-level `lockFileMaintenance` block (`branchTopic: lock-file-maintenance`)
- Remove the ineffective `rpm-lockfile` override block
- Minor config alignment (customManagers, tekton managerFilePatterns, top-level commitMessagePrefix)

Result: `renovate.json` becomes identical to `main`.

## Pilot

This is the pilot of a 6-branch rollout (4.16, 4.18–4.22). After merge, confirm a `konflux/mintmaker/release-4.20/lock-file-maintenance` PR appears before replicating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)