### PR TITLE
OCPEDGE-2863: feat(vgmanager): add selinux support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,8 +166,12 @@ ifeq ($(OPENSHIFT_CI), true)
 	hack/publish-codecov.sh
 endif
 
+# Host architecture: envtest's etcd segfaults under cross-arch emulation, so the
+# test container must match the host, not the amd64 default used for release builds.
+TEST_ARCH ?= $(shell go env GOARCH)
+
 docker-test: ## Run unit tests inside a Linux container (useful for non-Linux hosts).
-	$(IMAGE_BUILD_CMD) run --rm --platform=linux/$(ARCH) \
+	$(IMAGE_BUILD_CMD) run --rm --platform=linux/$(TEST_ARCH) \
 		-v $(shell pwd):/workspace$(MOUNT_LABEL) \
 		-w /workspace \
 		-e NON_ROOT=true \

--- a/internal/controllers/lvmcluster/resource/topolvm_csi_driver.go
+++ b/internal/controllers/lvmcluster/resource/topolvm_csi_driver.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	cutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -54,10 +55,14 @@ func (c csiDriver) GetName() string {
 func (c csiDriver) EnsureCreated(r Reconciler, ctx context.Context, cluster *lvmv1alpha1.LVMCluster) error {
 	logger := log.FromContext(ctx).WithValues("resourceManager", c.GetName())
 	csiDriverResource := getCSIDriverResource()
+	seLinuxMount := csiDriverResource.Spec.SELinuxMount
 
 	result, err := cutil.CreateOrUpdate(ctx, r, csiDriverResource, func() error {
 		labels.SetManagedLabels(r.Scheme(), csiDriverResource, cluster)
-		// no need to mutate any field
+		// seLinuxMount is the only mutable field of this spec. CreateOrUpdate replaces the
+		// constructed spec with the live one for an existing driver, so set it here as well,
+		// otherwise clusters upgraded from a release that predates it never get it.
+		csiDriverResource.Spec.SELinuxMount = seLinuxMount
 		return nil
 	})
 
@@ -115,6 +120,11 @@ func getCSIDriverResource() *storagev1.CSIDriver {
 			PodInfoOnMount:       &podInfoOnMount,
 			StorageCapacity:      &storageCapacity,
 			VolumeLifecycleModes: []storagev1.VolumeLifecycleMode{storagev1.VolumeLifecyclePersistent},
+			// each topolvm volume is a filesystem on its own logical volume, so every volume
+			// can be mounted with its own "-o context" option. This lets kubelet mount
+			// ReadWriteOncePod volumes with the Pod's SELinux context instead of relabelling
+			// the whole filesystem recursively.
+			SELinuxMount: ptr.To(true),
 		},
 	}
 	return csiDriver

--- a/internal/controllers/lvmcluster/resource/topolvm_csi_driver_test.go
+++ b/internal/controllers/lvmcluster/resource/topolvm_csi_driver_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright © 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/openshift/lvm-operator/v4/internal/controllers/constants"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func newFakeCSIDriverReconciler(t *testing.T, scheme *runtime.Scheme, objs ...client.Object) *fakeReconciler {
+	t.Helper()
+	return &fakeReconciler{
+		Client:    fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+		scheme:    scheme,
+		namespace: "default",
+	}
+}
+
+func getReconciledCSIDriver(t *testing.T, r *fakeReconciler) *storagev1.CSIDriver {
+	t.Helper()
+	ctx := log.IntoContext(context.Background(), testr.New(t))
+
+	if err := (csiDriver{}).EnsureCreated(r, ctx, testCluster()); err != nil {
+		t.Fatalf("EnsureCreated returned error: %v", err)
+	}
+
+	got := &storagev1.CSIDriver{}
+	key := types.NamespacedName{Name: constants.TopolvmCSIDriverName}
+	if err := r.Get(ctx, key, got); err != nil {
+		t.Fatalf("getting CSIDriver %q: %v", key.Name, err)
+	}
+	return got
+}
+
+// SELinuxMount tells kubelet it may mount ReadWriteOncePod volumes with "-o context".
+func TestCSIDriver_EnsureCreated_SetsSELinuxMount(t *testing.T) {
+	scheme := newTestScheme(t)
+	got := getReconciledCSIDriver(t, newFakeCSIDriverReconciler(t, scheme))
+
+	if !ptr.Deref(got.Spec.SELinuxMount, false) {
+		t.Errorf("expected spec.seLinuxMount to be true, got %v", got.Spec.SELinuxMount)
+	}
+}
+
+// A cluster upgraded from a release without seLinuxMount already has a CSIDriver, so the
+// field has to be reconciled onto the existing object rather than only set at creation.
+func TestCSIDriver_EnsureCreated_SetsSELinuxMountOnExistingDriver(t *testing.T) {
+	scheme := newTestScheme(t)
+	existing := getCSIDriverResource()
+	existing.Spec.SELinuxMount = nil
+
+	got := getReconciledCSIDriver(t, newFakeCSIDriverReconciler(t, scheme, existing))
+
+	if !ptr.Deref(got.Spec.SELinuxMount, false) {
+		t.Errorf("expected spec.seLinuxMount to be true after upgrade, got %v", got.Spec.SELinuxMount)
+	}
+}
+
+// The remaining spec fields are immutable, so reconciling an existing driver must leave them
+// untouched instead of trying to write them back.
+func TestCSIDriver_EnsureCreated_KeepsImmutableFields(t *testing.T) {
+	scheme := newTestScheme(t)
+	existing := &storagev1.CSIDriver{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.TopolvmCSIDriverName},
+		Spec: storagev1.CSIDriverSpec{
+			AttachRequired:       ptr.To(true),
+			PodInfoOnMount:       ptr.To(false),
+			VolumeLifecycleModes: []storagev1.VolumeLifecycleMode{storagev1.VolumeLifecycleEphemeral},
+		},
+	}
+
+	got := getReconciledCSIDriver(t, newFakeCSIDriverReconciler(t, scheme, existing))
+
+	if !ptr.Deref(got.Spec.AttachRequired, false) {
+		t.Errorf("spec.attachRequired was overwritten, got %v", got.Spec.AttachRequired)
+	}
+	if ptr.Deref(got.Spec.PodInfoOnMount, true) {
+		t.Errorf("spec.podInfoOnMount was overwritten, got %v", got.Spec.PodInfoOnMount)
+	}
+	if len(got.Spec.VolumeLifecycleModes) != 1 || got.Spec.VolumeLifecycleModes[0] != storagev1.VolumeLifecycleEphemeral {
+		t.Errorf("spec.volumeLifecycleModes was overwritten, got %v", got.Spec.VolumeLifecycleModes)
+	}
+}

--- a/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
+++ b/internal/controllers/lvmcluster/resource/vgmanager_daemonset.go
@@ -44,6 +44,7 @@ var (
 	devDirPath          = "/dev"
 	udevPath            = "/run/udev"
 	sysPath             = "/sys"
+	selinuxPath         = "/etc/selinux"
 	metricsCertsDirPath = "/tmp/k8s-metrics-server/serving-certs"
 )
 
@@ -203,6 +204,31 @@ var (
 )
 
 var (
+	SELinuxVolName = "etc-selinux"
+	// SELinuxHostDirVol is the corev1.Volume definition for the read-only "/etc/selinux"
+	// host bind-mount. libselinux resolves the host policy store through it, which the node
+	// plugin needs to translate the "-o context" mount option kubelet passes for
+	// ReadWriteOncePod volumes. DirectoryOrCreate keeps the pod schedulable on hosts that
+	// run without SELinux.
+	SELinuxHostDirVol = corev1.Volume{
+		Name: SELinuxVolName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: selinuxPath,
+				Type: &HostPathDirectoryOrCreate,
+			},
+		},
+	}
+
+	// SELinuxHostDirVolMount is the corresponding mount for SELinuxHostDirVol
+	SELinuxHostDirVolMount = corev1.VolumeMount{
+		Name:      SELinuxVolName,
+		MountPath: selinuxPath,
+		ReadOnly:  true,
+	}
+)
+
+var (
 	MetricsCertsVolName = "metrics-cert"
 	// MetricsCertsDirVol is the corev1.Volume definition for the
 	// certs to be used in metrics endpoint.
@@ -247,6 +273,7 @@ func templateVGManagerDaemonset(
 		DevHostDirVol,
 		UDevHostDirVol,
 		SysHostDirVol,
+		SELinuxHostDirVol,
 		MetricsCertsDirVol,
 	}
 	volumeMounts := []corev1.VolumeMount{
@@ -259,6 +286,7 @@ func templateVGManagerDaemonset(
 		DevHostDirVolMount,
 		UDevHostDirVolMount,
 		SysHostDirVolMount,
+		SELinuxHostDirVolMount,
 		MetricsCertsDirVolMount,
 	}
 

--- a/internal/controllers/lvmcluster/resource/vgmanager_daemonset_test.go
+++ b/internal/controllers/lvmcluster/resource/vgmanager_daemonset_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright © 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"testing"
+
+	"github.com/openshift/lvm-operator/v4/internal/cluster"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// The node plugin needs the host SELinux policy store to handle the "-o context" mount
+// option, and must not be able to write to it.
+func TestTemplateVGManagerDaemonset_MountsSELinuxReadOnly(t *testing.T) {
+	ds := templateVGManagerDaemonset(testCluster(), cluster.TypeOCP, "default", "test-image", nil, nil)
+
+	var vol *corev1.Volume
+	for i := range ds.Spec.Template.Spec.Volumes {
+		if ds.Spec.Template.Spec.Volumes[i].Name == SELinuxVolName {
+			vol = &ds.Spec.Template.Spec.Volumes[i]
+		}
+	}
+	if vol == nil {
+		t.Fatalf("no volume named %q on the daemonset", SELinuxVolName)
+	}
+	if vol.HostPath == nil {
+		t.Fatalf("volume %q is not a hostPath volume", SELinuxVolName)
+	}
+	if vol.HostPath.Path != selinuxPath {
+		t.Errorf("volume %q points at %q, want %q", SELinuxVolName, vol.HostPath.Path, selinuxPath)
+	}
+
+	if len(ds.Spec.Template.Spec.Containers) != 1 {
+		t.Fatalf("expected 1 container, got %d", len(ds.Spec.Template.Spec.Containers))
+	}
+
+	var mount *corev1.VolumeMount
+	for i, m := range ds.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if m.Name == SELinuxVolName {
+			mount = &ds.Spec.Template.Spec.Containers[0].VolumeMounts[i]
+		}
+	}
+	if mount == nil {
+		t.Fatalf("volume %q is declared but not mounted into the container", SELinuxVolName)
+	}
+	if mount.MountPath != selinuxPath {
+		t.Errorf("mount path is %q, want %q", mount.MountPath, selinuxPath)
+	}
+	if !mount.ReadOnly {
+		t.Errorf("mount of %q must be read-only", selinuxPath)
+	}
+}


### PR DESCRIPTION
Enable mount-time SELinux labeling for RWOP PVs in LVMS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SELinux mount support for the TopoLVM CSI driver.
  * Improved compatibility with SELinux-enabled nodes, including support for volume mounts that require SELinux context handling.
  * Existing CSI driver resources are updated to enable SELinux mount support during reconciliation.

* **Bug Fixes**
  * Test containers now use the host’s architecture by default, improving reliability when running tests on non-amd64 systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->